### PR TITLE
Dev/fix/warnings

### DIFF
--- a/OBAApplicationDelegate.m
+++ b/OBAApplicationDelegate.m
@@ -42,7 +42,6 @@ static NSString * kOBAShowExperimentalRegionsDefaultsKey = @"kOBAShowExperimenta
 static NSString * kOBADefaultRegionApiServerName = @"regions.onebusaway.org";
 static NSString *const kTrackingId = @"UA-2423527-17";
 static NSString *const kAllowTracking = @"allowTracking";
-static BOOL const kGaDryRun = NO;
 
 @interface OBAApplicationDelegate ()
 @property(nonatomic,readwrite) BOOL active;

--- a/models/dao/OBAModelDAO.m
+++ b/models/dao/OBAModelDAO.m
@@ -135,6 +135,10 @@ const static int kMaxEntriesInMostRecentList = 10;
 
 - (void) addCustomApiUrl:(NSString *)customApiUrl {
     
+    if(!customApiUrl) {
+        return;
+    }
+    
     NSString *existingCustomApiUrl = nil;
     
     for( NSString * recentCustomApiUrl in _mostRecentCustomApiUrls ) {

--- a/models/unmanaged/OBASearch.m
+++ b/models/unmanaged/OBASearch.m
@@ -23,10 +23,6 @@
 #import "OBASphericalGeometryLibrary.h"
 #import "OBAJsonDataSource.h"
 
-
-static const float kSearchRadius = 400;
-
-
 NSString * kOBASearchTypeParameter = @"OBASearchTypeParameter";
 NSString * kOBASearchControllerSearchArgumentParameter = @"OBASearchControllerSearchArgumentParameter";
 NSString * kOBASearchControllerSearchLocationParameter = @"OBASearchControllerSearchLocationParameter";

--- a/view_controllers/OBACustomApiViewController.m
+++ b/view_controllers/OBACustomApiViewController.m
@@ -213,9 +213,7 @@ static NSString *editingCellTag = @"editingCell";
 
 - (void) saveCustomApiUrl {
     if (![self.customApiUrlTextField.text isEqualToString:self.appDelegate.modelDao.readCustomApiUrl]) {
-
-
-        if (![self.customApiUrlTextField.text isEqualToString:@""]) {
+        if ([self.customApiUrlTextField.text length] > 0) {
             [self.appDelegate.modelDao addCustomApiUrl:self.customApiUrlTextField.text];
             [self.appDelegate.modelDao writeCustomApiUrl:self.customApiUrlTextField.text];
             [self.appDelegate.modelDao writeSetRegionAutomatically:NO];

--- a/view_controllers/OBASearchResultsMapViewController.m
+++ b/view_controllers/OBASearchResultsMapViewController.m
@@ -46,16 +46,12 @@ static const double kDefaultMapRadius = 100;
 static const double kMinMapRadius = 150;
 static const double kMaxLatDeltaToShowStops = 0.008;
 static const double kRegionScaleFactor = 1.5;
-static const double kMinRegionDeltaToDetectUserDrag = 50;
-
-static const double kRegionChangeRequestsTimeToLive = 3.0;
 
 static const double kMaxMapDistanceFromCurrentLocationForNearby = 800;
 static const double kPaddingScaleFactor = 1.075;
 static const NSUInteger kShowNClosestStops = 4;
 
 static const double kStopsInRegionRefreshDelayOnDrag = 0.1;
-static const double kStopsInRegionRefreshDelayOnLocate = 0.1;
 
 static NSString *kOBAIncreaseContrastKey = @"OBAIncreaseContrastDefaultsKey";
 

--- a/view_controllers/StopDetails/OBAGenericStopViewController.m
+++ b/view_controllers/StopDetails/OBAGenericStopViewController.m
@@ -39,13 +39,12 @@
 #import "OBABookmarkGroup.h"
 #import "OBAStopWebViewController.h"
 
-static const double kNearbyStopRadius = 200;
 static NSString *kOBANoStopInformationURL = @"http://stopinfo.pugetsound.onebusaway.org/testing";
 static NSString *kOBADidShowStopInfoHintDefaultsKey = @"OBADidShowStopInfoHintDefaultsKey";
 static NSString *kOBAIncreaseContrastKey = @"OBAIncreaseContrastDefaultsKey";
 
 @interface OBAGenericStopViewController ()
-@property(strong,readwrite) OBAApplicationDelegate * _appDelegate;
+@property(strong,readwrite) OBAApplicationDelegate * appDelegate;
 @property(strong,readwrite) NSString * stopId;
 
 @property(strong) id<OBAModelServiceRequest> request;


### PR DESCRIPTION
Addressed all warnings detected by Xcode static analysis.

Build settings should be updated to treat warnings as errors, additional warnings (i.e. implicit retain by blocks) should be enabled as well.
