### PR TITLE
Fix crash when trying to load more arrivals in report a problem

### DIFF
--- a/view_controllers/StopDetails/OBAGenericStopViewController.h
+++ b/view_controllers/StopDetails/OBAGenericStopViewController.h
@@ -43,6 +43,7 @@ typedef enum {
 @property BOOL showServiceAlerts;
 @property BOOL showActions;
 @property NSUInteger minutesBefore;
+@property NSUInteger minutesAfter;
 @property(strong) OBAArrivalEntryTableViewCellFactory * arrivalCellFactory;
 @property(strong) NSMutableArray *allArrivals;
 @property(strong) NSMutableArray *filteredArrivals;
@@ -51,4 +52,5 @@ typedef enum {
 - (id)initWithApplicationDelegate:(OBAApplicationDelegate*)appDelegate;
 - (id)initWithApplicationDelegate:(OBAApplicationDelegate*)appDelegate stopId:(NSString*)stopId;
 - (OBAStopSectionType) sectionTypeForSection:(NSUInteger)section;
+- (void)refresh;
 @end

--- a/view_controllers/StopDetails/OBAGenericStopViewController.m
+++ b/view_controllers/StopDetails/OBAGenericStopViewController.m
@@ -41,7 +41,6 @@ static const double kNearbyStopRadius = 200;
 @interface OBAGenericStopViewController ()
 @property(strong,readwrite) OBAApplicationDelegate * _appDelegate;
 @property(strong,readwrite) NSString * stopId;
-@property NSUInteger minutesAfter;
 
 @property(strong) id<OBAModelServiceRequest> request;
 @property(strong) NSTimer *timer;
@@ -52,12 +51,11 @@ static const double kNearbyStopRadius = 200;
 @property(strong) OBAServiceAlertsModel * serviceAlerts;
 @end
 
-@interface OBAGenericStopViewController (Private)
+@interface OBAGenericStopViewController ()
 
 // Override point for extension classes
 - (void)customSetup;
 
-- (void)refresh;
 - (void)clearPendingRequest;
 - (void)didBeginRefresh;
 - (void)didFinishRefresh;
@@ -467,11 +465,6 @@ static const double kNearbyStopRadius = 200;
     }
     return 44;
 }
-
-@end
-
-
-@implementation OBAGenericStopViewController (Private)
 
 - (void) customSetup {
     

--- a/view_controllers/StopDetails/OBAReportProblemWithRecentTripsViewController.m
+++ b/view_controllers/StopDetails/OBAReportProblemWithRecentTripsViewController.m
@@ -17,7 +17,7 @@
     self.showActions = NO;
     self.arrivalCellFactory.showServiceAlerts = NO;
     self.showServiceAlerts = NO;
-    self.minutesBefore = 20;
+    self.minutesBefore = 30;
     
     self.tripDetailsHandler = [[OBATripDetailsHandler alloc] init];
 }
@@ -33,7 +33,11 @@
 
 - (void)tableView:(UITableView *)tableView didSelectTripRowAtIndexPath:(NSIndexPath *)indexPath {
     NSArray *arrivals = self.showFilteredArrivals ? self.filteredArrivals : self.allArrivals;
-    if (arrivals.count > 0) {
+    if ((arrivals.count == 0 && indexPath.row == 1) || (arrivals.count == indexPath.row && arrivals.count > 0)) {
+        [self.tableView deselectRowAtIndexPath:indexPath animated:YES];
+        self.minutesAfter += 30;
+        [self refresh];
+    } else if (arrivals.count > 0) {
         OBAArrivalAndDepartureV2 * arrivalAndDeparture = arrivals[indexPath.row];
         
         if (arrivalAndDeparture) {


### PR DESCRIPTION
This fixes the crash when you are in report problem for stop and trying to load more arrivals. 
Also disable 'Load more arrivals' while reloading for a better experience and understanding. 
