### PR TITLE
DON'T MERGE YET: Set minimum supported version of iOS to 6, and fix all deprecation warnings

### DIFF
--- a/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/Control/Common/OBALocationManager.m
+++ b/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/Control/Common/OBALocationManager.m
@@ -41,7 +41,6 @@ static const NSTimeInterval kSuccessiveLocationComparisonWindow = 3;
         _disabled = NO;
         _locationManager = [[CLLocationManager alloc] init];
         _locationManager.delegate = self;
-        _locationManager.purpose = @"Your location will be used to show nearby stops and routes.";
         _delegates = [[NSMutableArray alloc] init];
         
     }

--- a/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/View/OBALabelAndSwitchTableViewCell.m
+++ b/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/View/OBALabelAndSwitchTableViewCell.m
@@ -22,7 +22,7 @@
     if (cell == nil) {
         NSArray * nib = [[NSBundle mainBundle] loadNibNamed:cellId owner:self options:nil];
         cell = nib[0];
-        cell.label.textAlignment = UITextAlignmentLeft;
+        cell.label.textAlignment = NSTextAlignmentLeft;
         cell.accessoryType = UITableViewCellAccessoryNone;                    
         cell.selectionStyle = UITableViewCellSelectionStyleNone;
     }

--- a/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/View/OBAListSelectionViewController.m
+++ b/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/View/OBAListSelectionViewController.m
@@ -46,7 +46,7 @@
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     
     UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView];
-    cell.textLabel.textAlignment = UITextAlignmentLeft;
+    cell.textLabel.textAlignment = NSTextAlignmentLeft;
     cell.textLabel.font = [UIFont systemFontOfSize:18];
     cell.selectionStyle = UITableViewCellSelectionStyleBlue;
     cell.accessoryType = [self checkedItem].row == indexPath.row ? UITableViewCellAccessoryCheckmark : UITableViewCellAccessoryNone;

--- a/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/View/OBAPresentation.m
+++ b/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/View/OBAPresentation.m
@@ -72,7 +72,7 @@ static const float kStopForRouteAnnotationMinScaleDistance = 8000;
     
     UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView cellId:cellId];
     cell.textLabel.text = [NSString stringWithFormat:@"Service alerts: %d unread",serviceAlerts.unreadCount];
-    cell.textLabel.textAlignment = UITextAlignmentCenter;
+    cell.textLabel.textAlignment = NSTextAlignmentCenter;
     cell.selectionStyle = UITableViewCellSelectionStyleBlue;
     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
     
@@ -90,7 +90,7 @@ static const float kStopForRouteAnnotationMinScaleDistance = 8000;
     
     static NSString *cellId = @"ServiceAlertsCell";
     UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView cellId:cellId];
-    cell.textLabel.textAlignment = UITextAlignmentLeft;
+    cell.textLabel.textAlignment = NSTextAlignmentLeft;
     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
     cell.textLabel.font = [UIFont systemFontOfSize:18];
     

--- a/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/View/OBAProgressIndicatorView.m
+++ b/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/View/OBAProgressIndicatorView.m
@@ -99,8 +99,8 @@
     [self setupLabel:_label];
     [self setupLabel:_progressLabel];
     _activityIndicator.frame = acitivityIndicatorFrame;
-    _label.textAlignment = UITextAlignmentCenter;
-    _progressLabel.textAlignment = UITextAlignmentCenter;    
+    _label.textAlignment = NSTextAlignmentCenter;
+    _progressLabel.textAlignment = NSTextAlignmentCenter;    
     
     [self addSubview:_label];
     [self addSubview:_progressLabel];

--- a/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/View/OBARequestDrivenTableViewController.m
+++ b/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/View/OBARequestDrivenTableViewController.m
@@ -161,7 +161,7 @@
     cell.textLabel.text = @"Updating...";
     cell.textLabel.font = [UIFont systemFontOfSize:18];
     cell.textLabel.textColor = [UIColor grayColor];
-    cell.textLabel.textAlignment = UITextAlignmentCenter;    
+    cell.textLabel.textAlignment = NSTextAlignmentCenter;    
     
     return cell;
 }

