### PR TITLE
WIP: fix prompt for region when errors w/ location

### DIFF
--- a/OBAApplicationDelegate.m
+++ b/OBAApplicationDelegate.m
@@ -82,7 +82,6 @@ static NSString *kOBAShowSurveyAlertKey = @"OBASurveyAlertDefaultsKey";
 }
 
 - (void)refreshSettings {
-    
     NSUserDefaults * userDefaults = [NSUserDefaults standardUserDefaults];
     NSString * apiServerName = nil;
 	if([self.modelDao.readCustomApiUrl isEqualToString:@""]) {
@@ -93,7 +92,6 @@ static NSString *kOBAShowSurveyAlertKey = @"OBASurveyAlertDefaultsKey";
         }
         else {
             self.regionHelper = [[OBARegionHelper alloc] init];
-            [self.modelDao writeSetRegionAutomatically:YES];
             [self.regionHelper updateNearestRegion];
             apiServerName = [NSString stringWithFormat:@"http://%@",apiServerName];
         }

--- a/location/OBALocationManager.m
+++ b/location/OBALocationManager.m
@@ -35,6 +35,9 @@ static const NSTimeInterval kSuccessiveLocationComparisonWindow = 3;
         _locationManager.delegate = self;
         _delegates = [[NSMutableArray alloc] init];
         
+        if (![self hasRequestedInUseAuthorization]) {
+            [self requestInUseAuthorization];
+        }
     }
     return self;
 }
@@ -75,7 +78,7 @@ static const NSTimeInterval kSuccessiveLocationComparisonWindow = 3;
 #pragma mark - iOS 8 Location Manager Support
 
 - (BOOL)hasRequestedInUseAuthorization {
-    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"8.0")) {
+    if ([CLLocationManager respondsToSelector:@selector(authorizationStatus)]) {
         return [CLLocationManager authorizationStatus] != kCLAuthorizationStatusNotDetermined;
     }
     else {
@@ -84,8 +87,8 @@ static const NSTimeInterval kSuccessiveLocationComparisonWindow = 3;
 }
 
 - (void)requestInUseAuthorization {
-    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"8.0")) {
-        [_locationManager performSelector:@selector(requestWhenInUseAuthorization) withObject:nil];
+    if ([_locationManager respondsToSelector:@selector(requestWhenInUseAuthorization)]) {
+        [_locationManager requestWhenInUseAuthorization];
     }
 }
 

--- a/ui/search/OBASearchResultsMapViewController.m
+++ b/ui/search/OBASearchResultsMapViewController.m
@@ -236,13 +236,8 @@ static NSString *kOBAIncreaseContrastKey = @"OBAIncreaseContrastDefaultsKey";
 
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
-
-    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"8.0")) {
-        if (![APP_DELEGATE.locationManager hasRequestedInUseAuthorization]) {
-            [APP_DELEGATE.locationManager requestInUseAuthorization];
-        }
-    }
-    else {
+    
+    if (!SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"8.0")) {
         self.mapView.showsUserLocation = YES;
     }
 }


### PR DESCRIPTION
fixes #408: It appears using the simulator the app does not properly prompt you for your region which then results in errors.

Steps to test:
1. Open simulator & set location to None
2. Delete app
3. Install & run app

- [x] prompt for region when app runs with no region set and location cannot be aquired
- [x] do not prompt for region on subsequent app launches if region is set and location cannot be aquired
- [ ] fix bug introduced where on first run it always asks for user to select a region
- [ ] Merge https://github.com/OneBusAway/onebusaway-iphone/pull/410