### PR TITLE
Automatically opt in all OBA view controllers to analytics reporting

### DIFF
--- a/OBAApplicationDelegate.m
+++ b/OBAApplicationDelegate.m
@@ -205,7 +205,7 @@ static NSString *kOBAShowSurveyAlertKey = @"OBASurveyAlertDefaultsKey";
     [GAI sharedInstance].optOut = ![[NSUserDefaults standardUserDefaults] boolForKey:kAllowTracking];
 
     [GAI sharedInstance].trackUncaughtExceptions = YES;
-    [[[GAI sharedInstance] logger] setLogLevel:kGAILogLevelVerbose];
+    [[[GAI sharedInstance] logger] setLogLevel:kGAILogLevelInfo];
 
     //don't report to Google Analytics when developing
 #ifdef DEBUG
@@ -213,6 +213,8 @@ static NSString *kOBAShowSurveyAlertKey = @"OBASurveyAlertDefaultsKey";
 #endif
 
     self.tracker = [[GAI sharedInstance] trackerWithTrackingId:kTrackingId];
+
+    [OBAAnalytics configureVoiceOverStatus];
 
     [self _constructUI];
 

--- a/categories/UIViewController+OBAAnalytics.h
+++ b/categories/UIViewController+OBAAnalytics.h
@@ -1,0 +1,13 @@
+//
+//  UIViewController+OBAAnalytics.h
+//  org.onebusaway.iphone
+//
+//  Created by Aaron Brethorst on 3/26/15.
+//  Copyright (c) 2015 OneBusAway. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface UIViewController (OBAAnalytics)
+
+@end

--- a/categories/UIViewController+OBAAnalytics.m
+++ b/categories/UIViewController+OBAAnalytics.m
@@ -1,0 +1,60 @@
+//
+//  UIViewController+OBAAnalytics.m
+//  org.onebusaway.iphone
+//
+//  Created by Aaron Brethorst on 3/26/15.
+//  Copyright (c) 2015 OneBusAway. All rights reserved.
+//
+
+#import "UIViewController+OBAAnalytics.h"
+#import <objc/runtime.h>
+#import "OBAAnalytics.h"
+
+@implementation UIViewController (OBAAnalytics)
+
+// Adapted from http://nshipster.com/method-swizzling/
++ (void)load {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        Class class = [self class];
+        
+        SEL originalSelector = @selector(viewWillAppear:);
+        SEL swizzledSelector = @selector(oba_viewWillAppear:);
+        
+        Method originalMethod = class_getInstanceMethod(class, originalSelector);
+        Method swizzledMethod = class_getInstanceMethod(class, swizzledSelector);
+        
+        // When swizzling a class method, use the following:
+        // Class class = object_getClass((id)self);
+        // ...
+        // Method originalMethod = class_getClassMethod(class, originalSelector);
+        // Method swizzledMethod = class_getClassMethod(class, swizzledSelector);
+        
+        BOOL didAddMethod =
+        class_addMethod(class,
+                        originalSelector,
+                        method_getImplementation(swizzledMethod),
+                        method_getTypeEncoding(swizzledMethod));
+        
+        if (didAddMethod) {
+            class_replaceMethod(class,
+                                swizzledSelector,
+                                method_getImplementation(originalMethod),
+                                method_getTypeEncoding(originalMethod));
+        } else {
+            method_exchangeImplementations(originalMethod, swizzledMethod);
+        }
+    });
+}
+
+#pragma mark - Method Swizzling
+
+- (void)oba_viewWillAppear:(BOOL)animated {
+    [self oba_viewWillAppear:animated];
+    
+    if ([NSStringFromClass(self.class) hasPrefix:@"OBA"]) {
+        // Not a system class, and therefore something worth tracking.
+        [OBAAnalytics reportViewController:self];
+    }
+}
+@end

--- a/controls/view_controllers/OBAListSelectionViewController.m
+++ b/controls/view_controllers/OBAListSelectionViewController.m
@@ -10,7 +10,7 @@
 
 @implementation OBAListSelectionViewController
 
