### PR TITLE
Fix automatic region setting after turning off experimental regions

### DIFF
--- a/view_controllers/OBARegionListViewController.m
+++ b/view_controllers/OBARegionListViewController.m
@@ -524,7 +524,6 @@ typedef enum {
     if (_appDelegate.modelDao.region.experimental){
         
         //Change to automatic region if available
-        //Change to automatic region if available
         if (self.nearbyRegion && !self.nearbyRegion.experimental) {
             [_appDelegate.modelDao writeSetRegionAutomatically:YES];
             [_appDelegate.modelDao setOBARegion:self.nearbyRegion];


### PR DESCRIPTION
I was doing some last-minute testing and found a small bug with the automatic regions toggle. If from Puget Sound I chose to turn on Experimental Regions and chose Washington D.C., then turned off the experimental regions, it would appear to update my region (Puget Sound would be selected automatically from the table), but when I went back to the map/nearby stops list, the region wasn't set.

Fortunately it was a relatively simple fix. (And a stupid mistake on my part!)
