### PR TITLE
Stop Details view Stop Info link highlight

### DIFF
--- a/WSCoachMarksView.h
+++ b/WSCoachMarksView.h
@@ -1,0 +1,68 @@
+//
+//  WSCoachMarksView.h
+//  Version 0.2
+//
+//  Created by Dimitry Bentsionov on 4/1/13.
+//  Copyright (c) 2013 Workshirt, Inc. All rights reserved.
+//
+
+// This code is distributed under the terms and conditions of the MIT license.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <UIKit/UIKit.h>
+
+#ifndef WS_WEAK
+  #if __has_feature(objc_arc_weak)
+    #define WS_WEAK weak
+  #elif __has_feature(objc_arc)
+    #define WS_WEAK unsafe_unretained
+  #else
+    #define WS_WEAK assign
+  #endif
+#endif
+
+@protocol WSCoachMarksViewDelegate;
+
+@interface WSCoachMarksView : UIView
+
+@property (nonatomic, WS_WEAK) id<WSCoachMarksViewDelegate> delegate;
+@property (nonatomic, retain) NSArray *coachMarks;
+@property (nonatomic, retain) UILabel *lblCaption;
+@property (nonatomic, retain) UIColor *maskColor;
+@property (nonatomic) CGFloat animationDuration;
+@property (nonatomic) CGFloat cutoutRadius;
+@property (nonatomic) CGFloat maxLblWidth;
+@property (nonatomic) CGFloat lblSpacing;
+@property (nonatomic) BOOL enableContinueLabel;
+
+- (id)initWithFrame:(CGRect)frame coachMarks:(NSArray *)marks;
+- (void)start;
+
+@end
+
+@protocol WSCoachMarksViewDelegate <NSObject>
+
+@optional
+- (void)coachMarksView:(WSCoachMarksView*)coachMarksView willNavigateToIndex:(NSUInteger)index;
+- (void)coachMarksView:(WSCoachMarksView*)coachMarksView didNavigateToIndex:(NSUInteger)index;
+- (void)coachMarksViewWillCleanup:(WSCoachMarksView*)coachMarksView;
+- (void)coachMarksViewDidCleanup:(WSCoachMarksView*)coachMarksView;
+
+@end

