### PR TITLE
Change status text to match deviation color

### DIFF
--- a/controls/table_cells/OBAArrivalEntryTableViewCellFactory.m
+++ b/controls/table_cells/OBAArrivalEntryTableViewCellFactory.m
@@ -61,6 +61,14 @@
         cell.minutesLabel.text = [self getMinutesLabelForMinutes:minutes];
         cell.minutesLabel.textColor = [self getMinutesColorForArrival:arrival];
         cell.minutesSubLabel.hidden = YES;
+        NSMutableAttributedString *statusColoredString = [[NSMutableAttributedString alloc] initWithString:cell.statusLabel.text];
+        NSRange startOfStatusSubstring = [cell.statusLabel.text rangeOfString:@"-"];
+        if (startOfStatusSubstring.location != NSNotFound){
+            [statusColoredString addAttribute:NSForegroundColorAttributeName
+                                    value:[self getMinutesColorForArrival:arrival]
+                                    range:NSMakeRange(startOfStatusSubstring.location + 1, [statusColoredString length] - (startOfStatusSubstring.location + 1))];
+        }
+        [cell.statusLabel setAttributedText:statusColoredString];
     }
     
     NSString *minutesUntilArrivalText;
@@ -99,7 +107,7 @@
             return [UIColor redColor];
         }
         else if( diff < 1.5 ) {
-            return [UIColor colorWithRed:0.0 green:0.5 blue:0.0 alpha:1.0];
+            return OBALABELGREEN;
         }
         else {
             return [UIColor blueColor];

--- a/utilities/OBACommonV1.h
+++ b/utilities/OBACommonV1.h
@@ -24,7 +24,8 @@ typedef enum {
 #define OBARGBACOLOR(__r, __g, __b, __a) [UIColor colorWithRed:(__r / 255.f) green:(__g / 255.f) blue:(__b / 255.f) alpha:__a]
 #define OBAGREEN [UIColor colorWithHue:(86./360.) saturation:0.68 brightness:0.67 alpha:1];
 #define OBAGREENBACKGROUND [UIColor colorWithHue:(86./360.) saturation:0.68 brightness:0.67 alpha:0.1]
-#define OBADARKGREEN [UIColor colorWithRed:0.3529 green:0.5020 blue:0.1608 alpha:1.0000]
+#define OBALABELGREEN [UIColor colorWithRed:0 green:0.478 blue:0 alpha:1]
+#define OBADARKGREEN [UIColor colorWithRed:0.2 green:0.4 blue:0 alpha:1]
 
 #define OBAPlacemarkNotification @"OBAPlacemarkNotification"
 #define OBAViewedArrivalsAndDeparturesForStopNotification @"OBAViewedArrivalsAndDeparturesForStopNotification"


### PR DESCRIPTION
Changes as described in #317. 
1. Changed the label color to be slightly darker green. 
2. Matched the deviation time color to the color of the minutes. Please take a look at the code and let me know if there is a better way of doing this. I don't like how hacky it feels. (Particularly with `NSMakeRange`.)

Screenshot of changes below:
![Screenshot of Stop Details View with status colors changed](https://cloud.githubusercontent.com/assets/4627278/4568432/3b85a6ec-4f3a-11e4-84db-b2ea54ea0497.PNG)
