### PR TITLE
remove custom api url logging

### DIFF
--- a/OBAApplicationDelegate.m
+++ b/OBAApplicationDelegate.m
@@ -266,7 +266,7 @@ static NSString *const kAllowTracking = @"allowTracking";
     if([self.modelDao.readCustomApiUrl isEqualToString:@""]) {
         [OBAAnalytics reportEventWithCategory:@"app_settings" action:@"configured_region" label:[NSString stringWithFormat:@"API Region: %@",self.modelDao.region.regionName] value:nil];
     }else{
-        [OBAAnalytics reportEventWithCategory:@"app_settings" action:@"configured_region" label:[NSString stringWithFormat:@"API Region: %@",self.modelDao.readCustomApiUrl] value:nil];
+        [OBAAnalytics reportEventWithCategory:@"app_settings" action:@"configured_region" label:@"API Region: Custom URL" value:nil];
     }
     [OBAAnalytics reportEventWithCategory:@"app_settings" action:@"general" label:[NSString stringWithFormat:@"Set Region Automatically: %@", (self.modelDao.readSetRegionAutomatically ? @"YES" : @"NO")] value:nil];
 


### PR DESCRIPTION
Removes potential personally identifiable information discussed at https://github.com/OneBusAway/onebusaway-android/issues/105#issuecomment-71123903.

Eventually this could be updated to log the SHA265 of the custom API so we can get an idea of what custom APIs are getting a lot of continued usage.