### PR TITLE
Initial roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,30 @@
+# Roadmap
+
+These are things that we have expressed interest in but haven't implemented yet. They are generally listed in order of priorities however don't let that stop you from implementing something out of order. If you feel like you can complete one of the tasks, feel free to fork the project and send a pull request with the new code. We should work to release new updates to the App store frequently. 
+
+## Update x
+* Support iPhone 5 larger screen ([#5](https://github.com/OneBusAway/onebusaway-iphone/issues/5))
+* Change API to api.pugetsound.onebusaway.org
+
+## Independent from specific release
+* Continuous integration
+* Automatic deploy to TestFlight on successful builds
+
+## Update x
+* Support for iOS 7
+* Implement and document development workflow similar to OBA Android project model that @paulcwatts has implemented and describes at http://nvie.com/posts/a-successful-git-branching-model/
+* Merge OBA fork's other than multiagency support, deprecate onebusaway-iphone-common
+* Fix issues labeled as ['bug' in issue tracker](https://github.com/OneBusAway/onebusaway-iphone/issues?labels=bug&page=1&state=open)
+
+## Update x
+* [Implement TestFlight SDK](https://github.com/OneBusAway/onebusaway-iphone/issues/21)
+* Improve the current UI so that users understand "scheduled arrival" means "no real time data"
+* Redesign/improvement to the current service alerts facility
+
+## Update x
+* Add support for multiple agencies in one app, [work started](https://github.com/chirun/onebusaway-iphone)
+* Fix issues in issue tracker
+
+## Update x
+* Support for iPad and iPad mini
+* Change project name to OneBusAway-iOS


### PR DESCRIPTION
An initial roadmap for future OBA iPhone development efforts. Fixes https://github.com/OneBusAway/onebusaway-iphone/issues/17 and future updates after this is merged should just be created as PRs. By making this a markdown file rather than a wiki it allows anyone to propose changes to the roadmap via a PR rather than having to get a repo owner to change the wiki.
