### PR TITLE
build ipa file during travis ci

### DIFF
--- a/scripts/travis/upload.sh
+++ b/scripts/travis/upload.sh
@@ -123,6 +123,7 @@ CURRENT_DIR=`pwd`
 #echo $CURRENT_DIR
 #ls -R
 xcrun -sdk iphoneos PackageApplication -v "$CURRENT_DIR/$APPNAME.app" -o "$CURRENT_DIR/$APPNAME.ipa"
+checklastcommanderrorexit
 
 echo "\n********************"
 echo "*   Deploy to GH   *"


### PR DESCRIPTION
build invalidly signed ipa file as part of travis ci process, only useful for jailbreak testers/developers
