### PR TITLE
Fixed a linker error while building a unit test target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,9 @@ before_install:
 before_script:
     - chmod -R +x ./scripts
     - echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
-script: xctool -project org.onebusaway.iphone.xcodeproj -sdk iphonesimulator -scheme Debug build-tests run-tests
+script:
+    - xctool -project org.onebusaway.iphone.xcodeproj -sdk iphonesimulator -scheme Debug build-tests run-tests
+    - xctool -project org.onebusaway.iphone.xcodeproj -sdk iphonesimulator -scheme AppStoreRelease build-tests run-tests  
 env:
   global:
   - APPNAME="OneBusAway"

--- a/org.onebusaway.iphone.xcodeproj/project.pbxproj
+++ b/org.onebusaway.iphone.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		1D60589F0D05DD5A006BFB54 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
 		1DF5F4E00D08C38300B7A737 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DF5F4DF0D08C38300B7A737 /* UIKit.framework */; };
 		288765080DF74369002DB57D /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 288765070DF74369002DB57D /* CoreGraphics.framework */; };
+		5ED30F451A9FB8C400CFC794 /* OBAURLHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 93F152FF1A9AE9740015C141 /* OBAURLHelpers.m */; };
 		727E52F515824F1200534646 /* MessageUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 727E52F415824F1200534646 /* MessageUI.framework */; };
 		9211E32217B8236B0008A479 /* OBARegionHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 9211E32117B8236B0008A479 /* OBARegionHelper.m */; };
 		9211E32517B922D20008A479 /* OBACustomApiViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 9211E32417B922D20008A479 /* OBACustomApiViewController.m */; };
@@ -2206,6 +2207,7 @@
 			files = (
 				93F153021A9AEA500015C141 /* OBAURLHelpers_Tests.m in Sources */,
 				93F152F61A9AE91A0015C141 /* OneBusAway_Tests.m in Sources */,
+				5ED30F451A9FB8C400CFC794 /* OBAURLHelpers.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Added OBAURLHelpers.m file to the test target. Used to fail with linker error like: "Undefined symbols for architecture x86_64: _OBJC_CLASS_$_OBAURLHelpers"