### PR TITLE
Show a different icon for bookmarked stops in the map view.

### DIFF
--- a/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/View/OBAStopIconFactory.h
+++ b/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/View/OBAStopIconFactory.h
@@ -9,7 +9,7 @@
 
 - (UIImage*) getIconForStop:(OBAStopV2*)stop;
 - (UIImage*) getIconForStop:(OBAStopV2*)stop includeDirection:(BOOL)includeDirection;
-- (UIImage*) getBookmarkedIconForStop:(OBAStopV2*)stop;
+- (UIImage*) getIconForStop:(OBAStopV2*)stop includeDirection:(BOOL)includeDirection isBookmarked:(BOOL)isBookmarked;
 
 - (UIImage*) getModeIconForRoute:(OBARouteV2*)route;
 - (UIImage*) getModeIconForRoute:(OBARouteV2*)route selected:(BOOL)selected;

--- a/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/View/OBAStopIconFactory.h
+++ b/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/View/OBAStopIconFactory.h
@@ -9,6 +9,7 @@
 
 - (UIImage*) getIconForStop:(OBAStopV2*)stop;
 - (UIImage*) getIconForStop:(OBAStopV2*)stop includeDirection:(BOOL)includeDirection;
+- (UIImage*) getBookmarkedIconForStop:(OBAStopV2*)stop;
 
 - (UIImage*) getModeIconForRoute:(OBARouteV2*)route;
 - (UIImage*) getModeIconForRoute:(OBARouteV2*)route selected:(BOOL)selected;

--- a/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/View/OBAStopIconFactory.m
+++ b/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/View/OBAStopIconFactory.m
@@ -11,7 +11,7 @@
 - (NSString*) getRouteIconTypeForRouteTypes:(NSSet*)routeTypes;
 - (NSString*) getRouteIconTypeForRoute:(OBARouteV2*)route;
 
-- (NSString*) keyForIcontTypeId:(NSString *)iconTypeId
+- (NSString*) keyForIconTypeId:(NSString *)iconTypeId
                     directionId:(NSString *)directionId
                    isBookmarked:(BOOL) isBookmarked;
 
@@ -46,7 +46,7 @@
     if( includeDirection && stop.direction )
         direction = stop.direction;
     
-    NSString * key = [self keyForIcontTypeId:routeIconType directionId:direction isBookmarked:isBookmarked];
+    NSString * key = [self keyForIconTypeId:routeIconType directionId:direction isBookmarked:isBookmarked];
     
     UIImage * image = _stopIcons[key];
     
@@ -95,12 +95,12 @@
         NSString * iconType = iconTypeIds[j];
         for( int i=0; i<[directionIds count]; i++) {        
             NSString * directionId = directionIds[i];
-            NSString * key = [self keyForIcontTypeId:iconType directionId:directionId isBookmarked:NO];
+            NSString * key = [self keyForIconTypeId:iconType directionId:directionId isBookmarked:NO];
             NSString * imageName = [NSString stringWithFormat:@"%@.png",key];
             UIImage * image = [UIImage imageNamed:imageName];
             _stopIcons[key] = image;
             
-            NSString *bookmarkedKey = [self keyForIcontTypeId:iconType directionId:directionId isBookmarked:YES];
+            NSString *bookmarkedKey = [self keyForIconTypeId:iconType directionId:directionId isBookmarked:YES];
             UIImage *bookmarkedImage = [self getBookmarkedIconForImage:image];
             _stopIcons[bookmarkedKey] = bookmarkedImage;
         }        
@@ -109,7 +109,7 @@
     _defaultStopIcon = _stopIcons[@"BusStopIcon"];
 }
 
