### PR TITLE
on problem report submission return to screen initiating report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for OneBusAway for iPhone
 
+## 2.3
+
+* Improve problem submission process
+
 ## 2.2
 
 * Added support for finding and contributing information about bus stops in Stop Details page for Puget Sound (see http://stopinfo.pugetsound.onebusaway.org for more details)

--- a/view_controllers/StopDetails/OBAReportProblemWithStopViewController.m
+++ b/view_controllers/StopDetails/OBAReportProblemWithStopViewController.m
@@ -250,6 +250,10 @@ typedef enum {
     view.cancelButtonIndex = 0;
     [view show];
     [_activityIndicatorView hide];
+    
+    //go back to stop view
+    NSArray *allViewControllers = self.navigationController.viewControllers;
+    [self.navigationController popToViewController: [allViewControllers objectAtIndex: ([allViewControllers count]-3)] animated: YES];
 }
 
 - (void)requestDidFinish:(id<OBAModelServiceRequest>)request withCode:(NSInteger)code context:(id)context {

--- a/view_controllers/TripDetails/OBAReportProblemWithTripViewController.m
+++ b/view_controllers/TripDetails/OBAReportProblemWithTripViewController.m
@@ -3,6 +3,8 @@
 #import "OBALabelAndTextFieldTableViewCell.h"
 #import "OBALogger.h"
 #import "UITableViewController+oba_Additions.h"
+#import "OBAStopViewController.h"
+#import "OBAArrivalAndDepartureViewController.h"
 
 typedef enum {
     OBASectionTypeNone,    
@@ -269,11 +271,30 @@ typedef enum {
 - (void)requestDidFinish:(id<OBAModelServiceRequest>)request withObject:(id)obj context:(id)context {
     UIAlertView * view = [[UIAlertView alloc] init];
     view.title = NSLocalizedString(@"Submission Successful",@"view.title");
+    [[GAI sharedInstance].defaultTracker
+     send:[[GAIDictionaryBuilder createEventWithCategory:@"submit"
+                                                  action:@"report_problem"
+                                                   label:@"Reported Problem"
+                                                   value:nil] build]];
     view.message = NSLocalizedString(@"The problem was sucessfully reported. Thank you!",@"view.message");
     [view addButtonWithTitle:NSLocalizedString(@"Dismiss",@"view addButtonWithTitle")];
     view.cancelButtonIndex = 0;
     [view show];
     [_activityIndicatorView hide];
+
+    //go back to view that initiated report
+    NSArray *allViewControllers = self.navigationController.viewControllers;
+    for(int i=[allViewControllers count]-1; i>=0; i--){
+        id obj=[allViewControllers objectAtIndex:i];
+        
+        if([obj isKindOfClass:[OBAArrivalAndDepartureViewController class]]){
+            [self.navigationController popToViewController:obj animated: YES];
+            return;
+        }else if([obj isKindOfClass:[OBAStopViewController class]]){
+            [self.navigationController popToViewController:obj animated: YES];
+            return;
+        }
+    }
 }
 
 - (void)requestDidFinish:(id<OBAModelServiceRequest>)request withCode:(NSInteger)code context:(id)context {


### PR DESCRIPTION
After the user submits a problem report return them to the screen/view initiating the report (either `OBAArrivalAndDepartureViewController` or `OBAStopViewController`). Fixes #257.
