### PR TITLE
Dropped ios 5 and fixed warnings

### DIFF
--- a/EMHint.m
+++ b/EMHint.m
@@ -116,7 +116,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
         [label setText:message];
         [label setTextColor:[UIColor whiteColor]];
         [label setNumberOfLines:0];
-        [label setLineBreakMode:UILineBreakModeWordWrap];
+        [label setLineBreakMode:NSLineBreakByWordWrapping];
         [_modalView addSubview:label];
         [label release];
     }

--- a/EMHintsView.m
+++ b/EMHintsView.m
@@ -106,7 +106,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
     CGFloat colorLocations[2] = {0.25,0.5};
     
     // draw spotlights
-    int spotlightCount = _positionArray.count;
+    NSInteger spotlightCount = _positionArray.count;
     for (int i=0; i<spotlightCount; ++i)
     {
         // center and radius of spotlight

--- a/Libraries/TWSReleaseNotesView-343fb195887e0a86378b5af0ab0c1f02c5fe1365/UIImage+ImageEffects.m
+++ b/Libraries/TWSReleaseNotesView-343fb195887e0a86378b5af0ab0c1f02c5fe1365/UIImage+ImageEffects.m
@@ -132,7 +132,7 @@
 {
     const CGFloat EffectColorAlpha = 0.6;
     UIColor *effectColor = tintColor;
-    int componentCount = CGColorGetNumberOfComponents(tintColor.CGColor);
+    NSInteger componentCount = CGColorGetNumberOfComponents(tintColor.CGColor);
     if (componentCount == 2) {
         CGFloat b;
         if ([tintColor getWhite:&b alpha:NULL]) {

--- a/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/Control/Common/OBALocationManager.m
+++ b/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/Control/Common/OBALocationManager.m
@@ -41,7 +41,6 @@ static const NSTimeInterval kSuccessiveLocationComparisonWindow = 3;
         _disabled = NO;
         _locationManager = [[CLLocationManager alloc] init];
         _locationManager.delegate = self;
-        _locationManager.purpose = @"Your location will be used to show nearby stops and routes.";
         _delegates = [[NSMutableArray alloc] init];
         
     }

--- a/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/Control/Common/OBALogger.m
+++ b/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/Control/Common/OBALogger.m
@@ -25,7 +25,7 @@
 @implementation OBALogger
 
 + (void) logWithLevel:(OBALoggerLevel)level pointer:(id)pointer file:(NSString*)file line:(NSInteger)line message:(NSString*)message {
-    NSLog(@"# %@ - %p %@:%d",[self logLevelAsString:level],pointer,file,line);
+    NSLog(@"# %@ - %p %@:%ld",[self logLevelAsString:level],pointer,file,(long)line);
     NSLog(@"%@",message);
 }
 

--- a/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/Control/Common/OBAModelService.m
+++ b/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/Control/Common/OBAModelService.m
@@ -55,7 +55,7 @@ static const float kBigSearchRadius = 15000;
     stopId = [self escapeStringForUrl:stopId];
 
     NSString *url = [NSString stringWithFormat:@"/api/where/arrivals-and-departures-for-stop/%@.json", stopId];
-    NSString * args = [NSString stringWithFormat:@"version=2&minutesBefore=%d&minutesAfter=%d",minutesBefore,minutesAfter];
+    NSString * args = [NSString stringWithFormat:@"version=2&minutesBefore=%lu&minutesAfter=%lu",(unsigned long)minutesBefore,(unsigned long)minutesAfter];
     SEL selector = @selector(getArrivalsAndDeparturesForStopV2FromJSON:error:);
     
     return [self request:url args:args selector:selector delegate:delegate context:context];
@@ -179,7 +179,7 @@ static const float kBigSearchRadius = 15000;
         radius = kSearchRadius;
     
     NSString * url = @"/maps/api/place/search/json";
-    NSString * args = [NSString stringWithFormat:@"location=%f,%f&radius=%d&name=%@&sensor=true", coord.latitude, coord.longitude, radius, name];
+    NSString * args = [NSString stringWithFormat:@"location=%f,%f&radius=%ld&name=%@&sensor=true", coord.latitude, coord.longitude, (long)radius, name];
     SEL selector = @selector(getPlacemarksFromGooglePlacesJSONObject:error:);
     
     return [self request:_googlePlacesJsonDataSource url:url args:args selector:selector delegate:delegate context:context];
@@ -209,7 +209,7 @@ static const float kBigSearchRadius = 15000;
     if( tripInstance.vehicleId )
         [args appendFormat:@"&vehicleId=%@",[self escapeStringForUrl:tripInstance.vehicleId]];
     if( instance.stopSequence >= 0 )
-        [args appendFormat:@"&stopSequence=%d",instance.stopSequence];
+        [args appendFormat:@"&stopSequence=%ld",(long)instance.stopSequence];
     SEL selector = @selector(getArrivalAndDepartureForStopV2FromJSON:error:);
     
     return [self request:url args:args selector:selector delegate:delegate context:context];

--- a/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/Control/Digester/OBAJsonDigester.m
+++ b/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/Control/Digester/OBAJsonDigester.m
@@ -234,7 +234,7 @@
 -(id) peek:(NSUInteger)index {
     NSInteger objIndex = [_stack count] - 1 - index;
     if (objIndex < 0 || objIndex > [_stack count]) {
-        NSLog(@"OBAJsonDigesterContextImpl: peek - index out of bounds: %d => %d", index, objIndex);
+        NSLog(@"OBAJsonDigesterContextImpl: peek - index out of bounds: %lu => %ld", (unsigned long)index, (long)objIndex);
         return nil;
     }
     return _stack[objIndex];

--- a/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/Model/V2/OBAArrivalAndDepartureInstanceRef.m
+++ b/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/Model/V2/OBAArrivalAndDepartureInstanceRef.m
@@ -46,7 +46,7 @@
 }
 
 - (NSString*) description {
-    return [NSString stringWithFormat:@"(tripInstance=%@, stopId=%@, stopSequence=%d)",[_tripInstance description],_stopId,_stopSequence];
+    return [NSString stringWithFormat:@"(tripInstance=%@, stopId=%@, stopSequence=%ld)",[_tripInstance description],_stopId,(long)_stopSequence];
 }
 
 @end

--- a/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/Model/V2/OBAReferencesV2.m
+++ b/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/Model/V2/OBAReferencesV2.m
@@ -70,13 +70,13 @@
 }
 
 - (NSString*) description {
-    return [NSString stringWithFormat:@"%@ agencies:%d routes:%d stops:%d trips:%d situations:%d",
+    return [NSString stringWithFormat:@"%@ agencies:%lu routes:%lu stops:%lu trips:%lu situations:%lu",
             [super description],
-            [_agencies count],
-            [_routes count],
-            [_stops count],
-            [_trips count],
-            [_situations count]];
+            (unsigned long)[_agencies count],
+            (unsigned long)[_routes count],
+            (unsigned long)[_stops count],
+            (unsigned long)[_trips count],
+            (unsigned long)[_situations count]];
 }
 
 @end

--- a/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/View/OBALabelAndSwitchTableViewCell.m
+++ b/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/View/OBALabelAndSwitchTableViewCell.m
@@ -22,7 +22,7 @@
     if (cell == nil) {
         NSArray * nib = [[NSBundle mainBundle] loadNibNamed:cellId owner:self options:nil];
         cell = nib[0];
-        cell.label.textAlignment = UITextAlignmentLeft;
+        cell.label.textAlignment = NSTextAlignmentLeft;
         cell.accessoryType = UITableViewCellAccessoryNone;                    
         cell.selectionStyle = UITableViewCellSelectionStyleNone;
     }

--- a/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/View/OBAListSelectionViewController.m
+++ b/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/View/OBAListSelectionViewController.m
@@ -50,7 +50,7 @@
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     
     UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView];
-    cell.textLabel.textAlignment = UITextAlignmentLeft;
+    cell.textLabel.textAlignment = NSTextAlignmentLeft;
     cell.textLabel.font = [UIFont systemFontOfSize:18];
     cell.selectionStyle = UITableViewCellSelectionStyleBlue;
     cell.accessoryType = [self checkedItem].row == indexPath.row ? UITableViewCellAccessoryCheckmark : UITableViewCellAccessoryNone;

--- a/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/View/OBAPresentation.m
+++ b/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/View/OBAPresentation.m
@@ -71,8 +71,8 @@ static const float kStopForRouteAnnotationMinScaleDistance = 8000;
     static NSString *cellId = @"UnreadServiceAlertsCell";
     
     UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView cellId:cellId];