-#pragma mark Initialization
+#pragma mark - Initialization
 
 - (id)initWithValues:(NSArray*)values selectedIndex:(NSIndexPath*)selectedIndex {
     self = [super initWithStyle:UITableViewStylePlain];
@@ -28,13 +28,7 @@
     self.tableView.backgroundColor = [UIColor whiteColor];
 }
 
-- (void)viewWillAppear:(BOOL)animated {
-    [super viewWillAppear:animated];
-
-    [OBAAnalytics reportViewController:self];
-}
-
-#pragma mark Table view data source
+#pragma mark - Table view data source
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
     return self.values.count;

--- a/controls/view_controllers/OBARequestDrivenTableViewController.m
+++ b/controls/view_controllers/OBARequestDrivenTableViewController.m
@@ -92,8 +92,6 @@
         [self didRefreshEnd];
         [self.tableView reloadData];
     }
-
-    [OBAAnalytics reportViewController:self];
 }
 
 - (void)viewWillDisappear:(BOOL)animated {

--- a/controls/view_controllers/OBATextEditViewController.m
+++ b/controls/view_controllers/OBATextEditViewController.m
@@ -68,8 +68,6 @@
         [self.navigationController setToolbarHidden:YES animated:YES];
         [self.textView becomeFirstResponder];
     }
-
-    [OBAAnalytics reportViewController:self];
 }
 
 - (NSUInteger)supportedInterfaceOrientations {

--- a/org.onebusaway.iphone.xcodeproj/project.pbxproj
+++ b/org.onebusaway.iphone.xcodeproj/project.pbxproj
@@ -181,6 +181,7 @@
 		93AD3698160401EF00BDF03F /* OBAModelDAOUserPreferencesImpl.m in Sources */ = {isa = PBXBuildFile; fileRef = 93AD3695160401EF00BDF03F /* OBAModelDAOUserPreferencesImpl.m */; };
 		93AD369D1604027E00BDF03F /* OBAProgressIndicatorImpl.m in Sources */ = {isa = PBXBuildFile; fileRef = 93AD369B1604027E00BDF03F /* OBAProgressIndicatorImpl.m */; };
 		93AD36A3160402C000BDF03F /* OBASearchResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 93AD36A1160402C000BDF03F /* OBASearchResult.m */; };
+		93B32FF31AC4912F001DC177 /* UIViewController+OBAAnalytics.m in Sources */ = {isa = PBXBuildFile; fileRef = 93B32FF21AC4912F001DC177 /* UIViewController+OBAAnalytics.m */; };
 		93E0954719CE051700A31BA6 /* OBALaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 93E0954619CE051700A31BA6 /* OBALaunchScreen.xib */; };
 		93F152F61A9AE91A0015C141 /* OneBusAway_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 93F152F51A9AE91A0015C141 /* OneBusAway_Tests.m */; };
 		93F153001A9AE9740015C141 /* OBAURLHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 93F152FF1A9AE9740015C141 /* OBAURLHelpers.m */; };
@@ -527,6 +528,8 @@
 		93AD36A0160402C000BDF03F /* OBASearchResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBASearchResult.h; sourceTree = "<group>"; };
 		93AD36A1160402C000BDF03F /* OBASearchResult.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBASearchResult.m; sourceTree = "<group>"; };
 		93AD36A8160402FD00BDF03F /* OBANavigationTargetAware.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBANavigationTargetAware.h; sourceTree = "<group>"; };
+		93B32FF11AC4912F001DC177 /* UIViewController+OBAAnalytics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIViewController+OBAAnalytics.h"; sourceTree = "<group>"; };
+		93B32FF21AC4912F001DC177 /* UIViewController+OBAAnalytics.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+OBAAnalytics.m"; sourceTree = "<group>"; };
 		93E0954619CE051700A31BA6 /* OBALaunchScreen.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = OBALaunchScreen.xib; path = Resources/OBALaunchScreen.xib; sourceTree = "<group>"; };
 		93F152F11A9AE91A0015C141 /* OneBusAway Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "OneBusAway Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		93F152F41A9AE91A0015C141 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -695,6 +698,8 @@
 				934446B41AB10E67005B3333 /* UINavigationController+oba_Additions.m */,
 				934446B61AB10ECA005B3333 /* UITableViewCell+oba_Additions.h */,
 				934446B71AB10ECA005B3333 /* UITableViewCell+oba_Additions.m */,
