### PR TITLE
Changing title causes UI error

### DIFF
--- a/ui/search/OBASearchResultsMapViewController.m
+++ b/ui/search/OBASearchResultsMapViewController.m
@@ -488,7 +488,6 @@ static NSString *kOBAIncreaseContrastKey = @"OBAIncreaseContrastDefaultsKey";
         }
 
         self.hideFutureNetworkErrors = YES;
-        self.navigationItem.title = NSLocalizedString(@"Error connecting", @"self.navigationItem.title");
 
         UIAlertView *view = [[UIAlertView alloc] init];
         view.tag = 1;


### PR DESCRIPTION
If a network error occurs while looking at the map, once you regain
connection and stops load, once you go to look at an individual stop,
the back navigation button title is "Error connecting" instead of "Map"