### PR TITLE
update displayed minutes until arrival every 5 seconds and while offline

### DIFF
--- a/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/View/OBARequestDrivenTableViewController.h
+++ b/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/View/OBARequestDrivenTableViewController.h
@@ -12,6 +12,7 @@
     NSInteger _refreshInterval;    
     
     NSTimer * _timer;
+    NSTimer * _timerMinutesUpdater;
 }
 
 - (id) initWithApplicationDelegate:(OBAApplicationDelegate*)appDelegate;

--- a/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/View/OBARequestDrivenTableViewController.m
+++ b/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/View/OBARequestDrivenTableViewController.m
@@ -1,6 +1,8 @@
 #import "OBARequestDrivenTableViewController.h"
 #import "OBALogger.h"
 
+#define kMinutesUpdaterFreq 5
+
 
 @interface OBARequestDrivenTableViewController (Private)
 
@@ -177,6 +179,9 @@
 @implementation OBARequestDrivenTableViewController (Private)
 
 - (void) clearPendingRequest {
+    [_timerMinutesUpdater invalidate];
+    _timerMinutesUpdater = nil;
+
     [_timer invalidate];
     _timer = nil;
     
@@ -216,6 +221,7 @@
     UIBarButtonItem * refreshItem = [self.navigationItem rightBarButtonItem];
     if( refreshItem )
         [refreshItem setEnabled:YES];
+    _timerMinutesUpdater = [NSTimer scheduledTimerWithTimeInterval:kMinutesUpdaterFreq target:self.tableView selector:@selector(reloadData) userInfo:nil repeats:YES];
 }
 
 @end

--- a/view_controllers/StopDetails/OBAGenericStopViewController.m
+++ b/view_controllers/StopDetails/OBAGenericStopViewController.m
@@ -36,7 +36,12 @@
 #import "MKMapView+oba_Additions.h"
 #import "UITableViewController+oba_Additions.h"
 
+#define kMinutesUpdaterFreq 5
+#define kDataRefreshFreq 30
+
 static const double kNearbyStopRadius = 200;
+
+NSTimer * _timerMinutesUpdater;
 
 @interface OBAGenericStopViewController ()
 @property(strong,readwrite) OBAApplicationDelegate * _appDelegate;
@@ -476,11 +481,15 @@ static const double kNearbyStopRadius = 200;
     
     [self clearPendingRequest];
     _request = [_appDelegate.modelService requestStopWithArrivalsAndDeparturesForId:_stopId withMinutesBefore:_minutesBefore withMinutesAfter:_minutesAfter withDelegate:self withContext:nil];
-    _timer = [NSTimer scheduledTimerWithTimeInterval:30 target:self selector:@selector(refresh) userInfo:nil repeats:YES];
+    _timer = [NSTimer scheduledTimerWithTimeInterval:kDataRefreshFreq target:self selector:@selector(refresh) userInfo:nil repeats:YES];
+    _timerMinutesUpdater = [NSTimer scheduledTimerWithTimeInterval:kMinutesUpdaterFreq target:self selector:@selector(reloadData) userInfo:nil repeats:YES];
 }
      
 - (void) clearPendingRequest {
     
+    [_timerMinutesUpdater invalidate];
+    _timerMinutesUpdater = nil;
+
     [_timer invalidate];
     _timer = nil;
     


### PR DESCRIPTION
Currently when viewing arrivals the minutes until arrival are only updated whenever the data is refreshed (every 30 seconds when online) or when the view is reopened (such as when a lock and unlock occurs). This PR changes the code to update the minutes until arrival every 5 seconds based on the last data received. This PR does not change how often data is retrieved from OBA servers, just how often the minutes are recalculated. This will allow the application to display more accurate arrival times while online and allow a user to see arrival times while in the tunnel as long as they open the stop view before entering the tunnel.