--- a/WSCoachMarksView.m
+++ b/WSCoachMarksView.m
@@ -1,0 +1,264 @@
+//
+//  WSCoachMarksView.m
+//  Version 0.2
+//
+//  Created by Dimitry Bentsionov on 4/1/13.
+//  Copyright (c) 2013 Workshirt, Inc. All rights reserved.
+//
+
+#import <QuartzCore/QuartzCore.h>
+#import "WSCoachMarksView.h"
+
+static const CGFloat kAnimationDuration = 0.3f;
+static const CGFloat kCutoutRadius = 2.0f;
+static const CGFloat kMaxLblWidth = 230.0f;
+static const CGFloat kLblSpacing = 35.0f;
+static const BOOL kEnableContinueLabel = YES;
+
+@implementation WSCoachMarksView {
+    CAShapeLayer *mask;
+    NSUInteger markIndex;
+    UILabel *lblContinue;
+}
+
+#pragma mark - Properties
+
+@synthesize delegate;
+@synthesize coachMarks;
+@synthesize lblCaption;
+@synthesize maskColor = _maskColor;
+@synthesize animationDuration;
+@synthesize cutoutRadius;
+@synthesize maxLblWidth;
+@synthesize lblSpacing;
+@synthesize enableContinueLabel;
+
+#pragma mark - Methods
+
+- (id)initWithFrame:(CGRect)frame coachMarks:(NSArray *)marks {
+    self = [super initWithFrame:frame];
+    if (self) {
+        // Save the coach marks
+        self.coachMarks = marks;
+
+        // Setup
+        [self setup];
+    }
+    return self;
+}
+
+- (id)initWithFrame:(CGRect)frame {
+    self = [super initWithFrame:frame];
+    if (self) {
+        // Setup
+        [self setup];
+    }
+    return self;
+}
+
+- (id)initWithCoder:(NSCoder *)aDecoder {
+    self = [super initWithCoder:aDecoder];
+    if (self) {
+        // Setup
+        [self setup];
+    }
+    return self;
+}
+
+- (void)setup {
+    // Default
+    self.animationDuration = kAnimationDuration;
+    self.cutoutRadius = kCutoutRadius;
+    self.maxLblWidth = kMaxLblWidth;
+    self.lblSpacing = kLblSpacing;
+    self.enableContinueLabel = kEnableContinueLabel;
+
+    // Shape layer mask
+    mask = [CAShapeLayer layer];
+    [mask setFillRule:kCAFillRuleEvenOdd];
+    [mask setFillColor:[[UIColor colorWithHue:0.0f saturation:0.0f brightness:0.0f alpha:0.9f] CGColor]];
+    [self.layer addSublayer:mask];
+
+    // Capture touches
+    UITapGestureRecognizer *tapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(userDidTap:)];
+    [self addGestureRecognizer:tapGestureRecognizer];
+
+    // Captions
+    self.lblCaption = [[UILabel alloc] initWithFrame:(CGRect){{0.0f, 0.0f}, {self.maxLblWidth, 0.0f}}];
+    self.lblCaption.backgroundColor = [UIColor clearColor];
+    self.lblCaption.textColor = [UIColor whiteColor];
+    self.lblCaption.font = [UIFont systemFontOfSize:20.0f];
+    self.lblCaption.lineBreakMode = NSLineBreakByWordWrapping;
+    self.lblCaption.numberOfLines = 0;
+    self.lblCaption.textAlignment = NSTextAlignmentCenter;
+    self.lblCaption.alpha = 0.0f;
+    [self addSubview:self.lblCaption];
+
+    // Hide until unvoked
+    self.hidden = YES;
+}
+
+#pragma mark - Cutout modify
+
+- (void)setCutoutToRect:(CGRect)rect {
+    // Define shape
+    UIBezierPath *maskPath = [UIBezierPath bezierPathWithRect:self.bounds];
+    UIBezierPath *cutoutPath = [UIBezierPath bezierPathWithRoundedRect:rect cornerRadius:self.cutoutRadius];
+    [maskPath appendPath:cutoutPath];
+
+    // Set the new path
+    mask.path = maskPath.CGPath;
+}
+
+- (void)animateCutoutToRect:(CGRect)rect {
+    // Define shape
+    UIBezierPath *maskPath = [UIBezierPath bezierPathWithRect:self.bounds];
+    UIBezierPath *cutoutPath = [UIBezierPath bezierPathWithRoundedRect:rect cornerRadius:self.cutoutRadius];
+    [maskPath appendPath:cutoutPath];
+
+    // Animate it
+    CABasicAnimation *anim = [CABasicAnimation animationWithKeyPath:@"path"];
+    anim.delegate = self;
+    anim.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseOut];
+    anim.duration = self.animationDuration;
+    anim.removedOnCompletion = NO;
+    anim.fillMode = kCAFillModeForwards;
+    anim.fromValue = (__bridge id)(mask.path);
+    anim.toValue = (__bridge id)(maskPath.CGPath);
+    [mask addAnimation:anim forKey:@"path"];
+    mask.path = maskPath.CGPath;
+}
+
+#pragma mark - Mask color
+
+- (void)setMaskColor:(UIColor *)maskColor {
+    _maskColor = maskColor;
+    [mask setFillColor:[maskColor CGColor]];
+}
+
+#pragma mark - Touch handler
+
+- (void)userDidTap:(UITapGestureRecognizer *)recognizer {
+    // Go to the next coach mark
+    [self goToCoachMarkIndexed:(markIndex+1)];
+}
+
+#pragma mark - Navigation
+
+- (void)start {
+    // Fade in self
+    self.alpha = 0.0f;
+    self.hidden = NO;
+    [UIView animateWithDuration:self.animationDuration
+                     animations:^{
+                         self.alpha = 1.0f;
+                     }
+                     completion:^(BOOL finished) {
+                         // Go to the first coach mark
+                         [self goToCoachMarkIndexed:0];
+                     }];
+}
+
+- (void)goToCoachMarkIndexed:(NSUInteger)index {
+    // Out of bounds
+    if (index >= self.coachMarks.count) {
+        [self cleanup];
+        return;
+    }
+
+    // Current index
+    markIndex = index;
+
+    // Coach mark definition
+    NSDictionary *markDef = [self.coachMarks objectAtIndex:index];
+    NSString *markCaption = [markDef objectForKey:@"caption"];
+    CGRect markRect = [[markDef objectForKey:@"rect"] CGRectValue];
+
+    // Delegate (coachMarksView:willNavigateTo:atIndex:)
+    if ([self.delegate respondsToSelector:@selector(coachMarksView:willNavigateToIndex:)]) {
+        [self.delegate coachMarksView:self willNavigateToIndex:markIndex];
+    }
+
+    // Calculate the caption position and size
+    self.lblCaption.alpha = 0.0f;
+    self.lblCaption.frame = (CGRect){{0.0f, 0.0f}, {self.maxLblWidth, 0.0f}};
+    self.lblCaption.text = markCaption;
+    [self.lblCaption sizeToFit];
+    CGFloat y = markRect.origin.y + markRect.size.height + self.lblSpacing;
+    CGFloat bottomY = y + self.lblCaption.frame.size.height + self.lblSpacing;
+    if (bottomY > self.bounds.size.height) {
+        y = markRect.origin.y - self.lblSpacing - self.lblCaption.frame.size.height;
+    }
+    CGFloat x = floorf((self.bounds.size.width - self.lblCaption.frame.size.width) / 2.0f);
+
+    // Animate the caption label
+    self.lblCaption.frame = (CGRect){{x, y}, self.lblCaption.frame.size};
+    [UIView animateWithDuration:0.3f animations:^{
+        self.lblCaption.alpha = 1.0f;
+    }];
+
+    // If first mark, set the cutout to the center of first mark
+    if (markIndex == 0) {
+        CGPoint center = CGPointMake(floorf(markRect.origin.x + (markRect.size.width / 2.0f)), floorf(markRect.origin.y + (markRect.size.height / 2.0f)));
+        CGRect centerZero = (CGRect){center, CGSizeZero};
+        [self setCutoutToRect:centerZero];
+    }
+
+    // Animate the cutout
+    [self animateCutoutToRect:markRect];
+
+    // Show continue lbl if first mark
+    if (self.enableContinueLabel) {
+        if (markIndex == 0) {
+            lblContinue = [[UILabel alloc] initWithFrame:(CGRect){{0, self.bounds.size.height - 30.0f}, {self.bounds.size.width, 30.0f}}];
+            lblContinue.font = [UIFont boldSystemFontOfSize:13.0f];
+            lblContinue.textAlignment = NSTextAlignmentCenter;
+            lblContinue.text = @"Tap to continue";
+            lblContinue.alpha = 0.0f;
+            lblContinue.backgroundColor = [UIColor whiteColor];
+            [self addSubview:lblContinue];
+            [UIView animateWithDuration:0.3f delay:1.0f options:0 animations:^{
+                lblContinue.alpha = 1.0f;
+            } completion:nil];
+        } else if (markIndex > 0 && lblContinue != nil) {
+            // Otherwise, remove the lbl
+            [lblContinue removeFromSuperview];
+            lblContinue = nil;
+        }
+    }
+}
+
+#pragma mark - Cleanup
+
+- (void)cleanup {
+    // Delegate (coachMarksViewWillCleanup:)
+    if ([self.delegate respondsToSelector:@selector(coachMarksViewWillCleanup:)]) {
+        [self.delegate coachMarksViewWillCleanup:self];
+    }
+
+    // Fade out self
+    [UIView animateWithDuration:self.animationDuration
+                     animations:^{
+                         self.alpha = 0.0f;
+                     }
+                     completion:^(BOOL finished) {
+                         // Remove self
+                         [self removeFromSuperview];
+
+                         // Delegate (coachMarksViewDidCleanup:)
+                         if ([self.delegate respondsToSelector:@selector(coachMarksViewDidCleanup:)]) {
+                             [self.delegate coachMarksViewDidCleanup:self];
+                         }
+                     }];
+}
+
+#pragma mark - Animation delegate
+
+- (void)animationDidStop:(CAAnimation *)anim finished:(BOOL)flag {
+    // Delegate (coachMarksView:didNavigateTo:atIndex:)
+    if ([self.delegate respondsToSelector:@selector(coachMarksView:didNavigateToIndex:)]) {
+        [self.delegate coachMarksView:self didNavigateToIndex:markIndex];
+    }
+}
+
+@end