--- a/MarqueeLabel.h
+++ b/MarqueeLabel.h
@@ -60,13 +60,13 @@ typedef enum {
 /* marqueeType:
  * When set to LeftRight, the label moves from left to right and back from right to left alternatively.
  *
- *      NOTE: LeftRight type is ONLY compatible with a label text alignment of UITextAlignmentLeft. Specifying
- *      LeftRight will change any previously set, non-compatible text alignment to UITextAlignmentLeft.
+ *      NOTE: LeftRight type is ONLY compatible with a label text alignment of NSTextAlignmentLeft. Specifying
+ *      LeftRight will change any previously set, non-compatible text alignment to NSTextAlignmentLeft.
  *
  * When set to RightLeft, the label moves from right to left and back from left to right alternatively.
  *
- *      NOTE: RightLeft type is ONLY compatibile with a label text alignment of UITextAlignmentRight. Specifying
- *      RightLeft will change any previously set, non-compatible text alignment to UITextAlignmentRight.
+ *      NOTE: RightLeft type is ONLY compatible with a label text alignment of NSTextAlignmentRight. Specifying
+ *      RightLeft will change any previously set, non-compatible text alignment to NSTextAlignmentRight.
  *
  * When set to Continuous, the label slides continuously to the left.
  *

--- a/MarqueeLabel.m
+++ b/MarqueeLabel.m
@@ -826,15 +826,6 @@ typedef void (^animationCompletionBlock)(void);
     self.subLabel.baselineAdjustment = baselineAdjustment;
 }
 
-#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 60000
-- (NSAttributedString *)attributedText {
-    return self.subLabel.attributedText;
-}
-
-- (void)setAttributedText:(NSAttributedString *)attributedText {
-    self.subLabel.attributedText = attributedText;
-}
-
 - (void)setAdjustsLetterSpacingToFitWidth:(BOOL)adjustsLetterSpacingToFitWidth {
     // By the nature of MarqueeLabel, this is NO
     [super setAdjustsLetterSpacingToFitWidth:NO];
@@ -843,7 +834,6 @@ typedef void (^animationCompletionBlock)(void);
 - (void)setMinimumScaleFactor:(CGFloat)minimumScaleFactor {
     [super setMinimumScaleFactor:0.0f];
 }
-#endif
 
 #pragma mark - Custom Getters and Setters
 

--- a/controls/table_cells/OBALabelAndTextFieldTableViewCell.m
+++ b/controls/table_cells/OBALabelAndTextFieldTableViewCell.m
@@ -19,7 +19,7 @@
     if (cell == nil) {
         NSArray * nib = [[NSBundle mainBundle] loadNibNamed:cellId owner:self options:nil];
         cell = nib[0];
-        cell.textField.textAlignment = UITextAlignmentRight;
+        cell.textField.textAlignment = NSTextAlignmentRight;
         cell.textField.returnKeyType = UIReturnKeyDone;
         cell.accessoryType = UITableViewCellAccessoryNone;        
         cell.selectionStyle = UITableViewCellSelectionStyleNone;

--- a/org.onebusaway.iphone.xcodeproj/project.pbxproj
+++ b/org.onebusaway.iphone.xcodeproj/project.pbxproj
@@ -2170,7 +2170,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				INFOPLIST_FILE = Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 5.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)",
@@ -2208,7 +2208,7 @@
 				GCC_PREFIX_HEADER = org_onebusaway_iphone_Prefix.pch;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				INFOPLIST_FILE = Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 5.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)",
@@ -2286,7 +2286,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				INFOPLIST_FILE = Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 5.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)",
@@ -2336,7 +2336,7 @@
 				GCC_PREFIX_HEADER = org_onebusaway_iphone_Prefix.pch;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				INFOPLIST_FILE = Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 5.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)",

--- a/view_controllers/OBAAgenciesListViewController.m
+++ b/view_controllers/OBAAgenciesListViewController.m
@@ -173,7 +173,7 @@ typedef enum {
     cell.selectionStyle = UITableViewCellSelectionStyleDefault;
     cell.textLabel.textColor = [UIColor blackColor];
     cell.textLabel.font = [UIFont systemFontOfSize:18];
-    cell.textLabel.textAlignment = UITextAlignmentLeft;
+    cell.textLabel.textAlignment = NSTextAlignmentLeft;
     cell.textLabel.text = NSLocalizedString(@"Show on map",@"AgenciesListViewController");
     return cell;
 }
@@ -194,7 +194,7 @@ typedef enum {
     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
     cell.selectionStyle = UITableViewCellSelectionStyleDefault;
     cell.textLabel.textColor = [UIColor blackColor];
-    cell.textLabel.textAlignment = UITextAlignmentLeft;
+    cell.textLabel.textAlignment = NSTextAlignmentLeft;
     cell.textLabel.font = [UIFont systemFontOfSize:18];
     cell.textLabel.text = agency.name;
     return cell;
@@ -205,7 +205,7 @@ typedef enum {
     cell.accessoryType = UITableViewCellAccessoryNone;
     cell.selectionStyle = UITableViewCellSelectionStyleNone;
     cell.textLabel.textColor = [UIColor blackColor];
-    cell.textLabel.textAlignment = UITextAlignmentCenter;
+    cell.textLabel.textAlignment = NSTextAlignmentCenter;
     cell.textLabel.text = NSLocalizedString(@"No agencies found",@"cell.textLabel.text");
     return cell;    
 }

--- a/view_controllers/OBABookmarksViewController.m
+++ b/view_controllers/OBABookmarksViewController.m
@@ -77,7 +77,7 @@
     if( 0 == self.bookmarks.count ) {
         cell = [UITableViewCell getOrCreateCellForTableView:tableView];
         cell.textLabel.text = NSLocalizedString(@"No bookmarks set",@"[_bookmarks count] == 0");
-        cell.textLabel.textAlignment = UITextAlignmentCenter;
+        cell.textLabel.textAlignment = NSTextAlignmentCenter;
         cell.textLabel.font = [UIFont systemFontOfSize:18];
         cell.accessoryType = UITableViewCellAccessoryNone;
         cell.selectionStyle = UITableViewCellSelectionStyleNone;

--- a/view_controllers/OBACustomApiViewController.m
+++ b/view_controllers/OBACustomApiViewController.m
@@ -195,7 +195,7 @@ static NSString *editingCellTag = @"editingCell";
     UITableViewCell *cell = [UITableViewCell getOrCreateCellForTableView:tableView];
     cell.selectionStyle = UITableViewCellSelectionStyleBlue;
     cell.textLabel.textColor = [UIColor blackColor];
-    cell.textLabel.textAlignment = UITextAlignmentLeft;
+    cell.textLabel.textAlignment = NSTextAlignmentLeft;
     cell.textLabel.font = [UIFont systemFontOfSize:16];
     cell.textLabel.text = [self.recentUrls objectAtIndex:indexPath.row];
     return cell;

--- a/view_controllers/OBARecentStopsViewController.m
+++ b/view_controllers/OBARecentStopsViewController.m
@@ -74,7 +74,7 @@
     if( [_mostRecentStops count] == 0 ) {
         UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView];
         cell.textLabel.text = NSLocalizedString(@"No recent stops",@"cell.textLabel.text");
-        cell.textLabel.textAlignment = UITextAlignmentCenter;
+        cell.textLabel.textAlignment = NSTextAlignmentCenter;
         cell.selectionStyle = UITableViewCellSelectionStyleNone;
         return cell;
     }
@@ -82,9 +82,9 @@
         UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView style:UITableViewCellStyleSubtitle];
         OBAStopAccessEventV2 * event = _mostRecentStops[indexPath.row];
         cell.textLabel.text = event.title;
-        cell.textLabel.textAlignment = UITextAlignmentCenter;
+        cell.textLabel.textAlignment = NSTextAlignmentCenter;
         cell.detailTextLabel.text = event.subtitle;
-        cell.detailTextLabel.textAlignment = UITextAlignmentCenter;
+        cell.detailTextLabel.textAlignment = NSTextAlignmentCenter;
         cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
         cell.selectionStyle = UITableViewCellSelectionStyleBlue;
         return cell;

--- a/view_controllers/OBARegionListViewController.m
+++ b/view_controllers/OBARegionListViewController.m
@@ -374,7 +374,7 @@ typedef enum {
     cell.accessoryType = self.checkedItem == indexPath ? UITableViewCellAccessoryCheckmark : UITableViewCellAccessoryNone;
 	cell.selectionStyle = UITableViewCellSelectionStyleBlue;
 	cell.textLabel.textColor = [UIColor blackColor];
-	cell.textLabel.textAlignment = UITextAlignmentLeft;
+	cell.textLabel.textAlignment = NSTextAlignmentLeft;
     cell.textLabel.font = [UIFont systemFontOfSize:18];
 
 	cell.textLabel.text = region.regionName;
@@ -411,7 +411,7 @@ typedef enum {
     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
     cell.selectionStyle = UITableViewCellSelectionStyleBlue;
     cell.textLabel.textColor = [UIColor blackColor];
-    cell.textLabel.textAlignment = UITextAlignmentLeft;
+    cell.textLabel.textAlignment = NSTextAlignmentLeft;
     cell.textLabel.font = [UIFont systemFontOfSize:18];
     cell.textLabel.text = NSLocalizedString(@"Custom API URL", @"cell.textLabel.text");
     return cell;

--- a/view_controllers/OBAVehicleDetailsController.m
+++ b/view_controllers/OBAVehicleDetailsController.m
@@ -193,7 +193,7 @@ typedef enum {
     cell.selectionStyle = UITableViewCellSelectionStyleBlue;
 
     cell.textLabel.textColor = [UIColor blackColor];
-    cell.textLabel.textAlignment = UITextAlignmentLeft;
+    cell.textLabel.textAlignment = NSTextAlignmentLeft;
     cell.textLabel.text = [NSString stringWithFormat:@"%@: %@",NSLocalizedString(@"Vehicle",@"cell.textLabel.text"), _vehicleStatus.vehicleId];
     
     NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];    
@@ -202,7 +202,7 @@ typedef enum {
     NSString * result = [dateFormatter stringFromDate:[NSDate dateWithTimeIntervalSince1970:_vehicleStatus.lastUpdateTime/1000.0]];
 
     cell.detailTextLabel.textColor = [UIColor blackColor];
-    cell.detailTextLabel.textAlignment = UITextAlignmentLeft;
+    cell.detailTextLabel.textAlignment = NSTextAlignmentLeft;
     cell.detailTextLabel.text = [NSString stringWithFormat:@"%@: %@",NSLocalizedString(@"Last update",@"cell.detailTextLabel.text") , result];
 
     return cell;
@@ -217,7 +217,7 @@ typedef enum {
     cell.accessoryType = UITableViewCellAccessoryNone;
     cell.selectionStyle = UITableViewCellSelectionStyleNone;
     cell.textLabel.textColor = [UIColor blackColor];
-    cell.textLabel.textAlignment = UITextAlignmentLeft;
+    cell.textLabel.textAlignment = NSTextAlignmentLeft;
     cell.textLabel.font = [UIFont systemFontOfSize:18];    
     switch (indexPath.row) {
         case 0: {
@@ -260,7 +260,7 @@ typedef enum {
     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
     cell.selectionStyle = UITableViewCellSelectionStyleBlue;
     cell.textLabel.textColor = [UIColor blackColor];
-    cell.textLabel.textAlignment = UITextAlignmentLeft;
+    cell.textLabel.textAlignment = NSTextAlignmentLeft;
     cell.textLabel.font = [UIFont systemFontOfSize:18];    
     switch (indexPath.row) {
         case 0:

--- a/view_controllers/StopDetails/OBAGenericStopViewController.m
+++ b/view_controllers/StopDetails/OBAGenericStopViewController.m
@@ -561,14 +561,14 @@ static const double kNearbyStopRadius = 200;
     if ((arrivals.count == 0 && indexPath.row == 1) || (arrivals.count == indexPath.row && arrivals.count > 0)) {
         UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView];
         cell.textLabel.text = NSLocalizedString(@"Load more arrivals",@"load more arrivals");
-        cell.textLabel.textAlignment = UITextAlignmentCenter;
+        cell.textLabel.textAlignment = NSTextAlignmentCenter;
         cell.textLabel.font = [UIFont systemFontOfSize:18];
         cell.accessoryType = UITableViewCellAccessoryNone;
         return cell;
     } else if(arrivals.count == 0 ) {
         UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView];
         cell.textLabel.text = [NSString stringWithFormat:NSLocalizedString(@"No arrivals in the next %i minutes",@"[arrivals count] == 0"), self.minutesAfter];
-        cell.textLabel.textAlignment = UITextAlignmentCenter;
+        cell.textLabel.textAlignment = NSTextAlignmentCenter;
         cell.textLabel.font = [UIFont systemFontOfSize:18];
         cell.selectionStyle = UITableViewCellSelectionStyleNone;
         cell.accessoryType = UITableViewCellAccessoryNone;
@@ -597,7 +597,7 @@ static const double kNearbyStopRadius = 200;
     
     [self determineFilterTypeCellText:cell filteringEnabled:_showFilteredArrivals];
     
-    cell.textLabel.textAlignment = UITextAlignmentCenter;
+    cell.textLabel.textAlignment = NSTextAlignmentCenter;
     cell.textLabel.font = [UIFont systemFontOfSize:18];
     cell.selectionStyle = UITableViewCellSelectionStyleBlue;
     cell.accessoryType = UITableViewCellAccessoryNone;
@@ -609,7 +609,7 @@ static const double kNearbyStopRadius = 200;
     
     UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView];
 
-    cell.textLabel.textAlignment = UITextAlignmentLeft;
+    cell.textLabel.textAlignment = NSTextAlignmentLeft;
     cell.textLabel.font = [UIFont systemFontOfSize:18];
     cell.selectionStyle = UITableViewCellSelectionStyleBlue;
     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;

--- a/view_controllers/StopDetails/OBAReportProblemViewController.m
+++ b/view_controllers/StopDetails/OBAReportProblemViewController.m
@@ -68,7 +68,7 @@
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     
     UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView];            
-    cell.textLabel.textAlignment = UITextAlignmentLeft;
+    cell.textLabel.textAlignment = NSTextAlignmentLeft;
     cell.selectionStyle = UITableViewCellSelectionStyleBlue;
     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
     cell.textLabel.font = [UIFont systemFontOfSize:18];

--- a/view_controllers/StopDetails/OBAReportProblemWithStopViewController.m
+++ b/view_controllers/StopDetails/OBAReportProblemWithStopViewController.m
@@ -150,7 +150,7 @@ typedef enum {
     switch (sectionType) {
         case OBASectionTypeProblem: {
             UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView];            
-            cell.textLabel.textAlignment = UITextAlignmentLeft;
+            cell.textLabel.textAlignment = NSTextAlignmentLeft;
             cell.selectionStyle = UITableViewCellSelectionStyleBlue;
             cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
             cell.textLabel.font = [UIFont systemFontOfSize:18];
@@ -159,7 +159,7 @@ typedef enum {
         }
         case OBASectionTypeComment: {
             UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView];            
-            cell.textLabel.textAlignment = UITextAlignmentLeft;
+            cell.textLabel.textAlignment = NSTextAlignmentLeft;
             cell.selectionStyle = UITableViewCellSelectionStyleBlue;
             cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
             cell.textLabel.font = [UIFont systemFontOfSize:18];
@@ -178,7 +178,7 @@ typedef enum {
         
         case OBASectionTypeSubmit: {
             UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView];            
-            cell.textLabel.textAlignment = UITextAlignmentCenter;
+            cell.textLabel.textAlignment = NSTextAlignmentCenter;
             cell.selectionStyle = UITableViewCellSelectionStyleBlue;
             cell.accessoryType = UITableViewCellAccessoryNone;
             cell.textLabel.font = [UIFont systemFontOfSize:18];

--- a/view_controllers/TripDetails/OBAArrivalAndDepartureViewController.m
+++ b/view_controllers/TripDetails/OBAArrivalAndDepartureViewController.m
@@ -228,7 +228,7 @@ typedef enum {
     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
     cell.selectionStyle = UITableViewCellSelectionStyleBlue;
     cell.textLabel.textColor = [UIColor blackColor];
-    cell.textLabel.textAlignment = UITextAlignmentLeft;
+    cell.textLabel.textAlignment = NSTextAlignmentLeft;
     cell.textLabel.font = [UIFont systemFontOfSize:18];
     
     switch (indexPath.row) {
@@ -255,7 +255,7 @@ typedef enum {
             cell.selectionStyle = UITableViewCellSelectionStyleBlue;
             cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
             cell.textLabel.textColor = [UIColor blackColor];
-            cell.textLabel.textAlignment = UITextAlignmentLeft;
+            cell.textLabel.textAlignment = NSTextAlignmentLeft;
             cell.textLabel.font = [UIFont systemFontOfSize:18];
             cell.textLabel.text = NSLocalizedString(@"Report a problem for this trip",@"text");
             return cell;            
@@ -265,7 +265,7 @@ typedef enum {
             cell.selectionStyle = UITableViewCellSelectionStyleBlue;
             cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
             cell.textLabel.textColor = [UIColor blackColor];
-            cell.textLabel.textAlignment = UITextAlignmentLeft;
+            cell.textLabel.textAlignment = NSTextAlignmentLeft;
             cell.textLabel.font = [UIFont systemFontOfSize:18];
             cell.textLabel.text = NSLocalizedString(@"Vehicle Info",@"cell.textLabel.text");
             return cell;            

--- a/view_controllers/TripDetails/OBAReportProblemWithTripViewController.m
+++ b/view_controllers/TripDetails/OBAReportProblemWithTripViewController.m
@@ -166,7 +166,7 @@ typedef enum {
     switch (sectionType) {
         case OBASectionTypeProblem: {
             UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView];            
-            cell.textLabel.textAlignment = UITextAlignmentLeft;
+            cell.textLabel.textAlignment = NSTextAlignmentLeft;
             cell.selectionStyle = UITableViewCellSelectionStyleBlue;
             cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
             cell.textLabel.font = [UIFont systemFontOfSize:18];
@@ -175,7 +175,7 @@ typedef enum {
         }
         case OBASectionTypeComment: {
             UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView];            
-            cell.textLabel.textAlignment = UITextAlignmentLeft;
+            cell.textLabel.textAlignment = NSTextAlignmentLeft;
             cell.selectionStyle = UITableViewCellSelectionStyleBlue;
             cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
             cell.textLabel.font = [UIFont systemFontOfSize:18];
@@ -196,7 +196,7 @@ typedef enum {
 
         case OBASectionTypeSubmit: {
             UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView];            
-            cell.textLabel.textAlignment = UITextAlignmentCenter;
+            cell.textLabel.textAlignment = NSTextAlignmentCenter;
             cell.selectionStyle = UITableViewCellSelectionStyleBlue;
             cell.accessoryType = UITableViewCellAccessoryNone;
             cell.textLabel.font = [UIFont systemFontOfSize:18];

--- a/view_controllers/TripDetails/OBATripDetailsViewController.m
+++ b/view_controllers/TripDetails/OBATripDetailsViewController.m
@@ -244,7 +244,7 @@ typedef enum {
 
     cell.textLabel.text = NSLocalizedString(@"Updating...",@"message");
     cell.textLabel.textColor = [UIColor grayColor];    
-    cell.textLabel.textAlignment = UITextAlignmentCenter;    
+    cell.textLabel.textAlignment = NSTextAlignmentCenter;
     
     return cell;
 }
@@ -259,11 +259,11 @@ typedef enum {
     
     cell.textLabel.text = trip.asLabel;
     cell.textLabel.textColor = [UIColor blackColor];
-    cell.textLabel.textAlignment = UITextAlignmentLeft;    
+    cell.textLabel.textAlignment = NSTextAlignmentLeft;
     
     cell.detailTextLabel.text = NSLocalizedString(@"Schedule data only",@"cell.detailTextLabel.text");
     cell.detailTextLabel.textColor = [UIColor blackColor];
-    cell.detailTextLabel.textAlignment = UITextAlignmentLeft;    
+    cell.detailTextLabel.textAlignment = NSTextAlignmentLeft;
     
     OBATripStatusV2 * status = _tripDetails.status;
     if( status && status.predicted ) {
@@ -288,7 +288,7 @@ typedef enum {
     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
     cell.selectionStyle = UITableViewCellSelectionStyleBlue;
     cell.textLabel.textColor = [UIColor blackColor];
-    cell.textLabel.textAlignment = UITextAlignmentLeft;
+    cell.textLabel.textAlignment = NSTextAlignmentLeft;
     
     switch (indexPath.row) {
         case 0:
@@ -309,7 +309,7 @@ typedef enum {
     cell.selectionStyle = UITableViewCellSelectionStyleBlue;
     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
     cell.textLabel.textColor = [UIColor blackColor];
-    cell.textLabel.textAlignment = UITextAlignmentLeft;
+    cell.textLabel.textAlignment = NSTextAlignmentLeft;
     
     
     switch (indexPath.row) {

--- a/view_controllers/TripDetails/OBATripScheduleListViewController.m
+++ b/view_controllers/TripDetails/OBATripScheduleListViewController.m
@@ -303,7 +303,7 @@ typedef enum {
     cell.selectionStyle = UITableViewCellSelectionStyleNone;
     cell.accessoryType = UITableViewCellAccessoryNone;
     cell.textLabel.text = NSLocalizedString(@"Loading...",@"cell.textLabel.text");
-    cell.textLabel.textAlignment = UITextAlignmentCenter;
+    cell.textLabel.textAlignment = NSTextAlignmentCenter;
     cell.textLabel.font = [UIFont systemFontOfSize:18];
 
     return cell;

--- a/view_controllers/situations/OBASituationViewController.m
+++ b/view_controllers/situations/OBASituationViewController.m
@@ -190,7 +190,7 @@ typedef enum {
 - (UITableViewCell*) tableView:(UITableView*)tableView titleCellForRowAtIndexPath:(NSIndexPath *)indexPath {
     UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView];
     cell.textLabel.text = _situation.summary;
-    cell.textLabel.textAlignment = UITextAlignmentCenter;
+    cell.textLabel.textAlignment = NSTextAlignmentCenter;
     cell.selectionStyle = UITableViewCellSelectionStyleNone;
     cell.accessoryType = UITableViewCellAccessoryNone;
     return cell;    
@@ -200,7 +200,7 @@ typedef enum {
     UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView];    
     cell.selectionStyle = UITableViewCellSelectionStyleBlue;
     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
-    cell.textLabel.textAlignment = UITextAlignmentLeft;
+    cell.textLabel.textAlignment = NSTextAlignmentLeft;
     
     if( indexPath.row == 0 ) {
         cell.textLabel.text = [self getDetails:NO];
@@ -219,7 +219,7 @@ typedef enum {
 
     UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView];
     cell.textLabel.text = isRead ? NSLocalizedString(@"Mark as Unread",@"isRead") : NSLocalizedString(@"Mark as Read",@"!isRead");
-    cell.textLabel.textAlignment = UITextAlignmentCenter;
+    cell.textLabel.textAlignment = NSTextAlignmentCenter;
     cell.selectionStyle = UITableViewCellSelectionStyleBlue;
     cell.accessoryType = UITableViewCellAccessoryNone;           
     return cell;

--- a/view_controllers/situations/OBASituationsViewController.m
+++ b/view_controllers/situations/OBASituationsViewController.m
@@ -68,7 +68,7 @@
     if( [_situations count] == 0 ) {
         UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView];
         cell.textLabel.text = NSLocalizedString(@"No active service alerts",@"cell.textLabel.text");
-        cell.textLabel.textAlignment = UITextAlignmentCenter;
+        cell.textLabel.textAlignment = NSTextAlignmentCenter;
         cell.textLabel.font = [UIFont systemFontOfSize:18];
         cell.selectionStyle = UITableViewCellSelectionStyleNone;
         cell.accessoryType = UITableViewCellAccessoryNone;
@@ -79,7 +79,7 @@
     
     UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView];
     cell.textLabel.text = situation.summary;
-    cell.textLabel.textAlignment = UITextAlignmentCenter;
+    cell.textLabel.textAlignment = NSTextAlignmentCenter;
     cell.selectionStyle = UITableViewCellSelectionStyleBlue;
     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
     return cell;    


### PR DESCRIPTION
This PR drops support for iOS 5.1, sets the minimum supported version of iOS to 6.0, and fixes all iOS 6.0 deprecation warnings in the app.

This shouldn't be merged until we finish hammering out this topic: https://groups.google.com/forum/#!topic/onebusaway-developers/2Niw7mU5GEM
