### PR TITLE
Wrapped the setDeviceIdentifier method with a preprocessor macro

### DIFF
--- a/OBAApplicationDelegate.m
+++ b/OBAApplicationDelegate.m
@@ -194,7 +194,9 @@ static NSString * kOBADefaultRegionApiServerName = @"regions.onebusaway.org";
 #pragma mark UIApplicationDelegate Methods
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+#ifdef DEBUG
     [TestFlight setDeviceIdentifier:[[UIDevice currentDevice] uniqueIdentifier]];
+#endif
     [TestFlight takeOff:@"8720ef43-19cc-49ed-ab49-819f74329fe7"];
     [self _migrateUserPreferences];
     [self _constructUI];


### PR DESCRIPTION
This change should have been included in PR #139 as discussed in issue #21.