--- a/org.onebusaway.iphone.xcodeproj/project.pbxproj
+++ b/org.onebusaway.iphone.xcodeproj/project.pbxproj
@@ -351,6 +351,7 @@
 		D6575AEC0FEE13CF00D6D987 /* Entitlements.plist in Resources */ = {isa = PBXBuildFile; fileRef = D6575AEB0FEE13CF00D6D987 /* Entitlements.plist */; };
 		D6631B34104DC1BB001C7C90 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D6631B33104DC1BB001C7C90 /* SystemConfiguration.framework */; };
 		D69C598913F9BD6900BA90A2 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = D69C598713F9BD6900BA90A2 /* Localizable.strings */; };
+		FFA3C6B6188B0E6C006FBDD1 /* WSCoachMarksView.m in Sources */ = {isa = PBXBuildFile; fileRef = FFA3C6B5188B0E6C006FBDD1 /* WSCoachMarksView.m */; };
 		FFBFE02A1863D9B1009DAC8A /* OBAEditStopBookmarkGroupViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FFBFE0291863D9B1009DAC8A /* OBAEditStopBookmarkGroupViewController.m */; };
 		FFCA85721863D24200F87DCA /* OBABookmarkGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = FFCA85711863D24200F87DCA /* OBABookmarkGroup.m */; };
 		FFE76DCD186F94E10036D121 /* OBAEditBookmarkGroupViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FFE76DCC186F94E10036D121 /* OBAEditBookmarkGroupViewController.m */; };