-- (NSString *)keyForIcontTypeId:(NSString *)iconTypeId
+- (NSString *)keyForIconTypeId:(NSString *)iconTypeId
                     directionId:(NSString *)directionId
                    isBookmarked:(BOOL) isBookmarked
 {

--- a/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/View/OBAStopIconFactory.m
+++ b/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/View/OBAStopIconFactory.m
@@ -1,6 +1,7 @@
 #import "OBAStopIconFactory.h"
 #import "OBARouteV2.h"
 
+#define BOOKMARK_COLOR [UIColor colorWithRed:1.0 green:211.0/255.0 blue:94.0/255.0 alpha:1.0]
 
 @interface OBAStopIconFactory (Private)
 
@@ -43,6 +44,38 @@
         return _defaultStopIcon;
     
     return image;
+}
+
+- (UIImage *)bookmarkedIconForImage:(UIImage *)image {
+    UIColor *color = BOOKMARK_COLOR;
+    UIGraphicsBeginImageContextWithOptions(image.size, NO, image.scale);
+    
+    CGContextRef context = UIGraphicsGetCurrentContext();
+    CGRect area = CGRectMake(0, 0, image.size.width, image.size.height);
+    
+    CGContextScaleCTM(context, 1, -1);
+    CGContextTranslateCTM(context, 0, -area.size.height);
+    
+    CGContextSaveGState(context);
+    CGContextClipToMask(context, area, image.CGImage);
+    
+    [color set];
+    CGContextFillRect(context, area);
+    
+    CGContextRestoreGState(context);
+    
+    CGContextSetBlendMode(context, kCGBlendModeMultiply);
+    CGContextDrawImage(context, area, image.CGImage);
+    UIImage *colorizedImage = UIGraphicsGetImageFromCurrentImageContext();
+    
+    UIGraphicsEndImageContext();
+    
+    return colorizedImage;
+}
+
+- (UIImage *)getBookmarkedIconForStop:(OBAStopV2*)stop {
+    UIImage *originalIcon = [self getIconForStop:stop];
+    return [self bookmarkedIconForImage:originalIcon];
 }
 
 - (UIImage*) getModeIconForRoute:(OBARouteV2*)route {

--- a/view_controllers/OBASearchResultsMapViewController.m
+++ b/view_controllers/OBASearchResultsMapViewController.m
@@ -599,12 +599,8 @@ static NSString *kOBAIncreaseContrastKey = @"OBAIncreaseContrastDefaultsKey";
         }
 
         OBAStopIconFactory * stopIconFactory = self.appDelegate.stopIconFactory;
-        if ([self isStopBookmarked:stop]) {
-            view.image = [stopIconFactory getBookmarkedIconForStop:stop];
-        }
-        else {
-            view.image = [stopIconFactory getIconForStop:stop];
-        }
+        BOOL isBookmarked = [self isStopBookmarked:stop];
+        view.image = [stopIconFactory getIconForStop:stop includeDirection:YES isBookmarked:isBookmarked];
         return view;
     }
     else if ([annotation isKindOfClass:[OBAPlacemark class]]) {

--- a/view_controllers/OBASearchResultsMapViewController.m
+++ b/view_controllers/OBASearchResultsMapViewController.m
@@ -17,6 +17,7 @@
 #import "OBASearchResultsMapViewController.h"
 #import "OBARoute.h"
 #import "OBAStopV2.h"
+#import "OBABookmarkGroup.h"
 #import "OBARouteV2.h"
 #import "OBAAgencyWithCoverageV2.h"
 #import "OBAGenericAnnotation.h"
@@ -75,6 +76,8 @@ static NSString *kOBAIncreaseContrastKey = @"OBAIncreaseContrastDefaultsKey";
 @end
 
 @interface OBASearchResultsMapViewController (Private)
+
+- (BOOL)isStopBookmarked:(OBAStopV2*)stop;
 
 - (void)refreshCurrentLocation;
 
@@ -596,7 +599,12 @@ static NSString *kOBAIncreaseContrastKey = @"OBAIncreaseContrastDefaultsKey";
         }
 
         OBAStopIconFactory * stopIconFactory = self.appDelegate.stopIconFactory;
-        view.image = [stopIconFactory getIconForStop:stop];
+        if ([self isStopBookmarked:stop]) {
+            view.image = [stopIconFactory getBookmarkedIconForStop:stop];
+        }
+        else {
+            view.image = [stopIconFactory getIconForStop:stop];
+        }
         return view;
     }
     else if ([annotation isKindOfClass:[OBAPlacemark class]]) {
@@ -729,6 +737,22 @@ static NSString *kOBAIncreaseContrastKey = @"OBAIncreaseContrastDefaultsKey";
 #pragma mark - OBASearchMapViewController Private Methods
 
 @implementation OBASearchResultsMapViewController (Private)
+
+- (BOOL)isStopBookmarked:(OBAStopV2 *)stop {
+    for (OBABookmarkV2 *bm in [_appDelegate.modelDao bookmarks]) {
+        if ([bm.stopIds containsObject:stop.stopId]) {
+            return YES;
+        }
+    }
+    for (OBABookmarkGroup *group in [_appDelegate.modelDao bookmarkGroups]) {
+        for (OBABookmarkV2 *bm in group.bookmarks) {
+            if ([bm.stopIds containsObject:stop.stopId]) {
+                return YES;
+            }
+        }
+    }
+    return NO;
+}
 
 - (void) refreshCurrentLocation {
     


### PR DESCRIPTION
Show a different icon for bookmarked stops in the map view:
![2014-07-05 13 41 44](https://cloud.githubusercontent.com/assets/536584/3487535/7452f47a-0485-11e4-98c8-635a966444ab.png)

Part of feature request for 2.3:
https://huboard.com/OneBusAway/onebusaway-iphone/#/milestones/issues/6255628

The bookmark color can be tweaked if needed.