### PR TITLE
Display trips departing in 1 and -1 minutes

### DIFF
--- a/controls/table_cells/OBAArrivalEntryTableViewCellFactory.m
+++ b/controls/table_cells/OBAArrivalEntryTableViewCellFactory.m
@@ -69,8 +69,8 @@
 }
 
 - (NSString*) getMinutesLabelForMinutes:(int)minutes {
-    if(abs(minutes) <=1)
-        return NSLocalizedString(@"NOW",@"abs(minutes) <=1");
+    if(minutes == 0)
+        return NSLocalizedString(@"NOW",@"minutes == 0");
     else
         return [NSString stringWithFormat:@"%d",minutes];
 }


### PR DESCRIPTION
This PR updates the departure time logic to only show trips departing at `0` as `NOW`. This change is being made to improve the departure accuracy as well as match how the Android app displays departure times. Currently trips departing in `1` or `-1` minutes are shown as `NOW` which can result in a trip saying it has both departed and is departing `NOW` as can be seen here:

![image](https://f.cloud.github.com/assets/1192780/1168232/fd7f7f2a-209c-11e3-8545-35c81d2ec97c.jpg)