-    cell.textLabel.text = [NSString stringWithFormat:@"Service alerts: %d unread",serviceAlerts.unreadCount];
-    cell.textLabel.textAlignment = UITextAlignmentCenter;
+    cell.textLabel.text = [NSString stringWithFormat:@"Service alerts: %lu unread",(unsigned long)serviceAlerts.unreadCount];
+    cell.textLabel.textAlignment = NSTextAlignmentCenter;
     cell.selectionStyle = UITableViewCellSelectionStyleBlue;
     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
     
@@ -90,7 +90,7 @@ static const float kStopForRouteAnnotationMinScaleDistance = 8000;
     
     static NSString *cellId = @"ServiceAlertsCell";
     UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView cellId:cellId];
-    cell.textLabel.textAlignment = UITextAlignmentLeft;
+    cell.textLabel.textAlignment = NSTextAlignmentLeft;
     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
     cell.textLabel.font = [UIFont systemFontOfSize:18];
     
@@ -98,7 +98,7 @@ static const float kStopForRouteAnnotationMinScaleDistance = 8000;
         cell.textLabel.text = @"Service Alerts";
     }
     else {
-        cell.textLabel.text = [NSString stringWithFormat:@"Service Alerts: %d total", serviceAlerts.totalCount];                            
+        cell.textLabel.text = [NSString stringWithFormat:@"Service Alerts: %lu total", (unsigned long)serviceAlerts.totalCount];                            
     }
     
     if (serviceAlerts.totalCount == 0) {

--- a/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/View/OBAProgressIndicatorView.m
+++ b/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/View/OBAProgressIndicatorView.m
@@ -99,8 +99,8 @@
     [self setupLabel:_label];
     [self setupLabel:_progressLabel];
     _activityIndicator.frame = acitivityIndicatorFrame;
-    _label.textAlignment = UITextAlignmentCenter;
-    _progressLabel.textAlignment = UITextAlignmentCenter;    
+    _label.textAlignment = NSTextAlignmentCenter;
+    _progressLabel.textAlignment = NSTextAlignmentCenter;    
     
     [self addSubview:_label];
     [self addSubview:_progressLabel];

--- a/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/View/OBARequestDrivenTableViewController.m
+++ b/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/View/OBARequestDrivenTableViewController.m
@@ -165,7 +165,7 @@
     cell.textLabel.text = @"Updating...";
     cell.textLabel.font = [UIFont systemFontOfSize:18];
     cell.textLabel.textColor = [UIColor grayColor];
-    cell.textLabel.textAlignment = UITextAlignmentCenter;    
+    cell.textLabel.textAlignment = NSTextAlignmentCenter;    
     
     return cell;
 }

--- a/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/View/OBAUIKit.m
+++ b/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/View/OBAUIKit.m
@@ -119,7 +119,7 @@
 }
 
 +(UITableViewCell*) getOrCreateCellForTableView:(UITableView*)tableView style:(UITableViewCellStyle)style {    
-    NSString * cellId = [NSString stringWithFormat:@"DefaultIdentifier-%d",style];
+    NSString * cellId = [NSString stringWithFormat:@"DefaultIdentifier-%ld",style];
     return [self getOrCreateCellForTableView:tableView style:style cellId:cellId];
 }
 

