### PR TITLE
Fixing up OBATripDetails view to be more consistent with other views

### DIFF
--- a/view_controllers/TripDetails/OBATripDetailsViewController.h
+++ b/view_controllers/TripDetails/OBATripDetailsViewController.h
@@ -3,20 +3,19 @@
 #import "OBATripDetailsV2.h"
 #import "OBATripInstanceRef.h"
 #import "OBAProgressIndicatorView.h"
+#import "OBARequestDrivenTableViewController.h"
 
-
-@interface OBATripDetailsViewController : UITableViewController <OBANavigationTargetAware,OBAModelServiceDelegate> {
-    OBAApplicationDelegate * _appDelegate;
-    OBATripInstanceRef * _tripInstance;
-    OBATripDetailsV2 * _tripDetails;
-    OBAServiceAlertsModel * _serviceAlerts;
-    id<OBAModelServiceRequest> _request;
-    OBAProgressIndicatorView * _progressView;
+@interface OBATripDetailsViewController : OBARequestDrivenTableViewController <OBAModelServiceDelegate> {
+    OBATripInstanceRef *_tripInstance;
+    OBATripDetailsV2 *_tripDetails;
+    OBAServiceAlertsModel *_serviceAlerts;
 }
 
-- (id) initWithApplicationDelegate:(OBAApplicationDelegate*)appDelegate tripInstance:(OBATripInstanceRef*)tripInstance;
+- (id)initWithApplicationDelegate:(OBAApplicationDelegate *)appDelegate tripInstance:(OBATripInstanceRef *)tripInstance;
 
-@property (nonatomic,strong) OBATripDetailsV2 * tripDetails;
-@property (nonatomic,strong) NSString * currentStopId;
+@property (nonatomic, strong) OBATripInstanceRef *tripInstance;
+@property (nonatomic, strong) OBATripDetailsV2 *tripDetails;
+@property (nonatomic, strong) OBAServiceAlertsModel *serviceAlerts;
+@property (nonatomic, strong) NSString *currentStopId;
 
 @end

--- a/view_controllers/TripDetails/OBATripDetailsViewController.m
+++ b/view_controllers/TripDetails/OBATripDetailsViewController.m
@@ -3,6 +3,7 @@
 #import "OBATripScheduleListViewController.h"
 #import "OBAReportProblemWithTripViewController.h"
 #import "OBALogger.h"
+#import "OBAArrivalEntryTableViewCell.h"
 
 
 typedef enum {
@@ -17,190 +18,144 @@ typedef enum {
 
 @interface OBATripDetailsViewController (Private)
 
-- (void) clearPendingRequest;
+- (OBASectionType)sectionTypeForSection:(NSUInteger)section;
 
-- (OBASectionType) sectionTypeForSection:(NSUInteger)section;
+- (UITableViewCell *)tableView:(UITableView *)tableView titleCellForRowAtIndexPath:(NSIndexPath *)indexPath;
+- (UITableViewCell *)tableView:(UITableView *)tableView scheduleCellForRowAtIndexPath:(NSIndexPath *)indexPath;
+- (UITableViewCell *)tableView:(UITableView *)tableView actionCellForRowAtIndexPath:(NSIndexPath *)indexPath;
 
-- (UITableViewCell*) tableView:(UITableView*)tableView loadingCellForRowAtIndexPath:(NSIndexPath *)indexPath;
-- (UITableViewCell*) tableView:(UITableView*)tableView titleCellForRowAtIndexPath:(NSIndexPath *)indexPath;
-- (UITableViewCell*) tableView:(UITableView*)tableView scheduleCellForRowAtIndexPath:(NSIndexPath *)indexPath;
-- (UITableViewCell*) tableView:(UITableView*)tableView actionCellForRowAtIndexPath:(NSIndexPath *)indexPath;
+- (void)didSelectScheduleRowAtIndexPath:(NSIndexPath *)indexPath tableView:(UITableView *)tableView;
+- (void)didSelectActionRowAtIndexPath:(NSIndexPath *)indexPath tableView:(UITableView *)tableView;
 
 @end
 
 
 @implementation OBATripDetailsViewController
 
-@synthesize tripDetails = _tripDetails;
-@synthesize currentStopId;
-
-- (id) initWithApplicationDelegate:(OBAApplicationDelegate*)appDelegate tripInstance:(OBATripInstanceRef*)tripInstance {
-    if (self = [super initWithStyle:UITableViewStyleGrouped]) {
-        _appDelegate = appDelegate;
+- (id)initWithApplicationDelegate:(OBAApplicationDelegate *)appDelegate tripInstance:(OBATripInstanceRef *)tripInstance {
+    if (self = [super initWithApplicationDelegate:appDelegate]) {
         _tripInstance = tripInstance;
-        CGRect r = CGRectMake(0, 0, 160, 33);
-        _progressView = [[OBAProgressIndicatorView alloc] initWithFrame:r];
-        [self.navigationItem setTitleView:_progressView];
+        self.refreshable = YES;
+        self.refreshInterval = 30;
+        self.showUpdateTime = YES;
     }
+
     return self;
 }
 
-- (void)viewDidLoad
-{
+- (void)viewDidLoad {
     [super viewDidLoad];
     self.tableView.backgroundView = nil;
     self.tableView.backgroundColor = [UIColor whiteColor];
 }
-- (void)dealloc {
-    [self clearPendingRequest];
-}
-
-#pragma mark OBANavigationTargetAware
-
-- (OBANavigationTarget*) navigationTarget {
-    return nil;
-}
-
-#pragma mark UIViewController methods
 
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
-    [self clearPendingRequest];
-    [_progressView setMessage:NSLocalizedString(@"Updating...",@"message") inProgress:YES progress:0];
-    _request = [_appDelegate.modelService requestTripDetailsForTripInstance:_tripInstance withDelegate:self withContext:nil];
     [TestFlight passCheckpoint:[NSString stringWithFormat:@"View: %@", [self class]]];
 }
 
-#pragma mark OBAModelServiceDelegate
+- (BOOL)isLoading {
+    return self.tripDetails == nil;
+}
 
-- (void)requestDidFinish:(id<OBAModelServiceRequest>)request withObject:(id)obj context:(id)context {
-    OBAEntryWithReferencesV2 * entry = obj;
+- (id<OBAModelServiceRequest>)handleRefresh {
+    return [self.appDelegate.modelService requestTripDetailsForTripInstance:self.tripInstance withDelegate:self withContext:nil];
+}
+
+- (void)handleData:(id)obj context:(id)context {
+    OBAEntryWithReferencesV2 *entry = obj;
+
     self.tripDetails = entry.entry;
-    _serviceAlerts = [_appDelegate.modelDao getServiceAlertsModelForSituations:_tripDetails.situations];
-    [_progressView setMessage:NSLocalizedString(@"Trip Details",@"message") inProgress:NO progress:0];
-    [self.tableView reloadData];
 }
 
-- (void)requestDidFinish:(id<OBAModelServiceRequest>)request withCode:(NSInteger)code context:(id)context {
-    if( code == 404 )
-        [_progressView setMessage:NSLocalizedString(@"Stop not found",@"message") inProgress:NO progress:0];
-    else
-        [_progressView setMessage:NSLocalizedString(@"Unknown error",@"message") inProgress:NO progress:0];
-}
-
-- (void)requestDidFail:(id<OBAModelServiceRequest>)request withError:(NSError *)error context:(id)context {
-    OBALogWarningWithError(error, @"Error");
-    [_progressView setMessage:NSLocalizedString(@"Error connecting",@"message") inProgress:NO progress:0];
-}
-
-- (void)request:(id<OBAModelServiceRequest>)request withProgress:(float)progress context:(id)context {
-    [_progressView setInProgress:YES progress:progress];
+- (void)handleDataChanged {
+    self.serviceAlerts = [self.appDelegate.modelDao getServiceAlertsModelForSituations:self.tripDetails.situations];
 }
 
 #pragma mark Table view methods
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
-    if( _tripDetails )
-        return 3;
+    if ([self isLoading]) {
+        return [super numberOfSectionsInTableView:tableView];
+    }
+
+    if (_tripDetails) return 3;
+
     return 1;
 }
 
-- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section {
-    
-    OBASectionType sectionType = [self sectionTypeForSection:section];
-    
-    switch (sectionType) {
-        case OBASectionTypeSchedule:
-            return NSLocalizedString(@"Trip Schedule:",@"OBASectionTypeSchedule");
-        default:
-            return nil;
-    }
-}
-
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
-    
+    if ([self isLoading]) {
+        return [super tableView:tableView numberOfRowsInSection:section];
+    }
+
     OBASectionType sectionType = [self sectionTypeForSection:section];
-    
-    switch( sectionType ) {
+
+    switch (sectionType) {
         case OBASectionTypeLoading:
             return 1;
+
         case OBASectionTypeTitle:
             return 1;
+
         case OBASectionTypeSchedule:
             return 2;
+
         case OBASectionTypeActions:
             return 1;
+
         case OBASectionTypeNone:
         default:
             return 0;
     }
 }
 
-
 // Customize the appearance of table view cells.
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
-    
+    if ([self isLoading]) {
+        return [super tableView:tableView cellForRowAtIndexPath:indexPath];
+    }
+
     OBASectionType sectionType = [self sectionTypeForSection:indexPath.section];
-    
+
     switch (sectionType) {
-        case OBASectionTypeLoading:
-            return [self tableView:tableView loadingCellForRowAtIndexPath:indexPath];
         case OBASectionTypeTitle:
             return [self tableView:tableView titleCellForRowAtIndexPath:indexPath];
+
         case OBASectionTypeSchedule:
             return [self tableView:tableView scheduleCellForRowAtIndexPath:indexPath];
+
         case OBASectionTypeActions:
             return [self tableView:tableView actionCellForRowAtIndexPath:indexPath];
+
         default:
             break;
     }
-    
+
     return [UITableViewCell getOrCreateCellForTableView:tableView];
 }
 
-
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    if ([self isLoading]) {
+        [self tableView:tableView didSelectRowAtIndexPath:indexPath];
+        return;
+    }
 
     OBASectionType sectionType = [self sectionTypeForSection:indexPath.section];
-    
+
     switch (sectionType) {
-    
-        case OBASectionTypeSchedule: {
-            
-            if( indexPath.row == 0 ) {
-                if( _tripDetails ) {
-                    OBATripScheduleMapViewController * vc = [[OBATripScheduleMapViewController alloc]initWithApplicationDelegate:_appDelegate];
-                    vc.tripInstance = _tripInstance;
-                    vc.tripDetails = _tripDetails;
-                    vc.currentStopId = self.currentStopId;
-                    [self.navigationController pushViewController:vc animated:YES];
-                }
-            }            
-            else if( indexPath.row == 1 ) {
-                if( _tripDetails ) {
-                    OBATripScheduleListViewController * vc = [[OBATripScheduleListViewController alloc] initWithApplicationDelegate:_appDelegate tripInstance:_tripInstance];
-                    vc.tripDetails = _tripDetails;
-                    vc.currentStopId = self.currentStopId;
-                    [self.navigationController pushViewController:vc animated:YES];
-                }
-            }
-            break;            
-        }
-            
+        case OBASectionTypeSchedule:
+            [self didSelectScheduleRowAtIndexPath:indexPath tableView:tableView];
+            break;
+
         case OBASectionTypeActions: {
-            if( indexPath.row == 0 ) {
-                if( _tripDetails ) {
-                    OBAReportProblemWithTripViewController * vc = [[OBAReportProblemWithTripViewController alloc] initWithApplicationDelegate:_appDelegate tripInstance:_tripInstance trip:_tripDetails.trip];
-                    vc.currentStopId = self.currentStopId;
-                    [self.navigationController pushViewController:vc animated:YES];
-                }
-            }
+            [self didSelectActionRowAtIndexPath:indexPath tableView:tableView];
             break;
         }
+
         default:
             break;
     }
-    
 }
 
 @end
@@ -208,127 +163,175 @@ typedef enum {
 
 @implementation OBATripDetailsViewController (Private)
 
-- (void) clearPendingRequest {
-    [_request cancel];
-    _request = nil;
+- (void)didSelectScheduleRowAtIndexPath:(NSIndexPath *)indexPath tableView:(UITableView *)tableView {
+    if (indexPath.row == 0) {
+        if (self.tripDetails) {
+            OBATripScheduleMapViewController *vc = [[OBATripScheduleMapViewController alloc]initWithApplicationDelegate:self.appDelegate];
+            vc.tripInstance = self.tripInstance;
+            vc.tripDetails = self.tripDetails;
+            vc.currentStopId = self.currentStopId;
+            [self.navigationController pushViewController:vc animated:YES];
+        }
+    }
+    else if (indexPath.row == 1) {
+        if (self.tripDetails) {
+            OBATripScheduleListViewController *vc = [[OBATripScheduleListViewController alloc] initWithApplicationDelegate:self.appDelegate tripInstance:self.tripInstance];
+            vc.tripDetails = self.tripDetails;
+            vc.currentStopId = self.currentStopId;
+            [self.navigationController pushViewController:vc animated:YES];
+        }
+    }
 }
 
-- (OBASectionType) sectionTypeForSection:(NSUInteger)section {
-    
-    if( _tripDetails ) {
+- (void)didSelectActionRowAtIndexPath:(NSIndexPath *)indexPath tableView:(UITableView *)tableView {
+    if (indexPath.row == 0) {
+        if (self.tripDetails) {
+            OBAReportProblemWithTripViewController *vc = [[OBAReportProblemWithTripViewController alloc] initWithApplicationDelegate:self.appDelegate tripInstance:self.tripInstance trip:self.tripDetails.trip];
+            vc.currentStopId = self.currentStopId;
+            [self.navigationController pushViewController:vc animated:YES];
+        }
+    }
+}
+
+- (OBASectionType)sectionTypeForSection:(NSUInteger)section {
+    if (self.tripDetails) {
         switch (section) {
             case 0:
-                
+
                 return OBASectionTypeTitle;
+
             case 1:
                 return OBASectionTypeSchedule;
+
             case 2:
                 return OBASectionTypeActions;
+
             default:
                 return OBASectionTypeNone;
         }
     }
     else {
-        if( section == 0 )
-            return OBASectionTypeLoading;
+        if (section == 0) return OBASectionTypeLoading;
+
         return OBASectionTypeNone;
     }
-
 }
 
-- (UITableViewCell*) tableView:(UITableView*)tableView loadingCellForRowAtIndexPath:(NSIndexPath *)indexPath {
+- (UITableViewCell *)tableView:(UITableView *)tableView titleCellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    OBAArrivalEntryTableViewCell *cell = [OBAArrivalEntryTableViewCell getOrCreateCellForTableView:tableView];
 
-    UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView];
     cell.accessoryType = UITableViewCellAccessoryNone;
     cell.selectionStyle = UITableViewCellSelectionStyleNone;
 
-    cell.textLabel.text = NSLocalizedString(@"Updating...",@"message");
-    cell.textLabel.textColor = [UIColor grayColor];    
-    cell.textLabel.textAlignment = UITextAlignmentCenter;    
+    OBATripV2 *trip = self.tripDetails.trip;
     
-    return cell;
-}
-
-- (UITableViewCell*) tableView:(UITableView*)tableView titleCellForRowAtIndexPath:(NSIndexPath *)indexPath {
-
-    UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView style:UITableViewCellStyleSubtitle];
-    cell.accessoryType = UITableViewCellAccessoryNone;
-    cell.selectionStyle = UITableViewCellSelectionStyleNone;
-        
-    OBATripV2 * trip = _tripDetails.trip;
-    
-    cell.textLabel.text = trip.asLabel;
-    cell.textLabel.textColor = [UIColor blackColor];
-    cell.textLabel.textAlignment = UITextAlignmentLeft;    
-    
-    cell.detailTextLabel.text = NSLocalizedString(@"Schedule data only",@"cell.detailTextLabel.text");
-    cell.detailTextLabel.textColor = [UIColor blackColor];
-    cell.detailTextLabel.textAlignment = UITextAlignmentLeft;    
-    
-    OBATripStatusV2 * status = _tripDetails.status;
-    if( status && status.predicted ) {
-        NSInteger scheduleDeviation = status.scheduleDeviation/60;
-        NSString * label = @"";
-        if( scheduleDeviation <= -2 )
-            label = [NSString stringWithFormat:@"%d %@",(-scheduleDeviation), NSLocalizedString(@"minutes early",@"scheduleDeviation <= -2")];
-        else if (scheduleDeviation < 2 )
-            label = NSLocalizedString(@"on time",@"scheduleDeviation < 2");
-        else
-            label = [NSString stringWithFormat:@"%d %@",scheduleDeviation, NSLocalizedString(@"minutes late",@"scheduleDeviation >= 2")];
-        
-        cell.detailTextLabel.text = [NSString stringWithFormat:@"%@ # %@ - %@",NSLocalizedString(@"Vehicle",@"cell.detailTextLabel.text"),status.vehicleId,label];
+    NSString *routeName = trip.routeShortName;
+    if (!routeName) {
+        routeName = trip.route.safeShortName;
     }
     
+    cell.routeLabel.text = routeName;
+    cell.destinationLabel.text = trip.tripHeadsign ? trip.tripHeadsign : @"";
+    cell.statusLabel.text = NSLocalizedString(@"Schedule data only", @"cell.detailTextLable.text");
+
+    OBATripStatusV2 *status = self.tripDetails.status;
+
+    if (status && status.predicted) {
+        NSInteger scheduleDeviation = status.scheduleDeviation / 60;
+        NSString *label = @"";
+
+        if (scheduleDeviation <= -2) label = [NSString stringWithFormat:@"%d %@", (-scheduleDeviation), NSLocalizedString(@"minutes early", @"scheduleDeviation <= -2")];
+        else if (scheduleDeviation < 2) label = NSLocalizedString(@"on time", @"scheduleDeviation < 2");
+        else label = [NSString stringWithFormat:@"%d %@", scheduleDeviation, NSLocalizedString(@"minutes late", @"scheduleDeviation >= 2")];
+
+        cell.statusLabel.text = [NSString stringWithFormat:@"%@ # %@ - %@", NSLocalizedString(@"Vehicle", @"cell.statusLabel.text"), status.vehicleId, label];
+    }
+
+    cell.minutesLabel.text = @"";
+    cell.minutesSubLabel.text = @"";
+    
     return cell;
 }
 
+- (UITableViewCell *)tableView:(UITableView *)tableView scheduleCellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    UITableViewCell *cell = [UITableViewCell getOrCreateCellForTableView:tableView];
 
-- (UITableViewCell*) tableView:(UITableView*)tableView scheduleCellForRowAtIndexPath:(NSIndexPath *)indexPath {
-    UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView];
     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
     cell.selectionStyle = UITableViewCellSelectionStyleBlue;
     cell.textLabel.textColor = [UIColor blackColor];
     cell.textLabel.textAlignment = UITextAlignmentLeft;
-    
+    cell.textLabel.font = [UIFont systemFontOfSize:18];
+
     switch (indexPath.row) {
         case 0:
-            cell.textLabel.text = NSLocalizedString(@"Show as map",@"text");
+            cell.textLabel.text = NSLocalizedString(@"Show as map", @"text");
             break;
+
         case 1:
-            cell.textLabel.text = NSLocalizedString(@"Show as list",@"text");
+            cell.textLabel.text = NSLocalizedString(@"Show as list", @"text");
             break;
     }
-    
+
     return cell;
 }
 
+- (UITableViewCell *)tableView:(UITableView *)tableView actionCellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    UITableViewCell *cell = [UITableViewCell getOrCreateCellForTableView:tableView];
 
-- (UITableViewCell*) tableView:(UITableView*)tableView actionCellForRowAtIndexPath:(NSIndexPath *)indexPath {
-    
-    UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView];
     cell.selectionStyle = UITableViewCellSelectionStyleBlue;
     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
     cell.textLabel.textColor = [UIColor blackColor];
     cell.textLabel.textAlignment = UITextAlignmentLeft;
-    
-    
+    cell.textLabel.font = [UIFont systemFontOfSize:18];
+
+
     switch (indexPath.row) {
         case 0: {
-            cell.textLabel.text = NSLocalizedString(@"Report a problem for this trip",@"text");
-            if( _tripDetails == nil ) {
+            cell.textLabel.text = NSLocalizedString(@"Report a problem for this trip", @"text");
+
+            if (_tripDetails == nil) {
                 cell.textLabel.textColor = [UIColor grayColor];
                 cell.selectionStyle = UITableViewCellSelectionStyleNone;
             }
             else {
                 cell.textLabel.textColor = [UIColor blackColor];
-                cell.selectionStyle = UITableViewCellSelectionStyleBlue;    
+                cell.selectionStyle = UITableViewCellSelectionStyleBlue;
             }
+
             break;
         }
     }
-    
+
     return cell;
 }
 
-@end
+- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section {
+    switch ([self sectionTypeForSection:section]) {
+        case OBASectionTypeSchedule:
+            return 40;
 
+        case OBASectionTypeActions:
+            return 30;
+
+        default:
+            return 0;
+    }
+}
+
+- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section {
+    UIView *view = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 320, 40)];
+
+    view.backgroundColor = OBAGREENBACKGROUND;
+    UILabel *title = [[UILabel alloc] initWithFrame:CGRectMake(11, 5, 200, 30)];
+    title.font = [UIFont systemFontOfSize:18];
+    title.backgroundColor = [UIColor clearColor];
+
+    if ([self sectionTypeForSection:section] == OBASectionTypeSchedule) {
+        title.text = NSLocalizedString(@"Trip Schedule:", @"OBASectionTypeSchedule");
+    }
+
+    [view addSubview:title];
+    return view;
+}
+
+@end


### PR DESCRIPTION
Issue #217. 

Changed the OBATripDetails view to use plain rather than grouped table view styling, fixed up the section titles and row heights, and changed the header cell to use OBAArrivalEntryTableViewCell for the route number, destination, and status layout.
