### PR TITLE
compose email in app rather than in mail app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for OneBusAway for iPhone
 
+#3 2.3
+
+* Improve contact us by email feature
+
 ## 2.2
 
 * Added support for finding and contributing information about bus stops in Stop Details page for Puget Sound (see http://stopinfo.pugetsound.onebusaway.org for more details)

--- a/org.onebusaway.iphone.xcodeproj/project.pbxproj
+++ b/org.onebusaway.iphone.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		727E52F515824F1200534646 /* MessageUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 727E52F415824F1200534646 /* MessageUI.framework */; };
 		08741E1518B0358900251C1B /* libGoogleAnalyticsServices.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 08741E1418B0358900251C1B /* libGoogleAnalyticsServices.a */; };
 		1D60589B0D05DD56006BFB54 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; };
 		1D60589F0D05DD5A006BFB54 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
@@ -383,6 +384,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		727E52F415824F1200534646 /* MessageUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MessageUI.framework; path = System/Library/Frameworks/MessageUI.framework; sourceTree = SDKROOT; };
 		08741E0E18B0358900251C1B /* GAI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GAI.h; sourceTree = "<group>"; };
 		08741E0F18B0358900251C1B /* GAIDictionaryBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GAIDictionaryBuilder.h; sourceTree = "<group>"; };
 		08741E1018B0358900251C1B /* GAIFields.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GAIFields.h; sourceTree = "<group>"; };
@@ -899,6 +901,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				727E52F515824F1200534646 /* MessageUI.framework in Frameworks */,
 				935846AB17FB9EA40034200C /* Accelerate.framework in Frameworks */,
 				96ADB3DF17BDD5DA00314D65 /* libz.dylib in Frameworks */,
 				1D60589F0D05DD5A006BFB54 /* Foundation.framework in Frameworks */,
@@ -992,6 +995,7 @@
 		29B97323FDCFA39411CA2CEA /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				727E52F415824F1200534646 /* MessageUI.framework */,
 				935846AA17FB9EA40034200C /* Accelerate.framework */,
 				96ADB3DE17BDD5DA00314D65 /* libz.dylib */,
 				D62255AA0F8BCA8F00F139BA /* libsqlite3.0.dylib */,

--- a/view_controllers/OBAContactUsViewController.h
+++ b/view_controllers/OBAContactUsViewController.h
@@ -17,8 +17,9 @@
 
 #import "OBAApplicationDelegate.h"
 #import "OBANavigationTargetAware.h"
+#import <MessageUI/MFMailComposeViewController.h>
 
-@interface OBAContactUsViewController : UITableViewController <OBANavigationTargetAware> {
+@interface OBAContactUsViewController : UITableViewController <OBANavigationTargetAware, MFMailComposeViewControllerDelegate> {
     OBAApplicationDelegate * _appDelegate;
 }
 

--- a/view_controllers/OBAContactUsViewController.m
+++ b/view_controllers/OBAContactUsViewController.m
@@ -18,11 +18,11 @@
 #import "UITableViewController+oba_Additions.h"
 #import "OBANavigationTargetAware.h"
 #import <sys/utsname.h>
+#import <MessageUI/MFMailComposeViewController.h>
 
 #define kEmailRow 0
 #define kTwitterRow 1
 #define kFacebookRow 2
-
 
 #define kRowCount 3 //including Facebook which is optional
 
@@ -40,6 +40,27 @@ static NSString *kOBADefaultTwitterURL = @"http://twitter.com/onebusaway";
     return self;
 }
 
+#pragma mark mail methods
+
+- (void)mailComposeController:(MFMailComposeViewController*)controller  
+          didFinishWithResult:(MFMailComposeResult)result 
+                        error:(NSError*)error;
+{
+    [self becomeFirstResponder];
+    [self dismissViewControllerAnimated:YES completion:nil];
+    [self.navigationController popViewControllerAnimated:YES];
+}
+
+- (void)cantSendEmail
+{
+    UIAlertView *alert = [[UIAlertView alloc] initWithTitle:NSLocalizedString(@"Setup Mail",@"view.title")
+                                                    message:NSLocalizedString(@"Please setup your Mail app before trying to send an email.",@"view.message")
+                                                   delegate:nil
+                                          cancelButtonTitle:nil
+                                          otherButtonTitles:NSLocalizedString(@"Okay", @"Ok button"), nil];
+    
+    [alert show];
+}
 
 #pragma mark UIViewController
 