@@ -869,6 +870,8 @@
 		E81C7B031825DEBF0047C68C /* accept_license.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = accept_license.sh; sourceTree = "<group>"; };
 		E81C7B041825DEBF0047C68C /* upload.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = upload.sh; sourceTree = "<group>"; };
 		E81C7B051825DEBF0047C68C /* xcode5.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = xcode5.sh; sourceTree = "<group>"; };
+		FFA3C6B4188B0E6C006FBDD1 /* WSCoachMarksView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WSCoachMarksView.h; sourceTree = "<group>"; };
+		FFA3C6B5188B0E6C006FBDD1 /* WSCoachMarksView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WSCoachMarksView.m; sourceTree = "<group>"; };
 		FFBFE0281863D9B1009DAC8A /* OBAEditStopBookmarkGroupViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAEditStopBookmarkGroupViewController.h; sourceTree = "<group>"; };
 		FFBFE0291863D9B1009DAC8A /* OBAEditStopBookmarkGroupViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAEditStopBookmarkGroupViewController.m; sourceTree = "<group>"; };
 		FFCA85701863D24200F87DCA /* OBABookmarkGroup.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBABookmarkGroup.h; sourceTree = "<group>"; };
@@ -1720,6 +1723,7 @@
 		D61A66790FCDB155004D2E91 /* Libraries */ = {
 			isa = PBXGroup;
 			children = (
+				FFA3C6B3188B0E5D006FBDD1 /* WSCoachMarks */,
 				9358469A17FB9DC30034200C /* TWSReleaseNotesView */,
 				92CAAE96179C4AF40097DD3D /* MarqueeLabel */,
 				933C7E2B160C07440005AAFE /* Common */,
@@ -1746,6 +1750,15 @@
 				E81C7B051825DEBF0047C68C /* xcode5.sh */,
 			);
 			path = travis;
+			sourceTree = "<group>";
+		};
+		FFA3C6B3188B0E5D006FBDD1 /* WSCoachMarks */ = {
+			isa = PBXGroup;
+			children = (
+				FFA3C6B4188B0E6C006FBDD1 /* WSCoachMarksView.h */,
+				FFA3C6B5188B0E6C006FBDD1 /* WSCoachMarksView.m */,
+			);
+			name = WSCoachMarks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -2083,6 +2096,7 @@
 				93631E6E1604F99500CB7209 /* OBAEditStopBookmarkViewController.m in Sources */,
 				93631E6F1604F99500CB7209 /* OBAEditStopPreferencesViewController.m in Sources */,
 				93631E701604F99500CB7209 /* OBAGenericStopViewController.m in Sources */,
+				FFA3C6B6188B0E6C006FBDD1 /* WSCoachMarksView.m in Sources */,
 				93631E711604F99500CB7209 /* OBAReportProblemViewController.m in Sources */,
 				93631E721604F99500CB7209 /* OBAReportProblemWithRecentTripsViewController.m in Sources */,
 				93631E731604F99500CB7209 /* OBAReportProblemWithStopViewController.m in Sources */,

--- a/view_controllers/StopDetails/OBAGenericStopViewController.m
+++ b/view_controllers/StopDetails/OBAGenericStopViewController.m
@@ -36,7 +36,9 @@
 #import "MKMapView+oba_Additions.h"
 #import "UITableViewController+oba_Additions.h"
 #import "OBABookmarkGroup.h"
+#import "WSCoachMarksView.h"
 
+static NSString * kOBAStopInfoCoachMarkShownDefaultsKey = @"OBAStopInfoCoachMarkShown";
 static const double kNearbyStopRadius = 200;
 
 @interface OBAGenericStopViewController ()
@@ -178,6 +180,10 @@ static const double kNearbyStopRadius = 200;
         
         [self hideEmptySeparators];
     }
