### PR TITLE
add purpose to location prompt

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -42,5 +42,7 @@
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 	</array>
+	<key>NSLocationUsageDescription</key>
+	<string>Your location will be used to show nearby stops and routes.</string>
 </dict>
 </plist>

--- a/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/Control/Common/OBALocationManager.m
+++ b/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/Control/Common/OBALocationManager.m
@@ -41,6 +41,7 @@ static const NSTimeInterval kSuccessiveLocationComparisonWindow = 3;
         _disabled = NO;
         _locationManager = [[CLLocationManager alloc] init];
         _locationManager.delegate = self;
+        _locationManager.purpose = @"Your location will be used to show nearby stops and routes.";
         _delegates = [[NSMutableArray alloc] init];
         
     }


### PR DESCRIPTION
Add purpose to location prompt message as shown below:

![photo 1 2](https://f.cloud.github.com/assets/1192780/1144968/9b2016c4-1de4-11e3-8460-16347f5aa56f.PNG)

`_locationManager.purpose` is used for iOS 5 and `NSLocationUsageDescription` is used for iOS 6 and 7.
