### PR TITLE
Changed project settings for better crash reporting in TestFlight

### DIFF
--- a/org.onebusaway.iphone.xcodeproj/project.pbxproj
+++ b/org.onebusaway.iphone.xcodeproj/project.pbxproj
@@ -2089,6 +2089,7 @@
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = org_onebusaway_iphone_Prefix.pch;
+				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				INFOPLIST_FILE = Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 5.1;


### PR DESCRIPTION
Per [TestFlight's recommended project settings](http://help.testflightapp.com/customer/portal/articles/829558-how-do-i-implement-crash-reporting-), I changed "Strip Debug Symbols During Copy" from Yes to No for all project schemes.
