### PR TITLE
Fix custom API URL crash

### DIFF
--- a/models/dao/OBAModelDAO.m
+++ b/models/dao/OBAModelDAO.m
@@ -24,7 +24,7 @@
 #import "OBABookmarkGroup.h"
 #import "OBAAnalytics.h"
 
-const static int kMaxEntriesInMostRecentList = 10;
+const NSInteger kMaxEntriesInMostRecentList = 10;
 
 @interface OBAModelDAO ()
 


### PR DESCRIPTION
Fixes the crash when a custom API url address is typed into the text box. (There was a type incompatibility in the mostRecentStops list handling.) This is issue #305.