+				93B32FF11AC4912F001DC177 /* UIViewController+OBAAnalytics.h */,
+				93B32FF21AC4912F001DC177 /* UIViewController+OBAAnalytics.m */,
 			);
 			path = categories;
 			sourceTree = "<group>";
@@ -1457,6 +1462,7 @@
 				934446C31AB11066005B3333 /* OBAMapRegionManager.m in Sources */,
 				934446591AB108BF005B3333 /* OBAHasReferencesV2.m in Sources */,
 				93AD36A3160402C000BDF03F /* OBASearchResult.m in Sources */,
+				93B32FF31AC4912F001DC177 /* UIViewController+OBAAnalytics.m in Sources */,
 				934446701AB108BF005B3333 /* OBATripStopTimeV2.m in Sources */,
 				932BE49F1AB66D320011F2FB /* OBAInfoViewController.m in Sources */,
 				934446DA1AB12C5D005B3333 /* OBAProgressIndicatorView.m in Sources */,

--- a/ui/bookmarks/OBABookmarksViewController.m
+++ b/ui/bookmarks/OBABookmarksViewController.m
@@ -63,8 +63,6 @@
     // We reload the table here in case we are coming back from the user editing the label for a bookmark
     [self _refreshBookmarks];
     [self.tableView reloadData];
-
-    [OBAAnalytics reportViewController:self];
 }
 
 - (id)objectAtRow:(NSInteger)row {

--- a/ui/bookmarks/OBAEditStopBookmarkGroupViewController.m
+++ b/ui/bookmarks/OBAEditStopBookmarkGroupViewController.m
@@ -40,8 +40,6 @@
     
     [self _refreshGroups];
     [self.tableView reloadData];
-
-    [OBAAnalytics reportViewController:self];
 }
 
 - (void)onDoneButton:(id)sender {

--- a/ui/bookmarks/OBAEditStopBookmarkViewController.m
+++ b/ui/bookmarks/OBAEditStopBookmarkViewController.m
@@ -103,8 +103,6 @@
                       }
                   }];
     }
-
-    [OBAAnalytics reportViewController:self];
 }
 
 #pragma mark - Table view methods

--- a/ui/info/OBAAgenciesListViewController.m
+++ b/ui/info/OBAAgenciesListViewController.m
@@ -45,8 +45,6 @@ typedef NS_ENUM(NSInteger, OBASectionType) {
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
     [self refresh];
-
-    [OBAAnalytics reportViewController:self];
 }
 
 - (BOOL)isLoading {

--- a/ui/info/OBAContactUsViewController.m
+++ b/ui/info/OBAContactUsViewController.m
@@ -73,15 +73,6 @@ static NSString *kOBADefaultTwitterURL = @"http://twitter.com/onebusaway";
     self.tableView.backgroundColor = [UIColor whiteColor];
 }
 
-- (void)viewWillAppear:(BOOL)animated {
-    [super viewWillAppear:animated];
-    [OBAAnalytics reportViewController:self];
-}
-
-- (void)viewWillDisappear:(BOOL)animated {
-    [super viewWillDisappear:animated];
-}
-
 #pragma mark Table view methods
 
 // Customize the number of rows in the table view.

--- a/ui/info/OBACreditsViewController.m
+++ b/ui/info/OBACreditsViewController.m
@@ -31,12 +31,6 @@
     [self.webView loadHTMLString:htmlString baseURL:[NSURL fileURLWithPath:[NSBundle mainBundle].bundlePath]];
 }
 
