### PR TITLE
Improve time accuracy

### DIFF
--- a/controls/table_cells/OBAArrivalEntryTableViewCellFactory.m
+++ b/controls/table_cells/OBAArrivalEntryTableViewCellFactory.m
@@ -69,8 +69,8 @@
 }
 
 - (NSString*) getMinutesLabelForMinutes:(int)minutes {
-    if(abs(minutes) <=1)
-        return NSLocalizedString(@"NOW",@"abs(minutes) <=1");
+    if(minutes == 0)
+        return NSLocalizedString(@"NOW",@"minutes == 0");
     else
         return [NSString stringWithFormat:@"%d",minutes];
 }


### PR DESCRIPTION
Currently a bus is shown as arriving "NOW" if it is arriving in 1, 0, or -1 minutes and can result in the following conflicting display:

![image](https://f.cloud.github.com/assets/1192780/1168232/fd7f7f2a-209c-11e3-8545-35c81d2ec97c.jpg)

Many times this results in a bus appearing as if you might be able to run and catch it when in actuality it has already departed. I'd rather see the real times as outputted by OneBusAway servers and occasionally, when the system hiccups, catch a bus that was supposed to have already departed.

This PR will result in the display looking like follows:

![image](https://f.cloud.github.com/assets/1192780/1168268/b1c5412c-209d-11e3-8f70-c83fc6cf8627.jpg)
