### PR TITLE
remove unused OneBusAway-iPhone IRC channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 [![Build Status](https://img.shields.io/travis/OneBusAway/onebusaway-iphone.svg)](https://travis-ci.org/OneBusAway/onebusaway-iphone)
 [![Join the chat at https://gitter.im/OneBusAway/onebusaway-iphone](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/OneBusAway/onebusaway-iphone?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Visit our IRC channel](http://img.shields.io/badge/IRC-%23OneBusAway-green.svg)](https://kiwiirc.com/client/irc.freenode.net/?nick=obauser|?&theme=basic#OneBusAway)
-[![Visit our IRC channel](https://img.shields.io/badge/IRC-%23OneBusAway--iPhone-green.svg)](https://kiwiirc.com/client/irc.freenode.net/?nick=obauser|?&theme=basic#OneBusAway-iPhone)
 
 ## Test latest development release
 


### PR DESCRIPTION
Does not appear to be used & Gitter looks to be much better.