+    
+    if ([self shouldShowCoachMark]) {
+        [self showCoachMark];
+    }
 }
 
 - (void)viewDidUnload {
@@ -237,6 +243,27 @@ static const double kNearbyStopRadius = 200;
     }
     
     return OBAStopSectionTypeNone;
+}
+
+#pragma mark Stop Info Coach Mark
+
+- (BOOL)shouldShowCoachMark {
+    BOOL coachMarkShown = [[NSUserDefaults standardUserDefaults] boolForKey:kOBAStopInfoCoachMarkShownDefaultsKey];
+    return !coachMarkShown;
+}
+
+- (void)showCoachMark {
+    [[NSUserDefaults standardUserDefaults] setBool:YES forKey:kOBAStopInfoCoachMarkShownDefaultsKey];
+    [[NSUserDefaults standardUserDefaults] synchronize];
+    
+    NSArray *coachMarks = @[ @{
+            @"rect": [NSValue valueWithCGRect:(CGRect){{5,30}, {310, 70}}],
+            @"caption": @"Tap here to learn more about this stop with the new StopInfo service."
+            }];
+    
+    WSCoachMarksView *coachMarksView = [[WSCoachMarksView alloc] initWithFrame:self.view.bounds coachMarks:coachMarks];
+    [self.view addSubview:coachMarksView];
+    [coachMarksView start];
 }
 
 #pragma mark OBANavigationTargetAware


### PR DESCRIPTION
The stop view now shows a coach mark (rectangular highlight basically) near the top to indicate where the stop info link will be. This uses the WSCoachMarks library.
![stopinfo-coachmark](https://f.cloud.github.com/assets/354123/1948890/de5334a8-80c2-11e3-83b9-1ec9ee682fc6.png)
