### PR TITLE
prepare for Travis CI Xcode 5 upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,23 +11,9 @@ before_install:
     # install all software updates
     #- sudo softwareupdate -iva
     
-    #todo: move xcode install to seperate file
-    #todo: check if downloaded file, else retry
-    
-    #uninstall xcode 4
-    - sudo rm -R /Applications/Xcode.app
-    
-    #install xcode
-    - curl -o x5gm.dmg https://copy.com/8yyq7U7Bl0sVEIRe/x5gm.dmg
-    - hdiutil attach x5gm.dmg
-    - ln -s /Volumes/Xcode/Xcode.app /Applications/Xcode.app
-    
-    #agree to xcode license
+    #install xcode 5
     - chmod -R +x ./scripts
-    - sudo -E scripts/travis/accept_license.sh
-
-    #print ver
-    - xcodebuild -version -sdk
+    - ./scripts/travis/xcode5.sh
 
     #install xctool
     - brew update

--- a/scripts/travis/xcode5.sh
+++ b/scripts/travis/xcode5.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+XCODE_MAJOR_VERSION=`xcodebuild -version | awk 'NR == 1 {print substr($2,1,1)}'`
+if [ "$XCODE_MAJOR_VERSION" -ge "5" ]; then
+        echo "Xcode 5 already installed."
+        exit 0
+fi
+
+echo "Installing Xcode 5."
+
+#todo: check if downloaded file, else retry
+
+#uninstall xcode 4
+sudo rm -R /Applications/Xcode.app
+
+#install xcode
+curl -o x5gm.dmg https://copy.com/8yyq7U7Bl0sVEIRe/x5gm.dmg #download installer
+hdiutil attach x5gm.dmg #mount
+sudo cp -R "/Volumes/Xcode/Xcode.app" /Applications #copy
+rm x5gm.dmg #rm installer
+
+#agree to xcode license
+sudo -E scripts/travis/accept_license.sh
+
+#print ver
+xcodebuild -version -sdk


### PR DESCRIPTION
This PR prepares the branch for Travis CI to upgrade to Xcode 5. When Xcode 5 is detected on the Travis CI server it will not install Xcode 5 before running the tests thus saving computing power and speeding up the CI.