@@ -97,7 +118,6 @@ static NSString *kOBADefaultTwitterURL = @"http://twitter.com/onebusaway";
     return cell;
 }
 
-
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
     OBARegionV2 *region = _appDelegate.modelDao.region;
     switch( indexPath.row) {
@@ -109,21 +129,39 @@ static NSString *kOBADefaultTwitterURL = @"http://twitter.com/onebusaway";
                                                               action:@"button_press"
                                                                label:@"Clicked Email Link"
                                                                value:nil] build]];
-                NSString *contactEmail = kOBADefaultContactEmail;
-                if (region) {
-                    contactEmail = region.contactEmail;
-                }
 
-                //device model, thanks to http://stackoverflow.com/a/11197770/1233435
-                struct utsname systemInfo;
-                uname(&systemInfo);
-                
-                NSString *appVersionString = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
-                CLLocation * location = _appDelegate.locationManager.currentLocation;
-                NSString *args = [[NSString stringWithFormat:@"?subject=OneBusAway iOS Feedback&body=\n\n---------------\nApp Version: %@\nDevice: <a href='http://stackoverflow.com/a/11197770/1233435'>%@</a>\nOS Version: %@\nCurrent Location: %f, %f", appVersionString, [NSString stringWithCString:systemInfo.machine encoding:NSUTF8StringEncoding], [[UIDevice currentDevice] systemVersion], location.coordinate.latitude, location.coordinate.longitude] stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-   
-                contactEmail = [NSString stringWithFormat:@"mailto:%@%@",contactEmail, args];
-                [[UIApplication sharedApplication] openURL: [NSURL URLWithString: contactEmail]];
+                //check if user can send email
+                if ([MFMailComposeViewController canSendMail]){
+                    // Create and show composer
+                    NSString *contactEmail = kOBADefaultContactEmail;
+                    if (region) {
+                        contactEmail = region.contactEmail;
+                    }
+
+                    //device model, thanks to http://stackoverflow.com/a/11197770/1233435
+                    struct utsname systemInfo;
+                    uname(&systemInfo);
+                    
+                    NSString *appVersionString = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+                    CLLocation * location = _appDelegate.locationManager.currentLocation;                
+
+                    MFMailComposeViewController* controller = [[MFMailComposeViewController alloc] init];
+                    if (controller != nil){
+                        controller.mailComposeDelegate=self;
+                				[controller setToRecipients:[NSArray arrayWithObject:contactEmail]];
+                				[controller setSubject:NSLocalizedString(@"OneBusAway iOS Feedback", @"feedback mail subject")];
+                				[controller setMessageBody:[NSString stringWithFormat:@"<br><br>---------------<br>App Version: %@<br>Device: \
+                            <a href='http://stackoverflow.com/a/11197770/1233435'>%@</a><br>iOS Version: %@<br>Current Location: %f, %f", 
+                            appVersionString, [NSString stringWithCString:systemInfo.machine encoding:NSUTF8StringEncoding], 
+                            [[UIDevice currentDevice] systemVersion], location.coordinate.latitude, location.coordinate.longitude] isHTML:YES]; 
+                				
+                        [self presentModalViewController:controller animated:YES];
+                    }else{
+                        [self cantSendEmail];
+                    }
+                }else{
+                    [self cantSendEmail];
+                }
             }
             break;
         case kTwitterRow:
@@ -210,4 +248,3 @@ static NSString *kOBADefaultTwitterURL = @"http://twitter.com/onebusaway";
 }
 
 @end
-


### PR DESCRIPTION
When a user decides to send an email to OBA support, popup and allow them to send the email rather than jumping to the mail app. Once completed the user will be returned to the OBA app.

Currently this PR will popup and allow the user to send the email but the compose window does not go away after selecting send or cancel. @aaronbrethorst, @Wizecoder any ideas?

Update: PR now properly pops up, allows user to write email, sends email, and returns user to info view.
