### PR TITLE
set testflight token correctly using preprocessor

### DIFF
--- a/OBAApplicationDelegate.m
+++ b/OBAApplicationDelegate.m
@@ -195,9 +195,14 @@ static NSString * kOBADefaultRegionApiServerName = @"regions.onebusaway.org";
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
 #ifdef DEBUG
+    // if beta testing record uuid and use token for org.onebusaway.iphone-debug
     [TestFlight setDeviceIdentifier:[[UIDevice currentDevice] uniqueIdentifier]];
-#endif
     [TestFlight takeOff:@"8720ef43-19cc-49ed-ab49-819f74329fe7"];
+#else
+    // if app store version use token for org.onebusaway.iphone
+    [TestFlight takeOff:@"28959455-6425-40fb-a08c-204cb2a80421"];
+#endif
+
     [self _migrateUserPreferences];
     [self _constructUI];
 


### PR DESCRIPTION
app store version has different token, automating the replacement process.
