### PR TITLE
WIP: deep link to app location settings

### DIFF
--- a/view_controllers/OBARegionListViewController.m
+++ b/view_controllers/OBARegionListViewController.m
@@ -343,7 +343,13 @@ typedef NS_ENUM(NSInteger, OBASectionType) {
         UIAlertView *view = [[UIAlertView alloc] init];
         view.title = NSLocalizedString(@"Location Services Disabled", @"view.title");
         view.message = NSLocalizedString(@"Location Services are disabled for this app. Some location-aware functionality will be missing.", @"view.message");
-        [view addButtonWithTitle:NSLocalizedString(@"Dismiss", @"view addButtonWithTitle")];
+        view.delegate = self;
+        [view addButtonWithTitle:NSLocalizedString(@"Okay", @"Ok button")];
+
+        if (&UIApplicationOpenSettingsURLString != NULL) {
+            [view addButtonWithTitle:@"Location Settings"];
+        }
+
         view.cancelButtonIndex = 0;
         [view show];
     }
@@ -517,6 +523,12 @@ typedef NS_ENUM(NSInteger, OBASectionType) {
         }
         else {
             [_toggleSwitch setOn:NO animated:NO];
+        }
+    }
+    else if ([title isEqualToString:@"Location Settings"]) {
+        if (&UIApplicationOpenSettingsURLString != NULL) {
+            NSURL *appSettings = [NSURL URLWithString:UIApplicationOpenSettingsURLString];
+            [[UIApplication sharedApplication] openURL:appSettings];
         }
     }
 }

--- a/view_controllers/OBASearchResultsMapViewController.m
+++ b/view_controllers/OBASearchResultsMapViewController.m
@@ -966,18 +966,37 @@ static NSString *kOBAIncreaseContrastKey = @"OBAIncreaseContrastDefaultsKey";
     }
 }
 
-- (void) showLocationServicesAlert {
+#pragma mark UIAlertViewDelegate
+
+- (void)showLocationServicesAlert {
     self.navigationItem.leftBarButtonItem.enabled = NO;
 
     if (![self.appDelegate.modelDao hideFutureLocationWarnings]) {
-        [self.appDelegate.modelDao setHideFutureLocationWarnings:YES];
+        [self.appDelegate.modelDao setHideFutureLocationWarnings:TRUE];
 
         UIAlertView *view = [[UIAlertView alloc] init];
         view.title = NSLocalizedString(@"Location Services Disabled", @"view.title");
         view.message = NSLocalizedString(@"Location Services are disabled for this app. Some location-aware functionality will be missing.", @"view.message");
-        [view addButtonWithTitle:NSLocalizedString(@"Dismiss", @"view addButtonWithTitle")];
+        view.delegate = self;
+        [view addButtonWithTitle:NSLocalizedString(@"Okay", @"Ok button")];
+
+        if (&UIApplicationOpenSettingsURLString != NULL) {
+            [view addButtonWithTitle:@"Location Settings"];
+        }
+
         view.cancelButtonIndex = 0;
         [view show];
+    }
+}
+
+- (void)alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex {
+    NSString *title = [alertView buttonTitleAtIndex:buttonIndex];
+    
+    if ([title isEqualToString:@"Location Settings"]) {
+        if (&UIApplicationOpenSettingsURLString != NULL) {
+            NSURL *appSettings = [NSURL URLWithString:UIApplicationOpenSettingsURLString];
+            [[UIApplication sharedApplication] openURL:appSettings];
+        }
     }
 }
 


### PR DESCRIPTION
Currently we just show the following error when location services are disabled:
![capture](https://cloud.githubusercontent.com/assets/1192780/6440506/7479da3a-c092-11e4-95c2-90459620cc8c.PNG)

This PR allows users on iOS 8 to go directly to the app settings with one button click:
![capture2](https://cloud.githubusercontent.com/assets/1192780/6440521/90f374c8-c092-11e4-9d47-7d5ef8523493.PNG)
![capture3](https://cloud.githubusercontent.com/assets/1192780/6440523/926fe840-c092-11e4-918c-3120790f1392.PNG)

Still working on a bug in `OBASearchResultsMapViewController.m` but appreciate any feedback.

Todo:
* [X] Implement code to launch app settings
* [X] Maintain compatibility of current alert on iOS 7
* [ ] Fix bug on `OBASearchResultsMapViewController.m`
* [ ] Combine duplicate code in to one class
* [ ] Address @aaronbrethorst comments