### PR TITLE
Show correct Trip Details times for 'scheduled arrival' buses.

### DIFF
--- a/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/Model/V2/OBATripStopTimeV2.m
+++ b/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b/Classes/Model/V2/OBATripStopTimeV2.m
@@ -8,4 +8,8 @@
     return [refs getStopForId:self.stopId];
 }
 
+- (NSString*)description
+{
+    return [NSString stringWithFormat:@"<%@: %p> :: {arrivalTime: %@, departureTime: %@, stopId: %@, stop: %@}", self.class, self, @(self.arrivalTime), @(self.departureTime), self.stopId, self.stop];
+}
 @end

--- a/view_controllers/TripDetails/OBATripScheduleListViewController.m
+++ b/view_controllers/TripDetails/OBATripScheduleListViewController.m
@@ -50,6 +50,7 @@ typedef enum {
         _timeFormatter = [[NSDateFormatter alloc] init];
         [_timeFormatter setDateStyle:NSDateFormatterNoStyle];
         [_timeFormatter setTimeStyle:NSDateFormatterShortStyle];
+        [_timeFormatter setTimeZone:[NSTimeZone localTimeZone]];
 
         CGRect r = CGRectMake(0, 0, 160, 33);
         _progressView = [[OBAProgressIndicatorView alloc] initWithFrame:r];
@@ -313,8 +314,14 @@ typedef enum {
         serviceDate = status.serviceDate;
         scheduleDeviation = status.scheduleDeviation;
     }
+    else {
+        serviceDate = [[NSDate date] timeIntervalSince1970];
+        scheduleDeviation = 0;
+    }
 
-    return [NSDate dateWithTimeIntervalSince1970:(serviceDate / 1000 + stopTime + scheduleDeviation)];
+    NSTimeInterval interval = serviceDate / 1000 + stopTime + scheduleDeviation;
+
+    return [NSDate dateWithTimeIntervalSince1970:interval];
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView loadingCellForRowAtIndexPath:(NSIndexPath *)indexPath {


### PR DESCRIPTION
Fixes #359

It appears that for scheduled arrivals—I guess not surprisingly—there's no trip status object on the tripDetails object in OBATripScheduleListViewController.m (specifically relevant on line 313 of that file). When _tripDetails.status is nil, the date that is loaded into the schedule list view controller is actually in 1970, not 2015. When status is represented by an object, the date is correctly in 2015.

This commit fixes that issue by properly setting a base date (now) for cases where there isn't a status object. Also adds some debug info to OBATripStopTimeV2.

@icecrystal23 - this fixes the bug you reported.