### PR TITLE
Stop Info web view back button, thank you page URL check

### DIFF
--- a/view_controllers/StopDetails/OBAStopWebViewController.m
+++ b/view_controllers/StopDetails/OBAStopWebViewController.m
@@ -12,6 +12,7 @@
 
 @property (nonatomic, strong) UIWebView *webView;
 @property (nonatomic, strong) NSURL *url;
+@property (nonatomic, assign) BOOL onLastView;
 
 @end
 
@@ -48,11 +49,18 @@
 }
 
 - (void)handleBack {
-    if ([self.webView canGoBack]) {
+    if ([self.webView canGoBack] && !self.onLastView) {
         [self.webView goBack];
     } else {
         [self.navigationController popViewControllerAnimated:YES];
     }
+}
+
+- (BOOL)webView:(UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)navigationType {
+    if ([request.URL.absoluteString rangeOfString:@"http://stopinfo.pugetsound.onebusaway.org/about/entry/"].location != NSNotFound) {
+        self.onLastView = YES;
+    }
+    return YES;
 }
 
 - (UIWebView*)webView {


### PR DESCRIPTION
Issue #280

With this update if the thank you page has been reached within the Stop Info site the back button will then take the user all the way back to the stop details view.