-- (void)viewWillAppear:(BOOL)animated {
-    [super viewWillAppear:animated];
-
-    [OBAAnalytics reportViewController:self];
-}
-
 #pragma mark - UIWebViewDelegate
 
 - (BOOL)webView:(UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)navigationType {

--- a/ui/info/OBACustomApiViewController.m
+++ b/ui/info/OBACustomApiViewController.m
@@ -50,12 +50,6 @@ typedef NS_ENUM(NSInteger, OBASectionType) {
     [self hideEmptySeparators];
 }
 
-- (void)viewWillAppear:(BOOL)animated {
-    [super viewWillAppear:animated];
-
-    [OBAAnalytics reportViewController:self];
-}
-
 - (void)viewWillDisappear:(BOOL)animated {
     [super viewWillDisappear:animated];
     [self saveCustomApiUrl];

--- a/ui/info/OBAInfoViewController.m
+++ b/ui/info/OBAInfoViewController.m
@@ -44,11 +44,6 @@
     self.tableView.frame = self.view.bounds;
 }
 
-- (void)viewWillAppear:(BOOL)animated {
-    [super viewWillAppear:animated];
-    [OBAAnalytics reportViewController:self];
-}
-
 - (void) openContactUs {
     UIViewController *pushMe = nil;
     pushMe = [[OBAContactUsViewController alloc] init];

--- a/ui/info/OBARegionListViewController.m
+++ b/ui/info/OBARegionListViewController.m
@@ -83,8 +83,6 @@ typedef NS_ENUM(NSInteger, OBASectionType) {
     else {
         _locationTimedOut = YES;
     }
-
-    [OBAAnalytics reportViewController:self];
 }
 
 - (void)viewWillDisappear:(BOOL)animated {

--- a/ui/info/OBASettingsViewController.m
+++ b/ui/info/OBASettingsViewController.m
@@ -56,8 +56,6 @@ static NSString * kOBAIncreaseContrastKey = @"OBAIncreaseContrastDefaultsKey";
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:YES];
     [self.tableView reloadData];
-
-    [OBAAnalytics reportViewController:self];
 }
 
 - (void)didReceiveMemoryWarning

--- a/ui/recent_stops/OBARecentStopsViewController.m
+++ b/ui/recent_stops/OBARecentStopsViewController.m
@@ -46,8 +46,6 @@
     OBAModelDAO * modelDao = _appDelegate.modelDao;    
     _mostRecentStops = modelDao.mostRecentStops;
     [self.tableView reloadData];
-
-    [OBAAnalytics reportViewController:self];
 }
 
 - (void)viewWillDisappear:(BOOL)animated {

--- a/ui/search/OBASearchResultsListViewController.m
+++ b/ui/search/OBASearchResultsListViewController.m
@@ -60,8 +60,6 @@
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
     [self reloadData];
-
-    [OBAAnalytics reportViewController:self];
 }
 
 - (void)viewWillDisappear:(BOOL)animated {

--- a/ui/search/OBASearchResultsMapViewController.m
+++ b/ui/search/OBASearchResultsMapViewController.m
@@ -309,8 +309,6 @@ static NSString *kOBAIncreaseContrastKey = @"OBAIncreaseContrastDefaultsKey";
     if (self.searchController.unfilteredSearch) {
         [self refreshStopsInRegion];
     }
-
-    [OBAAnalytics reportViewController:self];
 }
 
 - (void)viewWillDisappear:(BOOL)animated {

--- a/ui/situations/OBASituationViewController.m
+++ b/ui/situations/OBASituationViewController.m
@@ -73,12 +73,6 @@ typedef NS_ENUM(NSInteger, OBASectionType) {
     self.tableView.backgroundColor = [UIColor whiteColor];
 }
 
-- (void)viewWillAppear:(BOOL)animated {
-    [super viewWillAppear:animated];
-
-    [OBAAnalytics reportViewController:self];
-}
-
 #pragma mark - Table view data source
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {

--- a/ui/situations/OBASituationsViewController.m
+++ b/ui/situations/OBASituationsViewController.m
@@ -51,12 +51,6 @@
     [self hideEmptySeparators];
 }
 
-- (void)viewWillAppear:(BOOL)animated {
-    [super viewWillAppear:animated];
-
-    [OBAAnalytics reportViewController:self];
-}
-
 #pragma mark - View lifecycle
 
 #pragma mark - Table view data source

--- a/ui/stop_details/OBAGenericStopViewController.m
+++ b/ui/stop_details/OBAGenericStopViewController.m
@@ -308,11 +308,6 @@ static NSString *kOBASurveyURL = @"http://tinyurl.com/stopinfo";
         if (self.showSurveyAlert) {
             [self showSurveyPopup];
         }
-        
-    }
-
-    if (UIAccessibilityIsVoiceOverRunning()) {
-        [OBAAnalytics reportEventWithCategory:OBAAnalyticsCategoryAccessibility action:@"voiceover_on" label:@"Loaded StopInfo with VoiceOver" value:nil];
     }
 }
 