--- a/MarqueeLabel.h
+++ b/MarqueeLabel.h
@@ -60,13 +60,13 @@ typedef enum {
 /* marqueeType:
  * When set to LeftRight, the label moves from left to right and back from right to left alternatively.
  *
- *      NOTE: LeftRight type is ONLY compatible with a label text alignment of UITextAlignmentLeft. Specifying
- *      LeftRight will change any previously set, non-compatible text alignment to UITextAlignmentLeft.
+ *      NOTE: LeftRight type is ONLY compatible with a label text alignment of NSTextAlignmentLeft. Specifying
+ *      LeftRight will change any previously set, non-compatible text alignment to NSTextAlignmentLeft.
  *
  * When set to RightLeft, the label moves from right to left and back from left to right alternatively.
  *
- *      NOTE: RightLeft type is ONLY compatibile with a label text alignment of UITextAlignmentRight. Specifying
- *      RightLeft will change any previously set, non-compatible text alignment to UITextAlignmentRight.
+ *      NOTE: RightLeft type is ONLY compatibile with a label text alignment of NSTextAlignmentRight. Specifying
+ *      RightLeft will change any previously set, non-compatible text alignment to NSTextAlignmentRight.
  *
  * When set to Continuous, the label slides continuously to the left.
  *

--- a/MarqueeLabel.m
+++ b/MarqueeLabel.m
@@ -826,15 +826,6 @@ typedef void (^animationCompletionBlock)(void);
     self.subLabel.baselineAdjustment = baselineAdjustment;
 }
 
-#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 60000
-- (NSAttributedString *)attributedText {
-    return self.subLabel.attributedText;
-}
-
-- (void)setAttributedText:(NSAttributedString *)attributedText {
-    self.subLabel.attributedText = attributedText;
-}
-
 - (void)setAdjustsLetterSpacingToFitWidth:(BOOL)adjustsLetterSpacingToFitWidth {
     // By the nature of MarqueeLabel, this is NO
     [super setAdjustsLetterSpacingToFitWidth:NO];
@@ -843,7 +834,6 @@ typedef void (^animationCompletionBlock)(void);
 - (void)setMinimumScaleFactor:(CGFloat)minimumScaleFactor {
     [super setMinimumScaleFactor:0.0f];
 }
-#endif
 
 #pragma mark - Custom Getters and Setters
 

--- a/OBAApplicationDelegate.m
+++ b/OBAApplicationDelegate.m
@@ -42,7 +42,6 @@ static NSString * kOBAShowExperimentalRegionsDefaultsKey = @"kOBAShowExperimenta
 static NSString * kOBADefaultRegionApiServerName = @"regions.onebusaway.org";
 static NSString *const kTrackingId = @"UA-2423527-17";
 static NSString *const kAllowTracking = @"allowTracking";
-static BOOL const kGaDryRun = NO;
 
 @interface OBAApplicationDelegate ()
 @property(nonatomic,readwrite) BOOL active;

--- a/controls/table_cells/OBAArrivalEntryTableViewCellFactory.m
+++ b/controls/table_cells/OBAArrivalEntryTableViewCellFactory.m
@@ -45,7 +45,7 @@
 
     if( arrival.predicted && arrival.predictedDepartureTime == 0 ) {
         if( arrival.distanceFromStop < 500 ) {
-            cell.minutesLabel.text = [NSString stringWithFormat:@"%d",(NSInteger) arrival.distanceFromStop];    
+            cell.minutesLabel.text = [NSString stringWithFormat:@"%ld",(long) arrival.distanceFromStop];
             cell.minutesSubLabel.text = NSLocalizedString(@"meters",@"cell.minutesSubLabel.text");
         }
         else {

--- a/controls/table_cells/OBALabelAndTextFieldTableViewCell.m
+++ b/controls/table_cells/OBALabelAndTextFieldTableViewCell.m
@@ -19,7 +19,7 @@
     if (cell == nil) {
         NSArray * nib = [[NSBundle mainBundle] loadNibNamed:cellId owner:self options:nil];
         cell = nib[0];
-        cell.textField.textAlignment = UITextAlignmentRight;
+        cell.textField.textAlignment = NSTextAlignmentRight;
         cell.textField.returnKeyType = UIReturnKeyDone;
         cell.accessoryType = UITableViewCellAccessoryNone;        
         cell.selectionStyle = UITableViewCellSelectionStyleNone;

--- a/models/annotations/OBATripStopTimeMapAnnotation.m
+++ b/models/annotations/OBATripStopTimeMapAnnotation.m
@@ -33,8 +33,8 @@
     
     if( schedule.frequency ) {
         OBATripStopTimeV2 * firstStopTime = (schedule.stopTimes)[0];
-        int minutes = (_stopTime.arrivalTime - firstStopTime.departureTime) / 60;
-        return [NSString stringWithFormat:@"%d %@",minutes,NSLocalizedString(@"mins",@"minutes")];                                      
+        NSInteger minutes = (_stopTime.arrivalTime - firstStopTime.departureTime) / 60;
+        return [NSString stringWithFormat:@"%ld %@",(long)minutes,NSLocalizedString(@"mins",@"minutes")];                                      
     }
     
     NSInteger stopTime = _stopTime.arrivalTime;

--- a/models/dao/OBAEntityManager.m
+++ b/models/dao/OBAEntityManager.m
@@ -70,7 +70,7 @@
     }
     
     if( [fetchedObjects count] > 1 ) {
-        OBALogSevere(@"Duplicate entities: entityName=%@ entityIdProperty=%@ entityId=%@ count=%d",entityName,entityIdProperty,entityId,[fetchedObjects count]);
+        OBALogSevere(@"Duplicate entities: entityName=%@ entityIdProperty=%@ entityId=%@ count=%lu",entityName,entityIdProperty,entityId,(unsigned long)[fetchedObjects count]);
       
         if (error != NULL)
             (*error) = [NSError errorWithDomain:OBAErrorDomain code:kOBAErrorDuplicateEntity userInfo:nil];

--- a/models/dao/OBAModelDAO.m
+++ b/models/dao/OBAModelDAO.m
@@ -126,7 +126,7 @@ const static int kMaxEntriesInMostRecentList = 10;
     existingEvent.title = event.title;
     existingEvent.subtitle = event.subtitle;
     
-    int over = [_mostRecentStops count] - kMaxEntriesInMostRecentList;
+    NSInteger over = [_mostRecentStops count] - kMaxEntriesInMostRecentList;
     for( int i=0; i<over; i++)
         [_mostRecentStops removeObjectAtIndex:([_mostRecentStops count]-1)];
     
@@ -154,7 +154,7 @@ const static int kMaxEntriesInMostRecentList = 10;
         
     }
     
-    int over = [_mostRecentCustomApiUrls count] - kMaxEntriesInMostRecentList;
+    NSUInteger over = [_mostRecentCustomApiUrls count] - kMaxEntriesInMostRecentList;
     for( int i=0; i<over; i++)
         [_mostRecentCustomApiUrls removeObjectAtIndex:([_mostRecentCustomApiUrls count]-1)];
     

--- a/models/migrations/OBAUserPreferencesMigration.m
+++ b/models/migrations/OBAUserPreferencesMigration.m
@@ -98,7 +98,7 @@
         [recentStops addObject:event];
     [recentStops sortUsingSelector:@selector(compare:)];
     
-    for( int i = [recentStops count]-1; i >= 0; i-- ) {
+    for( NSInteger i = [recentStops count]-1; i >= 0; i-- ) {
         OBAStopAccessEvent * event = recentStops[i];
         OBAStop * stop = event.stop;
         OBAStopAccessEventV2 * v2 = [[OBAStopAccessEventV2 alloc] init];
@@ -139,7 +139,7 @@
         return nil;
 
     if( [fetchedObjects count] > 1 ) {
-        OBALogSevere(@"Duplicate entities: entityName=OBAModel count=%d",[fetchedObjects count]);
+        OBALogSevere(@"Duplicate entities: entityName=OBAModel count=%lu",(unsigned long)[fetchedObjects count]);
         return nil;
     }
 

--- a/models/unmanaged/OBASearch.m
+++ b/models/unmanaged/OBASearch.m
@@ -24,9 +24,6 @@
 #import "OBAJsonDataSource.h"
 
 
-static const float kSearchRadius = 400;
-
-
 NSString * kOBASearchTypeParameter = @"OBASearchTypeParameter";
 NSString * kOBASearchControllerSearchArgumentParameter = @"OBASearchControllerSearchArgumentParameter";
 NSString * kOBASearchControllerSearchLocationParameter = @"OBASearchControllerSearchLocationParameter";

--- a/org.onebusaway.iphone.xcodeproj/project.pbxproj
+++ b/org.onebusaway.iphone.xcodeproj/project.pbxproj
@@ -412,11 +412,11 @@
 		923FE67E176082A7009AFDE8 /* UITableViewController+oba_Additions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UITableViewController+oba_Additions.h"; sourceTree = "<group>"; };
 		923FE67F176082A7009AFDE8 /* UITableViewController+oba_Additions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UITableViewController+oba_Additions.m"; sourceTree = "<group>"; };
 		925A1AD317B6ACA200029F0B /* OBARegionListViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBARegionListViewController.h; sourceTree = "<group>"; };
-		925A1AD417B6ACA200029F0B /* OBARegionListViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBARegionListViewController.m; sourceTree = "<group>"; };
+		925A1AD417B6ACA200029F0B /* OBARegionListViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = OBARegionListViewController.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		925A1AD617B7969500029F0B /* OBASettingsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBASettingsViewController.h; sourceTree = "<group>"; };
-		925A1AD717B7969500029F0B /* OBASettingsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBASettingsViewController.m; sourceTree = "<group>"; };
+		925A1AD717B7969500029F0B /* OBASettingsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = OBASettingsViewController.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		928E12B117D7863400FD855E /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = OneBusAway/Images.xcassets; sourceTree = "<group>"; };
-		92CAAE97179C4B070097DD3D /* MarqueeLabel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MarqueeLabel.h; sourceTree = "<group>"; };
+		92CAAE97179C4B070097DD3D /* MarqueeLabel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = MarqueeLabel.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		92CAAE98179C4B070097DD3D /* MarqueeLabel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MarqueeLabel.m; sourceTree = "<group>"; };
 		9302721416137A47004DBFDE /* info.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = info.png; path = ../../../../Resources/info.png; sourceTree = "<group>"; };
 		9302721516137A47004DBFDE /* info@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "info@2x.png"; path = "../../../../Resources/info@2x.png"; sourceTree = "<group>"; };
@@ -542,9 +542,9 @@
 		933C7EA0160C07440005AAFE /* OBAVehicleStatusV2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAVehicleStatusV2.h; sourceTree = "<group>"; };
 		933C7EA1160C07440005AAFE /* OBAVehicleStatusV2.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAVehicleStatusV2.m; sourceTree = "<group>"; };
 		933C7EA3160C07440005AAFE /* OBALabelAndSwitchTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBALabelAndSwitchTableViewCell.h; sourceTree = "<group>"; };
-		933C7EA4160C07440005AAFE /* OBALabelAndSwitchTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBALabelAndSwitchTableViewCell.m; sourceTree = "<group>"; };
+		933C7EA4160C07440005AAFE /* OBALabelAndSwitchTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = OBALabelAndSwitchTableViewCell.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		933C7EA5160C07440005AAFE /* OBAListSelectionViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAListSelectionViewController.h; sourceTree = "<group>"; };
-		933C7EA6160C07440005AAFE /* OBAListSelectionViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAListSelectionViewController.m; sourceTree = "<group>"; };
+		933C7EA6160C07440005AAFE /* OBAListSelectionViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = OBAListSelectionViewController.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		933C7EA7160C07440005AAFE /* OBAMapRegionManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAMapRegionManager.h; sourceTree = "<group>"; };
 		933C7EA8160C07440005AAFE /* OBAMapRegionManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAMapRegionManager.m; sourceTree = "<group>"; };
 		933C7EA9160C07440005AAFE /* OBAModalActivityIndicator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAModalActivityIndicator.h; sourceTree = "<group>"; };
@@ -552,11 +552,11 @@
 		933C7EAB160C07440005AAFE /* OBAPickerTextField.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAPickerTextField.h; sourceTree = "<group>"; };
 		933C7EAC160C07440005AAFE /* OBAPickerTextField.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAPickerTextField.m; sourceTree = "<group>"; };
 		933C7EAD160C07440005AAFE /* OBAPresentation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAPresentation.h; sourceTree = "<group>"; };
-		933C7EAE160C07440005AAFE /* OBAPresentation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAPresentation.m; sourceTree = "<group>"; };
+		933C7EAE160C07440005AAFE /* OBAPresentation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = OBAPresentation.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		933C7EAF160C07440005AAFE /* OBAProgressIndicatorView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAProgressIndicatorView.h; sourceTree = "<group>"; };
-		933C7EB0160C07440005AAFE /* OBAProgressIndicatorView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAProgressIndicatorView.m; sourceTree = "<group>"; };
+		933C7EB0160C07440005AAFE /* OBAProgressIndicatorView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = OBAProgressIndicatorView.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		933C7EB1160C07440005AAFE /* OBARequestDrivenTableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBARequestDrivenTableViewController.h; sourceTree = "<group>"; };
-		933C7EB2160C07440005AAFE /* OBARequestDrivenTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBARequestDrivenTableViewController.m; sourceTree = "<group>"; };
+		933C7EB2160C07440005AAFE /* OBARequestDrivenTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = OBARequestDrivenTableViewController.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		933C7EB3160C07440005AAFE /* OBAStopIconFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAStopIconFactory.h; sourceTree = "<group>"; };
 		933C7EB4160C07440005AAFE /* OBAStopIconFactory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAStopIconFactory.m; sourceTree = "<group>"; };
 		933C7EB5160C07440005AAFE /* OBATextEditViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBATextEditViewController.h; sourceTree = "<group>"; };
@@ -756,9 +756,9 @@
 		93631E661604F99500CB7209 /* OBAReportProblemWithTripViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAReportProblemWithTripViewController.h; sourceTree = "<group>"; };
 		93631E671604F99500CB7209 /* OBAReportProblemWithTripViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAReportProblemWithTripViewController.m; sourceTree = "<group>"; };
 		93631E681604F99500CB7209 /* OBATripDetailsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBATripDetailsViewController.h; sourceTree = "<group>"; };
-		93631E691604F99500CB7209 /* OBATripDetailsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBATripDetailsViewController.m; sourceTree = "<group>"; };
+		93631E691604F99500CB7209 /* OBATripDetailsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = OBATripDetailsViewController.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		93631E6A1604F99500CB7209 /* OBATripScheduleListViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBATripScheduleListViewController.h; sourceTree = "<group>"; };
-		93631E6B1604F99500CB7209 /* OBATripScheduleListViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBATripScheduleListViewController.m; sourceTree = "<group>"; };
+		93631E6B1604F99500CB7209 /* OBATripScheduleListViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = OBATripScheduleListViewController.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		93631E6C1604F99500CB7209 /* OBATripScheduleMapViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBATripScheduleMapViewController.h; sourceTree = "<group>"; };
 		93631E6D1604F99500CB7209 /* OBATripScheduleMapViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBATripScheduleMapViewController.m; sourceTree = "<group>"; };
 		93631E7B1604F9A200CB7209 /* OBANetworkErrorAlertViewDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBANetworkErrorAlertViewDelegate.h; sourceTree = "<group>"; };
@@ -2314,7 +2314,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				INFOPLIST_PREFIX_HEADER = $PROJECT_TEMP_DIR/infoplist.prefix;
 				INFOPLIST_PREPROCESS = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 5.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)",
@@ -2356,7 +2356,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				INFOPLIST_PREFIX_HEADER = $PROJECT_TEMP_DIR/infoplist.prefix;
 				INFOPLIST_PREPROCESS = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 5.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)",
@@ -2467,7 +2467,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				INFOPLIST_PREFIX_HEADER = $PROJECT_TEMP_DIR/infoplist.prefix;
 				INFOPLIST_PREPROCESS = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 5.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)",
@@ -2522,7 +2522,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				INFOPLIST_PREFIX_HEADER = $PROJECT_TEMP_DIR/infoplist.prefix;
 				INFOPLIST_PREPROCESS = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 5.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)",

--- a/view_controllers/OBAAgenciesListViewController.m
+++ b/view_controllers/OBAAgenciesListViewController.m
@@ -177,7 +177,7 @@ typedef enum {
     cell.selectionStyle = UITableViewCellSelectionStyleBlue;
     cell.textLabel.textColor = [UIColor blackColor];
     cell.textLabel.font = [UIFont systemFontOfSize:18];
-    cell.textLabel.textAlignment = UITextAlignmentLeft;
+    cell.textLabel.textAlignment = NSTextAlignmentLeft;
     cell.textLabel.text = NSLocalizedString(@"Show on map",@"AgenciesListViewController");
     return cell;
 }
@@ -198,7 +198,7 @@ typedef enum {
     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
     cell.selectionStyle = UITableViewCellSelectionStyleBlue;
     cell.textLabel.textColor = [UIColor blackColor];
-    cell.textLabel.textAlignment = UITextAlignmentLeft;
+    cell.textLabel.textAlignment = NSTextAlignmentLeft;
     cell.textLabel.font = [UIFont systemFontOfSize:18];
     cell.textLabel.text = agency.name;
     return cell;
@@ -209,7 +209,7 @@ typedef enum {
     cell.accessoryType = UITableViewCellAccessoryNone;
     cell.selectionStyle = UITableViewCellSelectionStyleNone;
     cell.textLabel.textColor = [UIColor blackColor];
-    cell.textLabel.textAlignment = UITextAlignmentCenter;
+    cell.textLabel.textAlignment = NSTextAlignmentCenter;
     cell.textLabel.text = NSLocalizedString(@"No agencies found",@"cell.textLabel.text");
     return cell;    
 }

--- a/view_controllers/OBABookmarksViewController.m
+++ b/view_controllers/OBABookmarksViewController.m
@@ -115,7 +115,7 @@
     if( 0 == self.bookmarks.count && 0 == self.bookmarkGroups.count ) {
         cell = [UITableViewCell getOrCreateCellForTableView:tableView];
         cell.textLabel.text = NSLocalizedString(@"No bookmarks set",@"[_bookmarks count] == 0");
-        cell.textLabel.textAlignment = UITextAlignmentCenter;
+        cell.textLabel.textAlignment = NSTextAlignmentCenter;
         cell.textLabel.font = [UIFont systemFontOfSize:18];
         cell.accessoryType = UITableViewCellAccessoryNone;
         cell.selectionStyle = UITableViewCellSelectionStyleNone;

--- a/view_controllers/OBAContactUsViewController.m
+++ b/view_controllers/OBAContactUsViewController.m
@@ -155,7 +155,7 @@ static NSString *kOBADefaultTwitterURL = @"http://twitter.com/onebusaway";
                             appVersionString, [NSString stringWithCString:systemInfo.machine encoding:NSUTF8StringEncoding], 
                             [[UIDevice currentDevice] systemVersion], location.coordinate.latitude, location.coordinate.longitude] isHTML:YES]; 
                 				
-                        [self presentModalViewController:controller animated:YES];
+                        [self presentViewController:controller animated:YES completion:^{ }];
                     }else{
                         [self cantSendEmail];
                     }

--- a/view_controllers/OBACustomApiViewController.m
+++ b/view_controllers/OBACustomApiViewController.m
@@ -199,7 +199,7 @@ static NSString *editingCellTag = @"editingCell";
     UITableViewCell *cell = [UITableViewCell getOrCreateCellForTableView:tableView];
     cell.selectionStyle = UITableViewCellSelectionStyleBlue;
     cell.textLabel.textColor = [UIColor blackColor];
-    cell.textLabel.textAlignment = UITextAlignmentLeft;
+    cell.textLabel.textAlignment = NSTextAlignmentLeft;
     cell.textLabel.font = [UIFont systemFontOfSize:16];
     cell.textLabel.text = [self.recentUrls objectAtIndex:indexPath.row];
     return cell;

--- a/view_controllers/OBARecentStopsViewController.m
+++ b/view_controllers/OBARecentStopsViewController.m
@@ -65,7 +65,7 @@
 
 // Customize the number of rows in the table view.
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
-    int count = [_mostRecentStops count];
+    NSUInteger count = [_mostRecentStops count];
     if( count == 0 ) 
         count = 1;
     return count;
@@ -78,7 +78,7 @@
     if( [_mostRecentStops count] == 0 ) {
         UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView];
         cell.textLabel.text = NSLocalizedString(@"No recent stops",@"cell.textLabel.text");
-        cell.textLabel.textAlignment = UITextAlignmentCenter;
+        cell.textLabel.textAlignment = NSTextAlignmentCenter;
         cell.selectionStyle = UITableViewCellSelectionStyleNone;
         return cell;
     }
@@ -86,9 +86,9 @@
         UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView style:UITableViewCellStyleSubtitle];
         OBAStopAccessEventV2 * event = _mostRecentStops[indexPath.row];
         cell.textLabel.text = event.title;
-        cell.textLabel.textAlignment = UITextAlignmentCenter;
+        cell.textLabel.textAlignment = NSTextAlignmentCenter;
         cell.detailTextLabel.text = event.subtitle;
-        cell.detailTextLabel.textAlignment = UITextAlignmentCenter;
+        cell.detailTextLabel.textAlignment = NSTextAlignmentCenter;
         cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
         cell.selectionStyle = UITableViewCellSelectionStyleBlue;
         return cell;

--- a/view_controllers/OBARegionListViewController.m
+++ b/view_controllers/OBARegionListViewController.m
@@ -405,7 +405,7 @@ typedef enum {
     cell.accessoryType = self.checkedItem == indexPath ? UITableViewCellAccessoryCheckmark : UITableViewCellAccessoryNone;
 	cell.selectionStyle = UITableViewCellSelectionStyleBlue;
 	cell.textLabel.textColor = [UIColor blackColor];
-	cell.textLabel.textAlignment = UITextAlignmentLeft;
+	cell.textLabel.textAlignment = NSTextAlignmentLeft;
     cell.textLabel.font = [UIFont systemFontOfSize:18];
 
 	cell.textLabel.text = region.regionName;
@@ -446,7 +446,7 @@ typedef enum {
     [cell.accessoryView addSubview:_toggleSwitch];
     
     cell.textLabel.textColor = [UIColor blackColor];
-    cell.textLabel.textAlignment = UITextAlignmentLeft;
+    cell.textLabel.textAlignment = NSTextAlignmentLeft;
     cell.textLabel.font = [UIFont systemFontOfSize:18];
     cell.textLabel.text = NSLocalizedString(@"Experimental Regions", @"cell.textLabel.text");
     cell.selectionStyle = UITableViewCellSelectionStyleNone;
@@ -458,7 +458,7 @@ typedef enum {
     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
     cell.selectionStyle = UITableViewCellSelectionStyleBlue;
     cell.textLabel.textColor = [UIColor blackColor];
-    cell.textLabel.textAlignment = UITextAlignmentLeft;
+    cell.textLabel.textAlignment = NSTextAlignmentLeft;
     cell.textLabel.font = [UIFont systemFontOfSize:18];
     cell.textLabel.text = NSLocalizedString(@"Custom API URL", @"cell.textLabel.text");
     return cell;

--- a/view_controllers/OBASearchResultsMapViewController.m
+++ b/view_controllers/OBASearchResultsMapViewController.m
@@ -46,16 +46,12 @@ static const double kDefaultMapRadius = 100;
 static const double kMinMapRadius = 150;
 static const double kMaxLatDeltaToShowStops = 0.008;
 static const double kRegionScaleFactor = 1.5;
-static const double kMinRegionDeltaToDetectUserDrag = 50;
-
-static const double kRegionChangeRequestsTimeToLive = 3.0;
 
 static const double kMaxMapDistanceFromCurrentLocationForNearby = 800;
 static const double kPaddingScaleFactor = 1.075;
 static const NSUInteger kShowNClosestStops = 4;
 
 static const double kStopsInRegionRefreshDelayOnDrag = 0.1;
-static const double kStopsInRegionRefreshDelayOnLocate = 0.1;
 
 static NSString *kOBAIncreaseContrastKey = @"OBAIncreaseContrastDefaultsKey";
 
@@ -895,8 +891,8 @@ static NSString *kOBAIncreaseContrastKey = @"OBAIncreaseContrastDefaultsKey";
             [toAdd addObject:annotation];
     }
     
-    OBALogDebug(@"Annotations to remove: %d",[toRemove count]);
-    OBALogDebug(@"Annotations to add: %d", [toAdd count]);
+    OBALogDebug(@"Annotations to remove: %lu",(unsigned long)[toRemove count]);
+    OBALogDebug(@"Annotations to add: %lu", (unsigned long)[toAdd count]);
     
     [self.mapView removeAnnotations:toRemove];
     [self.mapView addAnnotations:toAdd];

--- a/view_controllers/OBASettingsViewController.m
+++ b/view_controllers/OBASettingsViewController.m
@@ -143,7 +143,7 @@ static NSString * kOBAIncreaseContrastKey = @"OBAIncreaseContrastDefaultsKey";
             [cell.accessoryView addSubview:self.toggleSwitch];
             
             cell.textLabel.textColor = [UIColor blackColor];
-            cell.textLabel.textAlignment = UITextAlignmentLeft;
+            cell.textLabel.textAlignment = NSTextAlignmentLeft;
             cell.textLabel.font = [UIFont systemFontOfSize:18];
             cell.textLabel.text = NSLocalizedString(@"Increase Contrast", @"increase contrast");
             cell.selectionStyle = UITableViewCellSelectionStyleNone;

--- a/view_controllers/OBAVehicleDetailsController.m
+++ b/view_controllers/OBAVehicleDetailsController.m
@@ -197,7 +197,7 @@ typedef enum {
     cell.selectionStyle = UITableViewCellSelectionStyleBlue;
 
     cell.textLabel.textColor = [UIColor blackColor];
-    cell.textLabel.textAlignment = UITextAlignmentLeft;
+    cell.textLabel.textAlignment = NSTextAlignmentLeft;
     cell.textLabel.text = [NSString stringWithFormat:@"%@: %@",NSLocalizedString(@"Vehicle",@"cell.textLabel.text"), _vehicleStatus.vehicleId];
     
     NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];    
@@ -206,7 +206,7 @@ typedef enum {
     NSString * result = [dateFormatter stringFromDate:[NSDate dateWithTimeIntervalSince1970:_vehicleStatus.lastUpdateTime/1000.0]];
 
     cell.detailTextLabel.textColor = [UIColor blackColor];
-    cell.detailTextLabel.textAlignment = UITextAlignmentLeft;
+    cell.detailTextLabel.textAlignment = NSTextAlignmentLeft;
     cell.detailTextLabel.text = [NSString stringWithFormat:@"%@: %@",NSLocalizedString(@"Last update",@"cell.detailTextLabel.text") , result];
 
     return cell;
@@ -221,7 +221,7 @@ typedef enum {
     cell.accessoryType = UITableViewCellAccessoryNone;
     cell.selectionStyle = UITableViewCellSelectionStyleNone;
     cell.textLabel.textColor = [UIColor blackColor];
-    cell.textLabel.textAlignment = UITextAlignmentLeft;
+    cell.textLabel.textAlignment = NSTextAlignmentLeft;
     cell.textLabel.font = [UIFont systemFontOfSize:18];    
     switch (indexPath.row) {
         case 0: {
@@ -249,7 +249,7 @@ typedef enum {
                 NSInteger mins = sd / 60;
                 NSInteger secs = sd % 60;
                 
-                cell.textLabel.text = [NSString stringWithFormat:@"%@: %dm %ds%@",NSLocalizedString(@"Schedule deviation",@"cell.textLabel.text"),mins, secs, label];
+                cell.textLabel.text = [NSString stringWithFormat:@"%@: %ldm %lds%@",NSLocalizedString(@"Schedule deviation",@"cell.textLabel.text"),(long)mins, (long)secs, label];
             }
             break;
         }
@@ -264,7 +264,7 @@ typedef enum {
     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
     cell.selectionStyle = UITableViewCellSelectionStyleBlue;
     cell.textLabel.textColor = [UIColor blackColor];
-    cell.textLabel.textAlignment = UITextAlignmentLeft;
+    cell.textLabel.textAlignment = NSTextAlignmentLeft;
     cell.textLabel.font = [UIFont systemFontOfSize:18];    
     switch (indexPath.row) {
         case 0:

--- a/view_controllers/StopDetails/OBAEditStopBookmarkViewController.m
+++ b/view_controllers/StopDetails/OBAEditStopBookmarkViewController.m
@@ -72,7 +72,7 @@
     NSArray * stopIds = _bookmark.stopIds;
     for( NSUInteger i=0; i<[stopIds count]; i++) {
         NSString * stopId = stopIds[i];
-        NSNumber * index = [NSNumber numberWithInt:i];
+        NSNumber * index = [NSNumber numberWithInteger:i];
         id<OBAModelServiceRequest> request = [service requestStopForId:stopId withDelegate:self withContext:index];
         [_requests addObject:request];
     }

--- a/view_controllers/StopDetails/OBAEditStopPreferencesViewController.m
+++ b/view_controllers/StopDetails/OBAEditStopPreferencesViewController.m
@@ -110,7 +110,7 @@
             return 2;
         case 1:
         {
-            int c = [_routes count];
+            NSInteger c = [_routes count];
             if( c == 0 )
                 c = 1;
             return c;
@@ -191,7 +191,7 @@
     
     if( indexPath.section == 0) {
         if( _preferences.sortTripsByType != indexPath.row ) {
-            _preferences.sortTripsByType = indexPath.row;
+            _preferences.sortTripsByType = (int)indexPath.row;
             for( int i=0; i<2; i++) {
                 NSIndexPath * cellIndex = [NSIndexPath indexPathForRow:i inSection:0];
                 BOOL checked = (i == indexPath.row);

--- a/view_controllers/StopDetails/OBAGenericStopViewController.m
+++ b/view_controllers/StopDetails/OBAGenericStopViewController.m
@@ -39,13 +39,12 @@
 #import "OBABookmarkGroup.h"
 #import "OBAStopWebViewController.h"
 
-static const double kNearbyStopRadius = 200;
+//static const double kNearbyStopRadius = 200;
 static NSString *kOBANoStopInformationURL = @"http://stopinfo.pugetsound.onebusaway.org/testing";
 static NSString *kOBADidShowStopInfoHintDefaultsKey = @"OBADidShowStopInfoHintDefaultsKey";
 static NSString *kOBAIncreaseContrastKey = @"OBAIncreaseContrastDefaultsKey";
 
 @interface OBAGenericStopViewController ()
-@property(strong,readwrite) OBAApplicationDelegate * _appDelegate;
 @property(strong,readwrite) NSString * stopId;
 
 @property(strong) id<OBAModelServiceRequest> request;
@@ -352,7 +351,7 @@ static NSString *kOBAIncreaseContrastKey = @"OBAIncreaseContrastDefaultsKey";
     label.backgroundColor = [UIColor clearColor];
     label.textColor = [UIColor whiteColor];
     label.numberOfLines = 0;
-    label.lineBreakMode = UILineBreakModeWordWrap;
+    label.lineBreakMode = NSLineBreakByWordWrapping;
     label.text = message;
     label.accessibilityLabel = accessMessage;
     
@@ -567,7 +566,7 @@ static NSString *kOBAIncreaseContrastKey = @"OBAIncreaseContrastDefaultsKey";
             _showFilteredArrivals = !_showFilteredArrivals;
             
             // update arrivals section
-            int arrivalsViewSection = [self sectionIndexForSectionType:OBAStopSectionTypeArrivals];
+            NSInteger arrivalsViewSection = [self sectionIndexForSectionType:OBAStopSectionTypeArrivals];
 
             UITableViewCell * cell = [tableView cellForRowAtIndexPath:indexPath];
             [self determineFilterTypeCellText:cell filteringEnabled:_showFilteredArrivals];
@@ -729,7 +728,7 @@ static NSString *kOBAIncreaseContrastKey = @"OBAIncreaseContrastDefaultsKey";
     if ((arrivals.count == 0 && indexPath.row == 1) || (arrivals.count == indexPath.row && arrivals.count > 0)) {
         UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView];
         cell.textLabel.text = NSLocalizedString(@"Load more arrivals",@"load more arrivals");
-        cell.textLabel.textAlignment = UITextAlignmentCenter;
+        cell.textLabel.textAlignment = NSTextAlignmentCenter;
         cell.textLabel.font = [UIFont systemFontOfSize:18];
         cell.accessoryType = UITableViewCellAccessoryNone;
         return cell;
@@ -737,7 +736,7 @@ static NSString *kOBAIncreaseContrastKey = @"OBAIncreaseContrastDefaultsKey";
     else if(arrivals.count == 0 ) {
         UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView];
         cell.textLabel.text = [NSString stringWithFormat:NSLocalizedString(@"No arrivals in the next %i minutes",@"[arrivals count] == 0"), self.minutesAfter];
-        cell.textLabel.textAlignment = UITextAlignmentCenter;
+        cell.textLabel.textAlignment = NSTextAlignmentCenter;
         cell.textLabel.font = [UIFont systemFontOfSize:18];
         cell.selectionStyle = UITableViewCellSelectionStyleNone;
         cell.accessoryType = UITableViewCellAccessoryNone;
@@ -768,7 +767,7 @@ static NSString *kOBAIncreaseContrastKey = @"OBAIncreaseContrastDefaultsKey";
     
     [self determineFilterTypeCellText:cell filteringEnabled:_showFilteredArrivals];
     
-    cell.textLabel.textAlignment = UITextAlignmentCenter;
+    cell.textLabel.textAlignment = NSTextAlignmentCenter;
     cell.textLabel.font = [UIFont systemFontOfSize:18];
     cell.selectionStyle = UITableViewCellSelectionStyleBlue;
     cell.accessoryType = UITableViewCellAccessoryNone;
@@ -780,7 +779,7 @@ static NSString *kOBAIncreaseContrastKey = @"OBAIncreaseContrastDefaultsKey";
     
     UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView];
 
-    cell.textLabel.textAlignment = UITextAlignmentLeft;
+    cell.textLabel.textAlignment = NSTextAlignmentLeft;
     cell.textLabel.font = [UIFont systemFontOfSize:18];
     cell.selectionStyle = UITableViewCellSelectionStyleBlue;
     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
@@ -809,7 +808,7 @@ static NSString *kOBAIncreaseContrastKey = @"OBAIncreaseContrastDefaultsKey";
                 cell.textLabel.text = @"Service Alerts";
             }
             else {
-                cell.textLabel.text = [NSString stringWithFormat:@"Service Alerts: %d total", _serviceAlerts.totalCount];
+                cell.textLabel.text = [NSString stringWithFormat:@"Service Alerts: %lu total", (unsigned long)_serviceAlerts.totalCount];
             }
 
             if (_serviceAlerts.totalCount == 0) {

--- a/view_controllers/StopDetails/OBAReportProblemViewController.m
+++ b/view_controllers/StopDetails/OBAReportProblemViewController.m
@@ -72,7 +72,7 @@
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     
     UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView];            
-    cell.textLabel.textAlignment = UITextAlignmentLeft;
+    cell.textLabel.textAlignment = NSTextAlignmentLeft;
     cell.selectionStyle = UITableViewCellSelectionStyleBlue;
     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
     cell.textLabel.font = [UIFont systemFontOfSize:18];

--- a/view_controllers/StopDetails/OBAReportProblemWithStopViewController.m
+++ b/view_controllers/StopDetails/OBAReportProblemWithStopViewController.m
@@ -154,7 +154,7 @@ typedef enum {
     switch (sectionType) {
         case OBASectionTypeProblem: {
             UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView];            
-            cell.textLabel.textAlignment = UITextAlignmentLeft;
+            cell.textLabel.textAlignment = NSTextAlignmentLeft;
             cell.selectionStyle = UITableViewCellSelectionStyleBlue;
             cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
             cell.textLabel.font = [UIFont systemFontOfSize:18];
@@ -163,7 +163,7 @@ typedef enum {
         }
         case OBASectionTypeComment: {
             UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView];            
-            cell.textLabel.textAlignment = UITextAlignmentLeft;
+            cell.textLabel.textAlignment = NSTextAlignmentLeft;
             cell.selectionStyle = UITableViewCellSelectionStyleBlue;
             cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
             cell.textLabel.font = [UIFont systemFontOfSize:18];
@@ -182,7 +182,7 @@ typedef enum {
         
         case OBASectionTypeSubmit: {
             UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView];            
-            cell.textLabel.textAlignment = UITextAlignmentCenter;
+            cell.textLabel.textAlignment = NSTextAlignmentCenter;
             cell.selectionStyle = UITableViewCellSelectionStyleBlue;
             cell.accessoryType = UITableViewCellAccessoryNone;
             cell.textLabel.font = [UIFont systemFontOfSize:18];

--- a/view_controllers/TripDetails/OBAArrivalAndDepartureViewController.m
+++ b/view_controllers/TripDetails/OBAArrivalAndDepartureViewController.m
@@ -233,7 +233,7 @@ typedef enum {
     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
     cell.selectionStyle = UITableViewCellSelectionStyleBlue;
     cell.textLabel.textColor = [UIColor blackColor];
-    cell.textLabel.textAlignment = UITextAlignmentLeft;
+    cell.textLabel.textAlignment = NSTextAlignmentLeft;
     cell.textLabel.font = [UIFont systemFontOfSize:18];
     
     switch (indexPath.row) {
@@ -260,7 +260,7 @@ typedef enum {
             cell.selectionStyle = UITableViewCellSelectionStyleBlue;
             cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
             cell.textLabel.textColor = [UIColor blackColor];
-            cell.textLabel.textAlignment = UITextAlignmentLeft;
+            cell.textLabel.textAlignment = NSTextAlignmentLeft;
             cell.textLabel.font = [UIFont systemFontOfSize:18];
             cell.textLabel.text = NSLocalizedString(@"Report a problem for this trip",@"text");
             return cell;            
@@ -270,7 +270,7 @@ typedef enum {
             cell.selectionStyle = UITableViewCellSelectionStyleBlue;
             cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
             cell.textLabel.textColor = [UIColor blackColor];
-            cell.textLabel.textAlignment = UITextAlignmentLeft;
+            cell.textLabel.textAlignment = NSTextAlignmentLeft;
             cell.textLabel.font = [UIFont systemFontOfSize:18];
             cell.textLabel.text = NSLocalizedString(@"Vehicle Info",@"cell.textLabel.text");
             return cell;            

--- a/view_controllers/TripDetails/OBAReportProblemWithTripViewController.m
+++ b/view_controllers/TripDetails/OBAReportProblemWithTripViewController.m
@@ -172,7 +172,7 @@ typedef enum {
     switch (sectionType) {
         case OBASectionTypeProblem: {
             UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView];            
-            cell.textLabel.textAlignment = UITextAlignmentLeft;
+            cell.textLabel.textAlignment = NSTextAlignmentLeft;
             cell.selectionStyle = UITableViewCellSelectionStyleBlue;
             cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
             cell.textLabel.font = [UIFont systemFontOfSize:18];
@@ -181,7 +181,7 @@ typedef enum {
         }
         case OBASectionTypeComment: {
             UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView];            
-            cell.textLabel.textAlignment = UITextAlignmentLeft;
+            cell.textLabel.textAlignment = NSTextAlignmentLeft;
             cell.selectionStyle = UITableViewCellSelectionStyleBlue;
             cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
             cell.textLabel.font = [UIFont systemFontOfSize:18];
@@ -202,7 +202,7 @@ typedef enum {
 
         case OBASectionTypeSubmit: {
             UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView];            
-            cell.textLabel.textAlignment = UITextAlignmentCenter;
+            cell.textLabel.textAlignment = NSTextAlignmentCenter;
             cell.selectionStyle = UITableViewCellSelectionStyleBlue;
             cell.accessoryType = UITableViewCellAccessoryNone;
             cell.textLabel.font = [UIFont systemFontOfSize:18];
@@ -284,7 +284,7 @@ typedef enum {
 
     //go back to view that initiated report
     NSArray *allViewControllers = self.navigationController.viewControllers;
-    for(int i=[allViewControllers count]-1; i>=0; i--){
+    for(NSInteger i=[allViewControllers count]-1; i>=0; i--){
         id obj=[allViewControllers objectAtIndex:i];
         
         if([obj isKindOfClass:[OBAArrivalAndDepartureViewController class]]){

--- a/view_controllers/TripDetails/OBATripDetailsViewController.m
+++ b/view_controllers/TripDetails/OBATripDetailsViewController.m
@@ -244,9 +244,9 @@ typedef enum {
         NSInteger scheduleDeviation = status.scheduleDeviation / 60;
         NSString *label = @"";
 
-        if (scheduleDeviation <= -2) label = [NSString stringWithFormat:@"%d %@", (-scheduleDeviation), NSLocalizedString(@"minutes early", @"scheduleDeviation <= -2")];
+        if (scheduleDeviation <= -2) label = [NSString stringWithFormat:@"%ld %@", (long)(-scheduleDeviation), NSLocalizedString(@"minutes early", @"scheduleDeviation <= -2")];
         else if (scheduleDeviation < 2) label = NSLocalizedString(@"on time", @"scheduleDeviation < 2");
-        else label = [NSString stringWithFormat:@"%d %@", scheduleDeviation, NSLocalizedString(@"minutes late", @"scheduleDeviation >= 2")];
+        else label = [NSString stringWithFormat:@"%ld %@", (long)scheduleDeviation, NSLocalizedString(@"minutes late", @"scheduleDeviation >= 2")];
 
         cell.statusLabel.text = [NSString stringWithFormat:@"%@ # %@ - %@", NSLocalizedString(@"Vehicle", @"cell.statusLabel.text"), status.vehicleId, label];
     }
@@ -263,7 +263,7 @@ typedef enum {
     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
     cell.selectionStyle = UITableViewCellSelectionStyleBlue;
     cell.textLabel.textColor = [UIColor blackColor];
-    cell.textLabel.textAlignment = UITextAlignmentLeft;
+    cell.textLabel.textAlignment = NSTextAlignmentLeft;
     cell.textLabel.font = [UIFont systemFontOfSize:18];
 
     switch (indexPath.row) {
@@ -285,7 +285,7 @@ typedef enum {
     cell.selectionStyle = UITableViewCellSelectionStyleBlue;
     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
     cell.textLabel.textColor = [UIColor blackColor];
-    cell.textLabel.textAlignment = UITextAlignmentLeft;
+    cell.textLabel.textAlignment = NSTextAlignmentLeft;
     cell.textLabel.font = [UIFont systemFontOfSize:18];
 
 

--- a/view_controllers/TripDetails/OBATripScheduleListViewController.m
+++ b/view_controllers/TripDetails/OBATripScheduleListViewController.m
@@ -307,7 +307,7 @@ typedef enum {
     cell.selectionStyle = UITableViewCellSelectionStyleNone;
     cell.accessoryType = UITableViewCellAccessoryNone;
     cell.textLabel.text = NSLocalizedString(@"Loading...",@"cell.textLabel.text");
-    cell.textLabel.textAlignment = UITextAlignmentCenter;
+    cell.textLabel.textAlignment = NSTextAlignmentCenter;
     cell.textLabel.font = [UIFont systemFontOfSize:18];
 
     return cell;
@@ -322,7 +322,7 @@ typedef enum {
         UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView style:UITableViewCellStyleDefault];
         cell.selectionStyle = UITableViewCellSelectionStyleNone;
         cell.accessoryType = UITableViewCellAccessoryNone;
-        cell.textLabel.text = [NSString stringWithFormat:@"%@ %d %@",NSLocalizedString(@"Hiding",@"hidingPreviousStops && indexPath.row == 0"), _currentStopIndex, NSLocalizedString(@"previous stops",@"hidingPreviousStops && indexPath.row == 0")];
+        cell.textLabel.text = [NSString stringWithFormat:@"%@ %ld %@",NSLocalizedString(@"Hiding",@"hidingPreviousStops && indexPath.row == 0"), (long)_currentStopIndex, NSLocalizedString(@"previous stops",@"hidingPreviousStops && indexPath.row == 0")];
         cell.textLabel.textColor = [UIColor grayColor];
         return cell;
     }
@@ -345,8 +345,8 @@ typedef enum {
     
     if( schedule.frequency ) {
         OBATripStopTimeV2 * firstStopTime = stopTimes[0];
-        int minutes = (stopTime.arrivalTime - firstStopTime.departureTime) / 60;
-        cell.detailTextLabel.text = [NSString stringWithFormat:@"%d %@",minutes,NSLocalizedString(@"mins",@"minutes")];                                      
+        NSInteger minutes = (stopTime.arrivalTime - firstStopTime.departureTime) / 60;
+        cell.detailTextLabel.text = [NSString stringWithFormat:@"%ld %@",(long)minutes,NSLocalizedString(@"mins",@"minutes")];                                      
     }
     else {
         NSDate * time = [self getStopTimeAsDate:stopTime.arrivalTime];

--- a/view_controllers/situations/OBASituationViewController.m
+++ b/view_controllers/situations/OBASituationViewController.m
@@ -194,7 +194,7 @@ typedef enum {
 - (UITableViewCell*) tableView:(UITableView*)tableView titleCellForRowAtIndexPath:(NSIndexPath *)indexPath {
     UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView];
     cell.textLabel.text = _situation.summary;
-    cell.textLabel.textAlignment = UITextAlignmentCenter;
+    cell.textLabel.textAlignment = NSTextAlignmentCenter;
     cell.selectionStyle = UITableViewCellSelectionStyleNone;
     cell.accessoryType = UITableViewCellAccessoryNone;
     return cell;    
@@ -204,7 +204,7 @@ typedef enum {
     UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView];    
     cell.selectionStyle = UITableViewCellSelectionStyleBlue;
     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
-    cell.textLabel.textAlignment = UITextAlignmentLeft;
+    cell.textLabel.textAlignment = NSTextAlignmentLeft;
     
     if( indexPath.row == 0 ) {
         cell.textLabel.text = [self getDetails:NO];
@@ -223,7 +223,7 @@ typedef enum {
 
     UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView];
     cell.textLabel.text = isRead ? NSLocalizedString(@"Mark as Unread",@"isRead") : NSLocalizedString(@"Mark as Read",@"!isRead");
-    cell.textLabel.textAlignment = UITextAlignmentCenter;
+    cell.textLabel.textAlignment = NSTextAlignmentCenter;
     cell.selectionStyle = UITableViewCellSelectionStyleBlue;
     cell.accessoryType = UITableViewCellAccessoryNone;           
     return cell;

--- a/view_controllers/situations/OBASituationsViewController.m
+++ b/view_controllers/situations/OBASituationsViewController.m
@@ -60,7 +60,7 @@
 
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
-    int count = [_situations count];
+    NSUInteger count = [_situations count];
     if( count == 0 )
         count = 1;
     return count;
@@ -72,7 +72,7 @@
     if( [_situations count] == 0 ) {
         UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView];
         cell.textLabel.text = NSLocalizedString(@"No active service alerts",@"cell.textLabel.text");
-        cell.textLabel.textAlignment = UITextAlignmentCenter;
+        cell.textLabel.textAlignment = NSTextAlignmentCenter;
         cell.textLabel.font = [UIFont systemFontOfSize:18];
         cell.selectionStyle = UITableViewCellSelectionStyleNone;
         cell.accessoryType = UITableViewCellAccessoryNone;
@@ -83,7 +83,7 @@
     
     UITableViewCell * cell = [UITableViewCell getOrCreateCellForTableView:tableView];
     cell.textLabel.text = situation.summary;
-    cell.textLabel.textAlignment = UITextAlignmentCenter;
+    cell.textLabel.textAlignment = NSTextAlignmentCenter;
     cell.selectionStyle = UITableViewCellSelectionStyleBlue;
     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
     return cell;    


### PR DESCRIPTION
Similar to pull 247 (changed deployment target to 6.0, fixed deprecation warnings), but also fixed most of the warnings related to format strings, integer conversions, and the like.
