### PR TITLE
Fix crash on bookmarks view

### DIFF
--- a/view_controllers/OBABookmarksViewController.m
+++ b/view_controllers/OBABookmarksViewController.m
@@ -106,6 +106,10 @@
     return MAX(total, 1);
 }
 
+- (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath {
+    return self.bookmarks.count > 0 || self.bookmarkGroups.count > 0;
+}
+
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
 
     UITableViewCell * cell = nil;


### PR DESCRIPTION
Issue #325 

The issue is for the case with no bookmarks, side swiping the 'No bookmarks set' turned on editing mode, and dragging on that row would check if it could be moved, causing a array out of bounds exception in canMoveRowAtIndexPath.

This fixes that issue by not allowing editing when there are no bookmarks or groups.
