### PR TITLE
fix #67: some routes not showing bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog for OneBusAway for iPhone
 
+## 2.0
+* Fixed bug where some routes wouldn't appear when searching depending on your current location
+
 ## 1.2
 
 Special thanks to Sebastian Kießling, Aaron Brethorst, and all other parties involved for making this update possible. 

--- a/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/Control/Common/OBAModelService.m
+++ b/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/Control/Common/OBAModelService.m
@@ -113,7 +113,7 @@ static const float kSearchRadius = 400;
     routeQuery = [self escapeStringForUrl:routeQuery];
     
     NSString * url = @"/api/where/routes-for-location.json";
-    NSString * args = [NSString stringWithFormat:@"lat=%f&lon=%f&query=%@&version=2", coord.latitude, coord.longitude,routeQuery];
+    NSString * args = [NSString stringWithFormat:@"radius=50000&lat=%f&lon=%f&query=%@&version=2", coord.latitude, coord.longitude,routeQuery];
     SEL selector = @selector(getRoutesV2FromJSON:error:);
     
     return [self request:url args:args selector:selector delegate:delegate context:context];


### PR DESCRIPTION
sets search radius to 50000 meters (~30 miles)

Exposes new bug https://github.com/OneBusAway/onebusaway-iphone/issues/88 but technically fixes #67.

<!---
@huboard:{"order":14.0}
-->
