### PR TITLE
change agencies view link selection color from black to blue

### DIFF
--- a/view_controllers/OBAAgenciesListViewController.m
+++ b/view_controllers/OBAAgenciesListViewController.m
@@ -170,7 +170,7 @@ typedef enum {
 - (UITableViewCell*) actionsCellForRowAtIndexPath:(NSIndexPath *)indexPath tableView:(UITableView*)tableView {
     UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView];
     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
-    cell.selectionStyle = UITableViewCellSelectionStyleDefault;
+    cell.selectionStyle = UITableViewCellSelectionStyleBlue;
     cell.textLabel.textColor = [UIColor blackColor];
     cell.textLabel.font = [UIFont systemFontOfSize:18];
     cell.textLabel.textAlignment = UITextAlignmentLeft;
@@ -192,7 +192,7 @@ typedef enum {
     
     UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView];
     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
-    cell.selectionStyle = UITableViewCellSelectionStyleDefault;
+    cell.selectionStyle = UITableViewCellSelectionStyleBlue;
     cell.textLabel.textColor = [UIColor blackColor];
     cell.textLabel.textAlignment = UITextAlignmentLeft;
     cell.textLabel.font = [UIFont systemFontOfSize:18];


### PR DESCRIPTION
Changed the agencies view link selection color from black to blue to match the other links throughout the app.
