### PR TITLE
fix deselection of clicked options

### DIFF
--- a/view_controllers/StopDetails/OBAReportProblemWithStopViewController.m
+++ b/view_controllers/StopDetails/OBAReportProblemWithStopViewController.m
@@ -68,6 +68,7 @@ typedef enum {
 }
 
 - (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
     [TestFlight passCheckpoint:[NSString stringWithFormat:@"View: %@", [self class]]];
 }
 


### PR DESCRIPTION
Fixes deselection of clicked options in OBAReportProblemWithStopViewController.

Before this patch if you select report a problem at a stop, click "stop name is wrong" and then click back, "stop name is wrong" will appear stuck highlighted blue.