@@ -446,12 +441,6 @@ static NSString *kOBASurveyURL = @"http://tinyurl.com/stopinfo";
     self.navigationItem.title = @"Stop";
 
     [self refresh];
-
-    [OBAAnalytics reportViewController:self];
-
-    if (UIAccessibilityIsVoiceOverRunning()) {
-        [OBAAnalytics reportEventWithCategory:OBAAnalyticsCategoryAccessibility action:@"voiceover_on" label:[NSString stringWithFormat:@"Loaded view: %@ using VoiceOver", [self class]] value:nil];
-    }
 }
 
 - (void)viewWillDisappear:(BOOL)animated {

--- a/ui/stop_details/OBAReportProblemViewController.m
+++ b/ui/stop_details/OBAReportProblemViewController.m
@@ -31,12 +31,6 @@
     [self hideEmptySeparators];
 }
 
-- (void)viewWillAppear:(BOOL)animated {
-    [super viewWillAppear:animated];
-
-    [OBAAnalytics reportViewController:self];
-}
-
 #pragma mark - Table view data source
 
 - (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section

--- a/ui/stop_details/OBAReportProblemWithStopViewController.m
+++ b/ui/stop_details/OBAReportProblemWithStopViewController.m
@@ -68,12 +68,6 @@ typedef NS_ENUM(NSInteger, OBASectionType) {
     [self hideEmptySeparators];
 }
 
-- (void)viewWillAppear:(BOOL)animated {
-    [super viewWillAppear:animated];
-
-    [OBAAnalytics reportViewController:self];
-}
-
 #pragma mark Table view methods
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {

--- a/ui/trip_details/OBAArrivalAndDepartureViewController.m
+++ b/ui/trip_details/OBAArrivalAndDepartureViewController.m
@@ -51,12 +51,6 @@ typedef NS_ENUM(NSInteger, OBASectionType) {
     self.tableView.backgroundColor = [UIColor whiteColor];
 }
 
-- (void)viewWillAppear:(BOOL)animated {
-    [super viewWillAppear:animated];
-
-    [OBAAnalytics reportViewController:self];
-}
-
 - (id)initWithApplicationDelegate:(OBAApplicationDelegate *)appDelegate arrivalAndDeparture:(OBAArrivalAndDepartureV2 *)arrivalAndDeparture {
     self = [self initWithApplicationDelegate:appDelegate arrivalAndDepartureInstance:arrivalAndDeparture.instance];
     _arrivalAndDeparture = arrivalAndDeparture;

--- a/ui/trip_details/OBAReportProblemWithTripViewController.m
+++ b/ui/trip_details/OBAReportProblemWithTripViewController.m
@@ -83,12 +83,6 @@ typedef NS_ENUM(NSInteger, OBASectionType) {
     [self hideEmptySeparators];
 }
 
-- (void)viewWillAppear:(BOOL)animated {
-    [super viewWillAppear:animated];
-
-    [OBAAnalytics reportViewController:self];
-}
-
 #pragma mark Table view methods
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {

--- a/ui/trip_details/OBATripDetailsViewController.m
+++ b/ui/trip_details/OBATripDetailsViewController.m
@@ -51,12 +51,6 @@ typedef NS_ENUM(NSInteger, OBASectionType) {
     self.tableView.backgroundColor = [UIColor whiteColor];
 }
 
-- (void)viewWillAppear:(BOOL)animated {
-    [super viewWillAppear:animated];
-
-    [OBAAnalytics reportViewController:self];
-}
-
 - (BOOL)isLoading {
     return self.tripDetails == nil;
 }

--- a/ui/trip_details/OBATripScheduleListViewController.m
+++ b/ui/trip_details/OBATripScheduleListViewController.m
@@ -122,8 +122,6 @@ typedef NS_ENUM(NSInteger, OBASectionType) {
     else {
         [self handleTripDetails];
     }
-
-    [OBAAnalytics reportViewController:self];
 }
 
 #pragma mark - Table view data source

--- a/ui/trip_details/OBATripScheduleMapViewController.m
+++ b/ui/trip_details/OBATripScheduleMapViewController.m
@@ -88,8 +88,6 @@ static const NSString *kShapeContext = @"ShapeContext";
     else {
         [self handleTripDetails];
     }
-
-    [OBAAnalytics reportViewController:self];
 }
 
 - (void)showList:(id)source {

--- a/ui/trip_details/OBAVehicleDetailsController.m
+++ b/ui/trip_details/OBAVehicleDetailsController.m
@@ -42,12 +42,6 @@ typedef NS_ENUM(NSInteger, OBASectionType) {
     self.tableView.backgroundColor = [UIColor whiteColor];
 }
 
-- (void)viewWillAppear:(BOOL)animated {
-    [super viewWillAppear:animated];
-
-    [OBAAnalytics reportViewController:self];
-}
-
 - (BOOL)isLoading {
     return _vehicleStatus == nil;
 }

--- a/utilities/OBAAnalytics.h
+++ b/utilities/OBAAnalytics.h
@@ -18,7 +18,12 @@ extern NSString * const OBAAnalyticsCategoryAccessibility;
 extern NSString * const OBAAnalyticsCategorySubmit;
 
 @interface OBAAnalytics : NSObject
++ (void)configureVoiceOverStatus;
 + (void)reportEventWithCategory:(NSString *)category action:(NSString*)action label:(NSString*)label value:(id)value;
 + (void)reportScreenView:(NSString *)label;
+
+// This is automatically called for every view controller whose class name is prefixed with "OBA"
+// e.g. OBAGenericStopViewController, but not UINavigationController.
+// This is accomplished through method swizzling. See UIViewController+OBAAnalytics.
 + (void)reportViewController:(UIViewController*)viewController;
 @end

--- a/utilities/OBAAnalytics.m
+++ b/utilities/OBAAnalytics.m
@@ -19,7 +19,16 @@ NSString * const OBAAnalyticsCategoryUIAction = @"ui_action";
 NSString * const OBAAnalyticsCategoryAccessibility = @"accessibility";
 NSString * const OBAAnalyticsCategorySubmit = @"submit";
 
+NSInteger const OBAnalyticsDimensionVoiceOver = 4;
+
 @implementation OBAAnalytics
+
++ (void)configureVoiceOverStatus {
+    if (UIAccessibilityIsVoiceOverRunning()) {
+        NSString *dimensionValue = @"VoiceOver: ON";
+        [[GAI sharedInstance].defaultTracker set:[GAIFields customDimensionForIndex:OBAnalyticsDimensionVoiceOver] value:dimensionValue];
+    }
+}
 
 + (void)reportEventWithCategory:(NSString *)category action:(NSString*)action label:(NSString*)label value:(id)value {
     [[GAI sharedInstance].defaultTracker send:[[GAIDictionaryBuilder createEventWithCategory:category action:action label:label value:value] build]];


### PR DESCRIPTION
I'm WFH and—while eating lunch—was thinking about how we could use method swizzling to simplify our analytics approach. Turns out to be really straightforward, and took me less time to implement than it did to eat :)

- Replace -viewWillAppear: implementations of analytics screen tracking with a method swizzling approach.
- Add VoiceOver tracking to the -reportViewController: analytics method so that we can accurately see all VoiceOver usage of the app.