### PR TITLE
iOS 8-ification of OneBusAway

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.3.2</string>
+	<string>2.4.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/OBAApplicationDelegate.m
+++ b/OBAApplicationDelegate.m
@@ -179,13 +179,10 @@ static NSString *kOBAShowSurveyAlertKey = @"OBASurveyAlertDefaultsKey";
     [[UINavigationBar appearance] setTintColor:tintColor];
     [[UISearchBar appearance] setTintColor:tintColor];
     [[UISegmentedControl appearance] setTintColor:tintColor];
-    [[UITabBar appearance] setSelectedImageTintColor:tintColor];
-    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"7.0")) {
-        [[UITabBar appearance] setTintColor:tintColor];
-        [[UITextField appearance] setTintColor:tintColor];
-        [[UISegmentedControl appearance] setTitleTextAttributes:@{UITextAttributeTextColor: [UIColor whiteColor]} forState:UIControlStateNormal];
-        [[UISegmentedControl appearance] setTitleTextAttributes:@{UITextAttributeTextColor: [UIColor whiteColor]} forState:UIControlStateSelected];
-    }
+    [[UITabBar appearance] setTintColor:tintColor];
+    [[UITextField appearance] setTintColor:tintColor];
+    [[UISegmentedControl appearance] setTitleTextAttributes:@{NSForegroundColorAttributeName: [UIColor whiteColor]} forState:UIControlStateNormal];
+    [[UISegmentedControl appearance] setTitleTextAttributes:@{NSForegroundColorAttributeName: [UIColor whiteColor]} forState:UIControlStateSelected];
     
     self.window.rootViewController = self.tabBarController;
     

--- a/Podfile
+++ b/Podfile
@@ -1,7 +1,7 @@
-platform :ios, '6.0'
+platform :ios, '8.0'
 
 link_with 'OneBusAway', 'OneBusAway Tests'
-pod 'TWSReleaseNotesView', :inhibit_warnings => true
-pod 'GoogleAnalytics-iOS-SDK'
-pod 'MarqueeLabel'
-pod 'libextobjc'
+pod 'TWSReleaseNotesView', '1.2.0', :inhibit_warnings => true
+pod 'GoogleAnalytics-iOS-SDK', '3.11'
+pod 'MarqueeLabel', '2.2.3'
+pod 'libextobjc', '0.4.1'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -41,10 +41,10 @@ PODS:
   - TWSReleaseNotesView (1.2.0)
 
 DEPENDENCIES:
-  - GoogleAnalytics-iOS-SDK
-  - libextobjc
-  - MarqueeLabel
-  - TWSReleaseNotesView
+  - GoogleAnalytics-iOS-SDK (= 3.11)
+  - libextobjc (= 0.4.1)
+  - MarqueeLabel (= 2.2.3)
+  - TWSReleaseNotesView (= 1.2.0)
 
 SPEC CHECKSUMS:
   GoogleAnalytics-iOS-SDK: fb15cc7e3d01d06d531653f37443fda90274d53d

--- a/Pods/Manifest.lock
+++ b/Pods/Manifest.lock
@@ -41,10 +41,10 @@ PODS:
   - TWSReleaseNotesView (1.2.0)
 
 DEPENDENCIES:
-  - GoogleAnalytics-iOS-SDK
-  - libextobjc
-  - MarqueeLabel
-  - TWSReleaseNotesView
+  - GoogleAnalytics-iOS-SDK (= 3.11)
+  - libextobjc (= 0.4.1)
+  - MarqueeLabel (= 2.2.3)
+  - TWSReleaseNotesView (= 1.2.0)
 
 SPEC CHECKSUMS:
   GoogleAnalytics-iOS-SDK: fb15cc7e3d01d06d531653f37443fda90274d53d

--- a/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,540 +7,540 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		064D76A156F89034221DFE5F /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 399990AC96682209B07EF313 /* QuartzCore.framework */; };
-		0886B8CC116202D56C4C7EF8 /* NSMethodSignature+EXT.h in Headers */ = {isa = PBXBuildFile; fileRef = CAC72303EDCF1D4F028D0C47 /* NSMethodSignature+EXT.h */; };
-		0AA81BF58DA770C17C4B4AD7 /* extobjc.h in Headers */ = {isa = PBXBuildFile; fileRef = 0122AB02BD9E9AF52A569D53 /* extobjc.h */; };
-		0CF45B9E64E565849CE8314A /* Pods-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = EE6D08611DBE0F3D3FAFFD21 /* Pods-dummy.m */; };
-		136CFB10847379341FD454C7 /* EXTSelectorChecking.m in Sources */ = {isa = PBXBuildFile; fileRef = 19D81FB9CF98871D9603DB05 /* EXTSelectorChecking.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		26E639A382FD739E9D0EB046 /* EXTSafeCategory.h in Headers */ = {isa = PBXBuildFile; fileRef = DDD6E8721A172E989214C1CD /* EXTSafeCategory.h */; };
-		2F629A85B508E42EA03AD17B /* TWSReleaseNotesDownloadOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B1914E63CA74A4981152DE89 /* TWSReleaseNotesDownloadOperation.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
-		31A401E2B4D43F102B4664D0 /* MarqueeLabel.h in Headers */ = {isa = PBXBuildFile; fileRef = 64B4D83D8D95A92DACD68CB0 /* MarqueeLabel.h */; };
-		33B1C19125019F7687E1422C /* Pods-libextobjc-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = F6E00B072FD12A1DFA537DEC /* Pods-libextobjc-dummy.m */; };
-		35FBD641301C99FF4F6CC86A /* Pods-TWSReleaseNotesView-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0C5BB562BE8749173D6856F6 /* Pods-TWSReleaseNotesView-dummy.m */; };
-		3826504A16D23E599134AD04 /* EXTConcreteProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E8539001D52DC5738A9267B /* EXTConcreteProtocol.h */; };
-		473ABB64D075DFCCB6CFE14C /* EXTSafeCategory.m in Sources */ = {isa = PBXBuildFile; fileRef = B901F7CE5F4F3F437F04AEF4 /* EXTSafeCategory.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		4B2A89ECCEFB29E2089FABB0 /* UIImage+ImageEffects.h in Headers */ = {isa = PBXBuildFile; fileRef = B21C3C2345FC4E2C1D578466 /* UIImage+ImageEffects.h */; };
-		50D59143EB31B81BEC94D834 /* TWSReleaseNotesView.h in Headers */ = {isa = PBXBuildFile; fileRef = E43AF682E326B35D9EF80A2B /* TWSReleaseNotesView.h */; };
-		568D1B2C61C108D5B7759035 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 399990AC96682209B07EF313 /* QuartzCore.framework */; };
-		633524DBE1E4E45BCA7FC00F /* metamacros.h in Headers */ = {isa = PBXBuildFile; fileRef = C158A6D65D6732E444FB5B10 /* metamacros.h */; };
-		786C531B4FF96B035D470347 /* EXTSelectorChecking.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D6CA4E10F0D0C815D8A1AFA /* EXTSelectorChecking.h */; };
-		7BE0558286E348A6AE6A3DC6 /* NSInvocation+EXT.h in Headers */ = {isa = PBXBuildFile; fileRef = D7DE3D10150B47E8B379E7F1 /* NSInvocation+EXT.h */; };
-		81E2602B2263896493A3A40F /* NSInvocation+EXT.m in Sources */ = {isa = PBXBuildFile; fileRef = 02C654C1959919780FDA8A44 /* NSInvocation+EXT.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		83F74F20DD0E256685483CAD /* EXTNil.m in Sources */ = {isa = PBXBuildFile; fileRef = ACE6B56DE6E04B4A39B42970 /* EXTNil.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		87CD0002AB74E4649C5C1B97 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BCB9C02C2108124F3B3423A0 /* Accelerate.framework */; };
-		887E16A59B8F16413F633465 /* TWSReleaseNotesDownloadOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = F059398EE8115F55752F2E80 /* TWSReleaseNotesDownloadOperation.h */; };
-		8F114E3E275C1AFA8B4C3671 /* NSMethodSignature+EXT.m in Sources */ = {isa = PBXBuildFile; fileRef = 33CD191D3924727035FE0E99 /* NSMethodSignature+EXT.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		8F9594642E468AD5324BB650 /* EXTADT.m in Sources */ = {isa = PBXBuildFile; fileRef = 75828C2AAD933C5E103283DD /* EXTADT.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		91BD743F5A67C2FA4F44A1D3 /* EXTKeyPathCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = 0708CB8733750540B013C54E /* EXTKeyPathCoding.h */; };
-		91BE897F68853592DB28551A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 62387927BD1522C7BA2E9149 /* Foundation.framework */; };
-		96A72230F5565B280873E7A9 /* UIImage+ImageEffects.m in Sources */ = {isa = PBXBuildFile; fileRef = AAF3BCE6713BDBCAC3E7E16C /* UIImage+ImageEffects.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
-		989F1337C97C4D3A4924EDA4 /* EXTConcreteProtocol.m in Sources */ = {isa = PBXBuildFile; fileRef = BB61F1C8C1C396162A69B3FB /* EXTConcreteProtocol.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		9D6160ED476D14707F187BD6 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 62387927BD1522C7BA2E9149 /* Foundation.framework */; };
-		A2F6D96DD114284E88D161A9 /* EXTRuntimeExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8D5EAAAC683D699499CEE8CE /* EXTRuntimeExtensions.h */; };
-		AE634BF46D25C1B197F9B6F8 /* Pods-MarqueeLabel-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = B9768AB9A92B8342E52B2F89 /* Pods-MarqueeLabel-dummy.m */; };
-		B120E7230897C7D3B4B3E22B /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 13F7E200BE3D8AD202C96A32 /* CoreGraphics.framework */; };
-		B19357B331DB8A28A57094D5 /* TWSReleaseNotesView.m in Sources */ = {isa = PBXBuildFile; fileRef = 2E768BBD17893D8DE4E1CC2B /* TWSReleaseNotesView.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
-		B1EAF26B8C5E656C54239B75 /* EXTNil.h in Headers */ = {isa = PBXBuildFile; fileRef = 5937B59655EAA0FE69CEB7F7 /* EXTNil.h */; };
-		BC96A1AD6001C8054A80B37C /* EXTSynthesize.h in Headers */ = {isa = PBXBuildFile; fileRef = C8BF6EE17A970EABD5968CD8 /* EXTSynthesize.h */; };
-		BF429EC357A420E181D3829A /* EXTScope.h in Headers */ = {isa = PBXBuildFile; fileRef = 601D4425CD17071C7BE209DB /* EXTScope.h */; };
-		CFE1BA87EDF24BBF2C0FDBB0 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 62387927BD1522C7BA2E9149 /* Foundation.framework */; };
-		D3B37797F09D4B5940D4A7F7 /* EXTRuntimeExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = EBCE9E010602D0D9165C816A /* EXTRuntimeExtensions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		D54EAB4CB902B0B0554FEC29 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B41057719D7136A10AAE7F0A /* UIKit.framework */; };
-		DED8AA60288F2DC77F4B0A10 /* MarqueeLabel.m in Sources */ = {isa = PBXBuildFile; fileRef = 4034B27752498C70FF401731 /* MarqueeLabel.m */; };
-		E0650A0ABDAF80154D4B3935 /* EXTADT.h in Headers */ = {isa = PBXBuildFile; fileRef = 73BCBF10ADB78F20960DE534 /* EXTADT.h */; };
-		E15C90F37294EE615A47F80B /* EXTScope.m in Sources */ = {isa = PBXBuildFile; fileRef = 09B722D97579A71450045F37 /* EXTScope.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		E9D54A3DCE7328C47122A620 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 62387927BD1522C7BA2E9149 /* Foundation.framework */; };
+		178915188B014556ED55FD08 /* Pods-libextobjc-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FAE56AFDA92571CFCC4E6F3 /* Pods-libextobjc-dummy.m */; };
+		1B2A95244AD2DA3F2AB5C4C9 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C69F07D43498D1C322D58647 /* Foundation.framework */; };
+		237B0FD66A2A82F06A958831 /* EXTConcreteProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 1008DD84732663CC3F8933B6 /* EXTConcreteProtocol.h */; };
+		2ACDE089F5264D8B1709CEBC /* EXTSynthesize.h in Headers */ = {isa = PBXBuildFile; fileRef = C02B9EE3BC92A6AC605F5C25 /* EXTSynthesize.h */; };
+		2F76ADB9E48ADD1FF02E6831 /* EXTNil.h in Headers */ = {isa = PBXBuildFile; fileRef = C4BD07DB4DE5C0812798CC6D /* EXTNil.h */; };
+		31BA04C74D164BFDA68C0207 /* EXTRuntimeExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D4DB67FF764EB4F3C5CCC47 /* EXTRuntimeExtensions.h */; };
+		3E0132154407390FBC265616 /* EXTADT.h in Headers */ = {isa = PBXBuildFile; fileRef = 69AC7035759423D160885BAE /* EXTADT.h */; };
+		406F30285E5F1FA8A3E5BF46 /* UIImage+ImageEffects.h in Headers */ = {isa = PBXBuildFile; fileRef = 39A0A583D34A3B8B54E22374 /* UIImage+ImageEffects.h */; };
+		419D5B8CD593F36C33EDE537 /* NSMethodSignature+EXT.h in Headers */ = {isa = PBXBuildFile; fileRef = 65F72378D4FC1F9727A94E6D /* NSMethodSignature+EXT.h */; };
+		44B18D488716AAC17D76DF3A /* EXTScope.m in Sources */ = {isa = PBXBuildFile; fileRef = 015184D163D3755FD5D0C5B9 /* EXTScope.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		48C752E8E1B97C22815F2C2F /* extobjc.h in Headers */ = {isa = PBXBuildFile; fileRef = D4E97C7719AD5C6BD100E11C /* extobjc.h */; };
+		529ACD25F0FB7E5E2463695D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C69F07D43498D1C322D58647 /* Foundation.framework */; };
+		53592C1F3D855B4C4DF5AB0C /* EXTSelectorChecking.h in Headers */ = {isa = PBXBuildFile; fileRef = 912B3F7F48B223381E8D4597 /* EXTSelectorChecking.h */; };
+		586AE409A6CFBBA59CDD1F9E /* EXTNil.m in Sources */ = {isa = PBXBuildFile; fileRef = 3DC8DAC82EE9D94C808B33B2 /* EXTNil.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		58F8CBC5826DF56BFDCBDEE2 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8EA3DA92F4ED4A0233E5519E /* QuartzCore.framework */; };
+		5A5042A7EE7263B7B2F7528A /* TWSReleaseNotesView.h in Headers */ = {isa = PBXBuildFile; fileRef = DC9B6CF1037DB7F2267CB6C9 /* TWSReleaseNotesView.h */; };
+		621ED145912749E968D8138B /* EXTConcreteProtocol.m in Sources */ = {isa = PBXBuildFile; fileRef = FE7A63ADB9006ADDFDFBF66F /* EXTConcreteProtocol.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		6EB59EE836C1A46C04590237 /* TWSReleaseNotesDownloadOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 392470CCC81916956294990A /* TWSReleaseNotesDownloadOperation.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
+		8B447B52D033550F94F768E9 /* EXTScope.h in Headers */ = {isa = PBXBuildFile; fileRef = AD912E7212E24F137F58FAD6 /* EXTScope.h */; };
+		8D4CC136B22CEADD4F280C49 /* Pods-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = C45BAF949438C831A1B5355E /* Pods-dummy.m */; };
+		8E42057D3FB037ECAA32AA8E /* NSInvocation+EXT.m in Sources */ = {isa = PBXBuildFile; fileRef = A365214D5338564459A1F649 /* NSInvocation+EXT.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		91123F2D9A357DBD86FECCCD /* TWSReleaseNotesView.m in Sources */ = {isa = PBXBuildFile; fileRef = 2FBE084B8A7D3A0635F7DA68 /* TWSReleaseNotesView.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
+		97ADDA189148B5DD43DB805E /* EXTADT.m in Sources */ = {isa = PBXBuildFile; fileRef = 26B2B0345486422841F5377A /* EXTADT.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		98A2D4569400276ACF451C44 /* Pods-MarqueeLabel-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 4579799711C11E659F46F72A /* Pods-MarqueeLabel-dummy.m */; };
+		997475F15BA74FF553F81CCA /* EXTRuntimeExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = D3A623C49D4E1B61D3317818 /* EXTRuntimeExtensions.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		A752DF1183C683F310E937A3 /* EXTKeyPathCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = 88B856D1185DB4A9579950B5 /* EXTKeyPathCoding.h */; };
+		A8DB5D8BBA34269B35AC0535 /* Pods-TWSReleaseNotesView-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 239B232F5243EAFC70F9B50E /* Pods-TWSReleaseNotesView-dummy.m */; };
+		AADAACDFF5D72A0DE61DB602 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6514539EE85CB6F4E80DCE74 /* CoreGraphics.framework */; };
+		B263B250FC8360130591DB25 /* NSMethodSignature+EXT.m in Sources */ = {isa = PBXBuildFile; fileRef = FDA2F5E258BF7A9BAC0F0ABA /* NSMethodSignature+EXT.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		C5432D21B7ED0539A9319870 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C69F07D43498D1C322D58647 /* Foundation.framework */; };
+		C72209938DC877016BFCA1C8 /* metamacros.h in Headers */ = {isa = PBXBuildFile; fileRef = E830350106B6C4D34BA446D1 /* metamacros.h */; };
+		C73FC113B8E89838243D595D /* TWSReleaseNotesDownloadOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 6AB2FD3D822405055946ED65 /* TWSReleaseNotesDownloadOperation.h */; };
+		C9D239B5596EAB63DC249E1D /* UIImage+ImageEffects.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EABDB738D2C395520473315 /* UIImage+ImageEffects.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
+		CCD83C76F7759E1CB6DF9F99 /* EXTSafeCategory.m in Sources */ = {isa = PBXBuildFile; fileRef = AE4BF29B282541CB79E5665F /* EXTSafeCategory.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		D168EFEA468154C519508F76 /* MarqueeLabel.h in Headers */ = {isa = PBXBuildFile; fileRef = 0C846AC391E7ABD748856AD3 /* MarqueeLabel.h */; };
+		D5A62F93CFC0ADA2C323A354 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8EA3DA92F4ED4A0233E5519E /* QuartzCore.framework */; };
+		D65961ED5DAB8FC1991B648E /* EXTSafeCategory.h in Headers */ = {isa = PBXBuildFile; fileRef = EA7311AB5410321C2D679D07 /* EXTSafeCategory.h */; };
+		D83C6202AB7F12F93E186621 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C4B09F900783BEE9AB6B8552 /* UIKit.framework */; };
+		D9861AC93AFE16A74A1D165B /* NSInvocation+EXT.h in Headers */ = {isa = PBXBuildFile; fileRef = BA0666F2CF046D526A7D47C6 /* NSInvocation+EXT.h */; };
+		DF82EFA36204D48E90D47008 /* EXTSelectorChecking.m in Sources */ = {isa = PBXBuildFile; fileRef = CF43940F7FA301ADC20EABDD /* EXTSelectorChecking.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		E50CEDEFA05AD47B8169BA7F /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CDF91F77CF78C92C6E87462 /* Accelerate.framework */; };
+		F151DB21299D63B0AEC0FF6A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C69F07D43498D1C322D58647 /* Foundation.framework */; };
+		F4054EA2D7AC23F47B647D82 /* MarqueeLabel.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B80F145EF54D5E6C34D94CB /* MarqueeLabel.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		07A3ACF885A9FB453CD2BB87 /* PBXContainerItemProxy */ = {
+		0201D100C180E7ACB2A5A85A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 1C1EF5A24F379EACE93B041B /* Project object */;
+			containerPortal = 32401927A4BBDCDCB49BCF14 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 3F8AD37200ACC174D2334FE3;
+			remoteGlobalIDString = 1EA29FE494B647B1CA5B1F04;
 			remoteInfo = "Pods-TWSReleaseNotesView";
 		};
-		185907D2E1AA4F711682A95D /* PBXContainerItemProxy */ = {
+		27970B028C46F9F93A52217B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 1C1EF5A24F379EACE93B041B /* Project object */;
+			containerPortal = 32401927A4BBDCDCB49BCF14 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = B8A3A151E97B9FDB05163D89;
+			remoteGlobalIDString = DF469E6643E129BDD3EF381A;
 			remoteInfo = "Pods-libextobjc";
 		};
-		192A51FE74B1E297CC969A14 /* PBXContainerItemProxy */ = {
+		3E813D32C04D97AB45DE8881 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 1C1EF5A24F379EACE93B041B /* Project object */;
+			containerPortal = 32401927A4BBDCDCB49BCF14 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = E1BCB5CD685D8FB20D6D3235;
+			remoteGlobalIDString = 387E3EAAE60CCBA7E53D7CCE;
 			remoteInfo = "Pods-MarqueeLabel";
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		0122AB02BD9E9AF52A569D53 /* extobjc.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = extobjc.h; path = extobjc/extobjc.h; sourceTree = "<group>"; };
-		02C654C1959919780FDA8A44 /* NSInvocation+EXT.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSInvocation+EXT.m"; path = "extobjc/NSInvocation+EXT.m"; sourceTree = "<group>"; };
-		0708CB8733750540B013C54E /* EXTKeyPathCoding.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXTKeyPathCoding.h; path = extobjc/EXTKeyPathCoding.h; sourceTree = "<group>"; };
-		09B722D97579A71450045F37 /* EXTScope.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXTScope.m; path = extobjc/EXTScope.m; sourceTree = "<group>"; };
-		0C5BB562BE8749173D6856F6 /* Pods-TWSReleaseNotesView-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-TWSReleaseNotesView-dummy.m"; sourceTree = "<group>"; };
-		0D715BC25A6E8CB4FF62C54E /* Pods.appstoredistribution.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Pods.appstoredistribution.xcconfig; sourceTree = "<group>"; };
-		12B7FBCB31F8D969F3D2EDDC /* Podfile */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		13C36616246758F815C35FC5 /* libPods-libextobjc.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-libextobjc.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		13F7E200BE3D8AD202C96A32 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/CoreGraphics.framework; sourceTree = DEVELOPER_DIR; };
-		15AFC485D1B87FE93877BB4D /* GAIEcommerceProductAction.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GAIEcommerceProductAction.h; path = GoogleAnalytics/Library/GAIEcommerceProductAction.h; sourceTree = "<group>"; };
-		1806833E4CAF4D9F18E22229 /* GAILogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GAILogger.h; path = GoogleAnalytics/Library/GAILogger.h; sourceTree = "<group>"; };
-		19D81FB9CF98871D9603DB05 /* EXTSelectorChecking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXTSelectorChecking.m; path = extobjc/EXTSelectorChecking.m; sourceTree = "<group>"; };
-		204ABFE29C8E3873FD8BCBFD /* Pods-TWSReleaseNotesView-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-TWSReleaseNotesView-prefix.pch"; sourceTree = "<group>"; };
-		28085F98F47C83125CB69859 /* Pods-MarqueeLabel-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-MarqueeLabel-prefix.pch"; sourceTree = "<group>"; };
-		2E768BBD17893D8DE4E1CC2B /* TWSReleaseNotesView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = TWSReleaseNotesView.m; path = TWSReleaseNotesView/TWSReleaseNotesView.m; sourceTree = "<group>"; };
-		33CD191D3924727035FE0E99 /* NSMethodSignature+EXT.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSMethodSignature+EXT.m"; path = "extobjc/NSMethodSignature+EXT.m"; sourceTree = "<group>"; };
-		35AED058DA702BDFFF390530 /* Pods-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-acknowledgements.markdown"; sourceTree = "<group>"; };
-		399990AC96682209B07EF313 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/QuartzCore.framework; sourceTree = DEVELOPER_DIR; };
-		3A3F5E925BAF6DDD41D85D3C /* TAGContainerOpener.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = TAGContainerOpener.h; path = GoogleTagManager/Library/TAGContainerOpener.h; sourceTree = "<group>"; };
-		4034B27752498C70FF401731 /* MarqueeLabel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MarqueeLabel.m; sourceTree = "<group>"; };
-		42763778FEE6759EF6ADD67B /* GAIFields.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GAIFields.h; path = GoogleAnalytics/Library/GAIFields.h; sourceTree = "<group>"; };
-		4D6CA4E10F0D0C815D8A1AFA /* EXTSelectorChecking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXTSelectorChecking.h; path = extobjc/EXTSelectorChecking.h; sourceTree = "<group>"; };
-		51A14FCD0050502688A9DD10 /* GAI.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GAI.h; path = GoogleAnalytics/Library/GAI.h; sourceTree = "<group>"; };
-		548047DFC1733025091BBF4B /* Pods-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-acknowledgements.plist"; sourceTree = "<group>"; };
-		5937B59655EAA0FE69CEB7F7 /* EXTNil.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXTNil.h; path = extobjc/EXTNil.h; sourceTree = "<group>"; };
-		59BF9E805DF5C84AAE9FA037 /* TAGContainer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = TAGContainer.h; path = GoogleTagManager/Library/TAGContainer.h; sourceTree = "<group>"; };
-		601D4425CD17071C7BE209DB /* EXTScope.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXTScope.h; path = extobjc/EXTScope.h; sourceTree = "<group>"; };
-		62387927BD1522C7BA2E9149 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		64B4D83D8D95A92DACD68CB0 /* MarqueeLabel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MarqueeLabel.h; sourceTree = "<group>"; };
-		64D4F21E60017F6E759024E4 /* GAIDictionaryBuilder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GAIDictionaryBuilder.h; path = GoogleAnalytics/Library/GAIDictionaryBuilder.h; sourceTree = "<group>"; };
-		67FE525B989A3D3C1BC8B8F3 /* Pods-libextobjc-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-libextobjc-Private.xcconfig"; sourceTree = "<group>"; };
-		69A9A663DA6FB2DEA631D410 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Pods.release.xcconfig; sourceTree = "<group>"; };
-		69E7E844EDE38ECDAC95782E /* GAITrackedViewController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GAITrackedViewController.h; path = GoogleAnalytics/Library/GAITrackedViewController.h; sourceTree = "<group>"; };
-		6E8539001D52DC5738A9267B /* EXTConcreteProtocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXTConcreteProtocol.h; path = extobjc/EXTConcreteProtocol.h; sourceTree = "<group>"; };
-		73BCBF10ADB78F20960DE534 /* EXTADT.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXTADT.h; path = extobjc/EXTADT.h; sourceTree = "<group>"; };
-		75828C2AAD933C5E103283DD /* EXTADT.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXTADT.m; path = extobjc/EXTADT.m; sourceTree = "<group>"; };
-		7902F182229796B0D8E05E0C /* GAIEcommercePromotion.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GAIEcommercePromotion.h; path = GoogleAnalytics/Library/GAIEcommercePromotion.h; sourceTree = "<group>"; };
-		7B76D116B2FD42C2E6E10334 /* Pods-libextobjc-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-libextobjc-prefix.pch"; sourceTree = "<group>"; };
-		8D5EAAAC683D699499CEE8CE /* EXTRuntimeExtensions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXTRuntimeExtensions.h; path = extobjc/EXTRuntimeExtensions.h; sourceTree = "<group>"; };
-		8EF5B164269BF5E6BB8DE307 /* TAGDataLayer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = TAGDataLayer.h; path = GoogleTagManager/Library/TAGDataLayer.h; sourceTree = "<group>"; };
-		90CFF76D6136AC3FF48EF2CC /* GAIEcommerceProduct.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GAIEcommerceProduct.h; path = GoogleAnalytics/Library/GAIEcommerceProduct.h; sourceTree = "<group>"; };
-		91150E100B617842DBAFEA7A /* Pods-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-resources.sh"; sourceTree = "<group>"; };
-		A3FEBA243AC9096CE50C6159 /* Pods-MarqueeLabel-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-MarqueeLabel-Private.xcconfig"; sourceTree = "<group>"; };
-		A7F143BABD5842980F4BCADF /* Pods-libextobjc.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-libextobjc.xcconfig"; sourceTree = "<group>"; };
-		AAF3BCE6713BDBCAC3E7E16C /* UIImage+ImageEffects.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIImage+ImageEffects.m"; path = "TWSReleaseNotesView/UIImage+ImageEffects.m"; sourceTree = "<group>"; };
-		ACE6B56DE6E04B4A39B42970 /* EXTNil.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXTNil.m; path = extobjc/EXTNil.m; sourceTree = "<group>"; };
-		AD25AA18C85696E70483A7EF /* GAIEcommerceFields.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GAIEcommerceFields.h; path = GoogleAnalytics/Library/GAIEcommerceFields.h; sourceTree = "<group>"; };
-		B1914E63CA74A4981152DE89 /* TWSReleaseNotesDownloadOperation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = TWSReleaseNotesDownloadOperation.m; path = TWSReleaseNotesView/TWSReleaseNotesDownloadOperation.m; sourceTree = "<group>"; };
-		B21C3C2345FC4E2C1D578466 /* UIImage+ImageEffects.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImage+ImageEffects.h"; path = "TWSReleaseNotesView/UIImage+ImageEffects.h"; sourceTree = "<group>"; };
-		B41057719D7136A10AAE7F0A /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
-		B901F7CE5F4F3F437F04AEF4 /* EXTSafeCategory.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXTSafeCategory.m; path = extobjc/EXTSafeCategory.m; sourceTree = "<group>"; };
-		B9768AB9A92B8342E52B2F89 /* Pods-MarqueeLabel-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-MarqueeLabel-dummy.m"; sourceTree = "<group>"; };
-		BB5DA0671F9399685550440D /* libPods-TWSReleaseNotesView.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-TWSReleaseNotesView.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		BB61F1C8C1C396162A69B3FB /* EXTConcreteProtocol.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXTConcreteProtocol.m; path = extobjc/EXTConcreteProtocol.m; sourceTree = "<group>"; };
-		BCB9C02C2108124F3B3423A0 /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/Accelerate.framework; sourceTree = DEVELOPER_DIR; };
-		BFA7D0AE64CC9547D69CAD2B /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		C0F17F418B16670D9C0D014F /* Pods-TWSReleaseNotesView-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-TWSReleaseNotesView-Private.xcconfig"; sourceTree = "<group>"; };
-		C158A6D65D6732E444FB5B10 /* metamacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = metamacros.h; path = extobjc/metamacros.h; sourceTree = "<group>"; };
-		C8BF6EE17A970EABD5968CD8 /* EXTSynthesize.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXTSynthesize.h; path = extobjc/EXTSynthesize.h; sourceTree = "<group>"; };
-		CAC72303EDCF1D4F028D0C47 /* NSMethodSignature+EXT.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSMethodSignature+EXT.h"; path = "extobjc/NSMethodSignature+EXT.h"; sourceTree = "<group>"; };
-		CBCF0ADC9ED7AD7E6D320E52 /* Pods-MarqueeLabel.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-MarqueeLabel.xcconfig"; sourceTree = "<group>"; };
-		D2E4D157A777486E768F5B9A /* libPods-MarqueeLabel.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-MarqueeLabel.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		D2F0307525E036AFC24A13A7 /* Pods-environment.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-environment.h"; sourceTree = "<group>"; };
-		D7DE3D10150B47E8B379E7F1 /* NSInvocation+EXT.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSInvocation+EXT.h"; path = "extobjc/NSInvocation+EXT.h"; sourceTree = "<group>"; };
-		DDD6E8721A172E989214C1CD /* EXTSafeCategory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXTSafeCategory.h; path = extobjc/EXTSafeCategory.h; sourceTree = "<group>"; };
-		DFCEFC8881B9A95BB3FB332B /* TAGLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = TAGLogger.h; path = GoogleTagManager/Library/TAGLogger.h; sourceTree = "<group>"; };
-		E43AF682E326B35D9EF80A2B /* TWSReleaseNotesView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = TWSReleaseNotesView.h; path = TWSReleaseNotesView/TWSReleaseNotesView.h; sourceTree = "<group>"; };
-		EBCE9E010602D0D9165C816A /* EXTRuntimeExtensions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXTRuntimeExtensions.m; path = extobjc/EXTRuntimeExtensions.m; sourceTree = "<group>"; };
-		EE6D08611DBE0F3D3FAFFD21 /* Pods-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-dummy.m"; sourceTree = "<group>"; };
-		F0216D99F63DE66DBB58C5CA /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Pods.debug.xcconfig; sourceTree = "<group>"; };
-		F059398EE8115F55752F2E80 /* TWSReleaseNotesDownloadOperation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = TWSReleaseNotesDownloadOperation.h; path = TWSReleaseNotesView/TWSReleaseNotesDownloadOperation.h; sourceTree = "<group>"; };
-		F2C5E014231056C41F1BF545 /* Pods.adhocdistribution.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Pods.adhocdistribution.xcconfig; sourceTree = "<group>"; };
-		F5CCCBAE2BAE61601E773D29 /* TAGManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = TAGManager.h; path = GoogleTagManager/Library/TAGManager.h; sourceTree = "<group>"; };
-		F6E00B072FD12A1DFA537DEC /* Pods-libextobjc-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-libextobjc-dummy.m"; sourceTree = "<group>"; };
-		F75DB44F7F32BB0883517AD0 /* Pods-TWSReleaseNotesView.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-TWSReleaseNotesView.xcconfig"; sourceTree = "<group>"; };
-		FCC35C8E262A6C657FC0E7EF /* GAITracker.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GAITracker.h; path = GoogleAnalytics/Library/GAITracker.h; sourceTree = "<group>"; };
+		015184D163D3755FD5D0C5B9 /* EXTScope.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXTScope.m; path = extobjc/EXTScope.m; sourceTree = "<group>"; };
+		04C24AFBA0A7E63E231E3823 /* Pods-MarqueeLabel-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-MarqueeLabel-prefix.pch"; sourceTree = "<group>"; };
+		0B80F145EF54D5E6C34D94CB /* MarqueeLabel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MarqueeLabel.m; sourceTree = "<group>"; };
+		0C846AC391E7ABD748856AD3 /* MarqueeLabel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MarqueeLabel.h; sourceTree = "<group>"; };
+		0FF71F6E3D5CEADEE3BEF151 /* Pods-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-resources.sh"; sourceTree = "<group>"; };
+		1008DD84732663CC3F8933B6 /* EXTConcreteProtocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXTConcreteProtocol.h; path = extobjc/EXTConcreteProtocol.h; sourceTree = "<group>"; };
+		1923AB4C80B13F1E226A9D4D /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Pods.debug.xcconfig; sourceTree = "<group>"; };
+		1CDF91F77CF78C92C6E87462 /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/Accelerate.framework; sourceTree = DEVELOPER_DIR; };
+		2142A80816C2C0C9A649A6D8 /* GAIDictionaryBuilder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GAIDictionaryBuilder.h; path = GoogleAnalytics/Library/GAIDictionaryBuilder.h; sourceTree = "<group>"; };
+		239B232F5243EAFC70F9B50E /* Pods-TWSReleaseNotesView-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-TWSReleaseNotesView-dummy.m"; sourceTree = "<group>"; };
+		249539CE95312D2028E2844F /* Podfile */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		26A1A5E03A87C0A2226E1FB8 /* Pods-libextobjc.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-libextobjc.xcconfig"; sourceTree = "<group>"; };
+		26B2B0345486422841F5377A /* EXTADT.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXTADT.m; path = extobjc/EXTADT.m; sourceTree = "<group>"; };
+		2D4DB67FF764EB4F3C5CCC47 /* EXTRuntimeExtensions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXTRuntimeExtensions.h; path = extobjc/EXTRuntimeExtensions.h; sourceTree = "<group>"; };
+		2FBE084B8A7D3A0635F7DA68 /* TWSReleaseNotesView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = TWSReleaseNotesView.m; path = TWSReleaseNotesView/TWSReleaseNotesView.m; sourceTree = "<group>"; };
+		32E1B01A64F4ADCA31E258FF /* Pods-TWSReleaseNotesView-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-TWSReleaseNotesView-Private.xcconfig"; sourceTree = "<group>"; };
+		36506C549071A864ABE9A4AF /* GAIEcommercePromotion.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GAIEcommercePromotion.h; path = GoogleAnalytics/Library/GAIEcommercePromotion.h; sourceTree = "<group>"; };
+		392470CCC81916956294990A /* TWSReleaseNotesDownloadOperation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = TWSReleaseNotesDownloadOperation.m; path = TWSReleaseNotesView/TWSReleaseNotesDownloadOperation.m; sourceTree = "<group>"; };
+		39A0A583D34A3B8B54E22374 /* UIImage+ImageEffects.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImage+ImageEffects.h"; path = "TWSReleaseNotesView/UIImage+ImageEffects.h"; sourceTree = "<group>"; };
+		3CCB6B1EF4491E7A5BC518F0 /* Pods-MarqueeLabel.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-MarqueeLabel.xcconfig"; sourceTree = "<group>"; };
+		3DC8DAC82EE9D94C808B33B2 /* EXTNil.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXTNil.m; path = extobjc/EXTNil.m; sourceTree = "<group>"; };
+		3EA1FE2AC4295C5E3D6EA979 /* TAGContainer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = TAGContainer.h; path = GoogleTagManager/Library/TAGContainer.h; sourceTree = "<group>"; };
+		4579799711C11E659F46F72A /* Pods-MarqueeLabel-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-MarqueeLabel-dummy.m"; sourceTree = "<group>"; };
+		48FD56A309AED6C2D20EADC2 /* TAGManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = TAGManager.h; path = GoogleTagManager/Library/TAGManager.h; sourceTree = "<group>"; };
+		549E3BD8EF5EFDB173C4AFAD /* GAI.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GAI.h; path = GoogleAnalytics/Library/GAI.h; sourceTree = "<group>"; };
+		58A065FB1C7DC8E6D89B10BB /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		5D7C97C9BB1DEE09F82E6901 /* libPods-TWSReleaseNotesView.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-TWSReleaseNotesView.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		6514539EE85CB6F4E80DCE74 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/CoreGraphics.framework; sourceTree = DEVELOPER_DIR; };
+		65F72378D4FC1F9727A94E6D /* NSMethodSignature+EXT.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSMethodSignature+EXT.h"; path = "extobjc/NSMethodSignature+EXT.h"; sourceTree = "<group>"; };
+		69AC7035759423D160885BAE /* EXTADT.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXTADT.h; path = extobjc/EXTADT.h; sourceTree = "<group>"; };
+		6AB2FD3D822405055946ED65 /* TWSReleaseNotesDownloadOperation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = TWSReleaseNotesDownloadOperation.h; path = TWSReleaseNotesView/TWSReleaseNotesDownloadOperation.h; sourceTree = "<group>"; };
+		6D91020BAA5B0C3A47FA40F4 /* Pods.appstoredistribution.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Pods.appstoredistribution.xcconfig; sourceTree = "<group>"; };
+		7A4B714055BF777B977F9F7A /* Pods-MarqueeLabel-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-MarqueeLabel-Private.xcconfig"; sourceTree = "<group>"; };
+		7BFB73D8B189485E38041DC6 /* Pods-libextobjc-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-libextobjc-Private.xcconfig"; sourceTree = "<group>"; };
+		7FA8A74AE6E12A2A3E3C182D /* TAGLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = TAGLogger.h; path = GoogleTagManager/Library/TAGLogger.h; sourceTree = "<group>"; };
+		88B856D1185DB4A9579950B5 /* EXTKeyPathCoding.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXTKeyPathCoding.h; path = extobjc/EXTKeyPathCoding.h; sourceTree = "<group>"; };
+		8EA3DA92F4ED4A0233E5519E /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/QuartzCore.framework; sourceTree = DEVELOPER_DIR; };
+		8F8AD78F6E5D7827679B33FF /* Pods-libextobjc-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-libextobjc-prefix.pch"; sourceTree = "<group>"; };
+		912B3F7F48B223381E8D4597 /* EXTSelectorChecking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXTSelectorChecking.h; path = extobjc/EXTSelectorChecking.h; sourceTree = "<group>"; };
+		95C9620860D7DD8C30473BCC /* GAITracker.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GAITracker.h; path = GoogleAnalytics/Library/GAITracker.h; sourceTree = "<group>"; };
+		98F752C2607DCCB5DAA2D428 /* Pods-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-acknowledgements.plist"; sourceTree = "<group>"; };
+		99446CCDA0D71763FAD8ABD5 /* Pods-TWSReleaseNotesView-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-TWSReleaseNotesView-prefix.pch"; sourceTree = "<group>"; };
+		9C596A1EFCEBF89C5265F977 /* GAIFields.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GAIFields.h; path = GoogleAnalytics/Library/GAIFields.h; sourceTree = "<group>"; };
+		9EABDB738D2C395520473315 /* UIImage+ImageEffects.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIImage+ImageEffects.m"; path = "TWSReleaseNotesView/UIImage+ImageEffects.m"; sourceTree = "<group>"; };
+		9FAE56AFDA92571CFCC4E6F3 /* Pods-libextobjc-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-libextobjc-dummy.m"; sourceTree = "<group>"; };
+		A365214D5338564459A1F649 /* NSInvocation+EXT.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSInvocation+EXT.m"; path = "extobjc/NSInvocation+EXT.m"; sourceTree = "<group>"; };
+		A57DE3E1C2EC2B31975DEA78 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Pods.release.xcconfig; sourceTree = "<group>"; };
+		A7D5D829B980E2034534B4E6 /* libPods-libextobjc.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-libextobjc.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		AD912E7212E24F137F58FAD6 /* EXTScope.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXTScope.h; path = extobjc/EXTScope.h; sourceTree = "<group>"; };
+		AE4BF29B282541CB79E5665F /* EXTSafeCategory.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXTSafeCategory.m; path = extobjc/EXTSafeCategory.m; sourceTree = "<group>"; };
+		B1FA73E56874D3A3538CCF8C /* Pods-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-acknowledgements.markdown"; sourceTree = "<group>"; };
+		BA0666F2CF046D526A7D47C6 /* NSInvocation+EXT.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSInvocation+EXT.h"; path = "extobjc/NSInvocation+EXT.h"; sourceTree = "<group>"; };
+		C02B9EE3BC92A6AC605F5C25 /* EXTSynthesize.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXTSynthesize.h; path = extobjc/EXTSynthesize.h; sourceTree = "<group>"; };
+		C45BAF949438C831A1B5355E /* Pods-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-dummy.m"; sourceTree = "<group>"; };
+		C4B09F900783BEE9AB6B8552 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
+		C4BD07DB4DE5C0812798CC6D /* EXTNil.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXTNil.h; path = extobjc/EXTNil.h; sourceTree = "<group>"; };
+		C69F07D43498D1C322D58647 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		CAA9812938AF2647B0999409 /* Pods.adhocdistribution.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Pods.adhocdistribution.xcconfig; sourceTree = "<group>"; };
+		CF1E9DD695C98C3B9782E3E7 /* GAIEcommerceFields.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GAIEcommerceFields.h; path = GoogleAnalytics/Library/GAIEcommerceFields.h; sourceTree = "<group>"; };
+		CF43940F7FA301ADC20EABDD /* EXTSelectorChecking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXTSelectorChecking.m; path = extobjc/EXTSelectorChecking.m; sourceTree = "<group>"; };
+		D3A623C49D4E1B61D3317818 /* EXTRuntimeExtensions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXTRuntimeExtensions.m; path = extobjc/EXTRuntimeExtensions.m; sourceTree = "<group>"; };
+		D4E97C7719AD5C6BD100E11C /* extobjc.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = extobjc.h; path = extobjc/extobjc.h; sourceTree = "<group>"; };
+		D4F6E8B47F0B7721082DE162 /* TAGDataLayer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = TAGDataLayer.h; path = GoogleTagManager/Library/TAGDataLayer.h; sourceTree = "<group>"; };
+		D8B96EA818825B1F4B28CAEF /* GAIEcommerceProduct.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GAIEcommerceProduct.h; path = GoogleAnalytics/Library/GAIEcommerceProduct.h; sourceTree = "<group>"; };
+		DA9C4C1616FFDFE5779C3B63 /* Pods-environment.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-environment.h"; sourceTree = "<group>"; };
+		DC9B6CF1037DB7F2267CB6C9 /* TWSReleaseNotesView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = TWSReleaseNotesView.h; path = TWSReleaseNotesView/TWSReleaseNotesView.h; sourceTree = "<group>"; };
+		E394934C550774D955A23F3A /* GAIEcommerceProductAction.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GAIEcommerceProductAction.h; path = GoogleAnalytics/Library/GAIEcommerceProductAction.h; sourceTree = "<group>"; };
+		E830350106B6C4D34BA446D1 /* metamacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = metamacros.h; path = extobjc/metamacros.h; sourceTree = "<group>"; };
+		E83C38BA57545C2922141738 /* GAITrackedViewController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GAITrackedViewController.h; path = GoogleAnalytics/Library/GAITrackedViewController.h; sourceTree = "<group>"; };
+		EA7311AB5410321C2D679D07 /* EXTSafeCategory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXTSafeCategory.h; path = extobjc/EXTSafeCategory.h; sourceTree = "<group>"; };
+		EBE849972449CD8BF3DF9D41 /* Pods-TWSReleaseNotesView.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-TWSReleaseNotesView.xcconfig"; sourceTree = "<group>"; };
+		ED573AC019589D45B70A05B1 /* TAGContainerOpener.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = TAGContainerOpener.h; path = GoogleTagManager/Library/TAGContainerOpener.h; sourceTree = "<group>"; };
+		F52633F3B3FEA1AECE8569AC /* GAILogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GAILogger.h; path = GoogleAnalytics/Library/GAILogger.h; sourceTree = "<group>"; };
+		F92F540EE0A833F8DF79E1B3 /* libPods-MarqueeLabel.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-MarqueeLabel.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FDA2F5E258BF7A9BAC0F0ABA /* NSMethodSignature+EXT.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSMethodSignature+EXT.m"; path = "extobjc/NSMethodSignature+EXT.m"; sourceTree = "<group>"; };
+		FE7A63ADB9006ADDFDFBF66F /* EXTConcreteProtocol.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXTConcreteProtocol.m; path = extobjc/EXTConcreteProtocol.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		0790DE054B70D8F5BD68C8A5 /* Frameworks */ = {
+		206EF4F034CBE1AEDB2246C3 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				87CD0002AB74E4649C5C1B97 /* Accelerate.framework in Frameworks */,
-				B120E7230897C7D3B4B3E22B /* CoreGraphics.framework in Frameworks */,
-				9D6160ED476D14707F187BD6 /* Foundation.framework in Frameworks */,
-				064D76A156F89034221DFE5F /* QuartzCore.framework in Frameworks */,
-				D54EAB4CB902B0B0554FEC29 /* UIKit.framework in Frameworks */,
+				529ACD25F0FB7E5E2463695D /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		43F7A9DDDB998A83C1309A86 /* Frameworks */ = {
+		788431196C5DE6B8246E4B36 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				91BE897F68853592DB28551A /* Foundation.framework in Frameworks */,
+				F151DB21299D63B0AEC0FF6A /* Foundation.framework in Frameworks */,
+				D5A62F93CFC0ADA2C323A354 /* QuartzCore.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		9C5B568189AA3FD773445B88 /* Frameworks */ = {
+		8322D9A8E9F7D5CC4D981FE4 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E9D54A3DCE7328C47122A620 /* Foundation.framework in Frameworks */,
-				568D1B2C61C108D5B7759035 /* QuartzCore.framework in Frameworks */,
+				E50CEDEFA05AD47B8169BA7F /* Accelerate.framework in Frameworks */,
+				AADAACDFF5D72A0DE61DB602 /* CoreGraphics.framework in Frameworks */,
+				1B2A95244AD2DA3F2AB5C4C9 /* Foundation.framework in Frameworks */,
+				58F8CBC5826DF56BFDCBDEE2 /* QuartzCore.framework in Frameworks */,
+				D83C6202AB7F12F93E186621 /* UIKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		CFD93F41F64DF2026A253BE4 /* Frameworks */ = {
+		E1D2A4CC1E1BFEE45EBE6AE8 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CFE1BA87EDF24BBF2C0FDBB0 /* Foundation.framework in Frameworks */,
+				C5432D21B7ED0539A9319870 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		1298A8E6F792976EB9B14892 /* NSInvocation+EXT */ = {
+		148F2BB2AA6D0C747B10E76D /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				D7DE3D10150B47E8B379E7F1 /* NSInvocation+EXT.h */,
-				02C654C1959919780FDA8A44 /* NSInvocation+EXT.m */,
-			);
-			name = "NSInvocation+EXT";
-			sourceTree = "<group>";
-		};
-		141E8D8442279E577E67FA8D /* EXTSelectorChecking */ = {
-			isa = PBXGroup;
-			children = (
-				4D6CA4E10F0D0C815D8A1AFA /* EXTSelectorChecking.h */,
-				19D81FB9CF98871D9603DB05 /* EXTSelectorChecking.m */,
-			);
-			name = EXTSelectorChecking;
-			sourceTree = "<group>";
-		};
-		15F4E104F59B87371A8349C7 /* EXTSynthesize */ = {
-			isa = PBXGroup;
-			children = (
-				C8BF6EE17A970EABD5968CD8 /* EXTSynthesize.h */,
-			);
-			name = EXTSynthesize;
-			sourceTree = "<group>";
-		};
-		180212EFB52560630BDDFB82 /* MarqueeLabel */ = {
-			isa = PBXGroup;
-			children = (
-				64B4D83D8D95A92DACD68CB0 /* MarqueeLabel.h */,
-				4034B27752498C70FF401731 /* MarqueeLabel.m */,
-				2244CFAD690D9D073D0CC4F9 /* Support Files */,
-			);
-			path = MarqueeLabel;
-			sourceTree = "<group>";
-		};
-		1BC849E247A0A97765EF6B5F = {
-			isa = PBXGroup;
-			children = (
-				12B7FBCB31F8D969F3D2EDDC /* Podfile */,
-				1CDFAA45CB92FE0C1139D207 /* Frameworks */,
-				A4EF6B2AA6FC8EB20DA0EBE5 /* Pods */,
-				5D0F93B46E1E28E542CC7A5C /* Products */,
-				47E35398AF4E75F540E366E6 /* Targets Support Files */,
-			);
-			sourceTree = "<group>";
-		};
-		1CDFAA45CB92FE0C1139D207 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				946A245E76500C5689624595 /* iOS */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		2244CFAD690D9D073D0CC4F9 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				CBCF0ADC9ED7AD7E6D320E52 /* Pods-MarqueeLabel.xcconfig */,
-				A3FEBA243AC9096CE50C6159 /* Pods-MarqueeLabel-Private.xcconfig */,
-				B9768AB9A92B8342E52B2F89 /* Pods-MarqueeLabel-dummy.m */,
-				28085F98F47C83125CB69859 /* Pods-MarqueeLabel-prefix.pch */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/Pods-MarqueeLabel";
-			sourceTree = "<group>";
-		};
-		47E35398AF4E75F540E366E6 /* Targets Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				ED06DBF02D36CE907C7B4FF6 /* Pods */,
-			);
-			name = "Targets Support Files";
-			sourceTree = "<group>";
-		};
-		4A7C2AE1A010E37C5511255A /* Core */ = {
-			isa = PBXGroup;
-			children = (
-				51A14FCD0050502688A9DD10 /* GAI.h */,
-				64D4F21E60017F6E759024E4 /* GAIDictionaryBuilder.h */,
-				AD25AA18C85696E70483A7EF /* GAIEcommerceFields.h */,
-				90CFF76D6136AC3FF48EF2CC /* GAIEcommerceProduct.h */,
-				15AFC485D1B87FE93877BB4D /* GAIEcommerceProductAction.h */,
-				7902F182229796B0D8E05E0C /* GAIEcommercePromotion.h */,
-				42763778FEE6759EF6ADD67B /* GAIFields.h */,
-				1806833E4CAF4D9F18E22229 /* GAILogger.h */,
-				69E7E844EDE38ECDAC95782E /* GAITrackedViewController.h */,
-				FCC35C8E262A6C657FC0E7EF /* GAITracker.h */,
-				59BF9E805DF5C84AAE9FA037 /* TAGContainer.h */,
-				3A3F5E925BAF6DDD41D85D3C /* TAGContainerOpener.h */,
-				8EF5B164269BF5E6BB8DE307 /* TAGDataLayer.h */,
-				DFCEFC8881B9A95BB3FB332B /* TAGLogger.h */,
-				F5CCCBAE2BAE61601E773D29 /* TAGManager.h */,
-			);
-			name = Core;
-			sourceTree = "<group>";
-		};
-		5988F44C4E1B560E1B0D12DC /* EXTNil */ = {
-			isa = PBXGroup;
-			children = (
-				5937B59655EAA0FE69CEB7F7 /* EXTNil.h */,
-				ACE6B56DE6E04B4A39B42970 /* EXTNil.m */,
-			);
-			name = EXTNil;
-			sourceTree = "<group>";
-		};
-		5D0F93B46E1E28E542CC7A5C /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				BFA7D0AE64CC9547D69CAD2B /* libPods.a */,
-				D2E4D157A777486E768F5B9A /* libPods-MarqueeLabel.a */,
-				BB5DA0671F9399685550440D /* libPods-TWSReleaseNotesView.a */,
-				13C36616246758F815C35FC5 /* libPods-libextobjc.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		6345A4503D5A300F56CFAA5C /* UmbrellaHeader */ = {
-			isa = PBXGroup;
-			children = (
-				0122AB02BD9E9AF52A569D53 /* extobjc.h */,
-			);
-			name = UmbrellaHeader;
-			sourceTree = "<group>";
-		};
-		6DF43A8FEA0CF5B507B15327 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				F75DB44F7F32BB0883517AD0 /* Pods-TWSReleaseNotesView.xcconfig */,
-				C0F17F418B16670D9C0D014F /* Pods-TWSReleaseNotesView-Private.xcconfig */,
-				0C5BB562BE8749173D6856F6 /* Pods-TWSReleaseNotesView-dummy.m */,
-				204ABFE29C8E3873FD8BCBFD /* Pods-TWSReleaseNotesView-prefix.pch */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/Pods-TWSReleaseNotesView";
-			sourceTree = "<group>";
-		};
-		7A803F4FABFE649FCF1A763A /* EXTADT */ = {
-			isa = PBXGroup;
-			children = (
-				73BCBF10ADB78F20960DE534 /* EXTADT.h */,
-				75828C2AAD933C5E103283DD /* EXTADT.m */,
-			);
-			name = EXTADT;
-			sourceTree = "<group>";
-		};
-		946A245E76500C5689624595 /* iOS */ = {
-			isa = PBXGroup;
-			children = (
-				BCB9C02C2108124F3B3423A0 /* Accelerate.framework */,
-				13F7E200BE3D8AD202C96A32 /* CoreGraphics.framework */,
-				62387927BD1522C7BA2E9149 /* Foundation.framework */,
-				399990AC96682209B07EF313 /* QuartzCore.framework */,
-				B41057719D7136A10AAE7F0A /* UIKit.framework */,
-			);
-			name = iOS;
-			sourceTree = "<group>";
-		};
-		96FBC804CABBBA90AA213420 /* NSMethodSignature+EXT */ = {
-			isa = PBXGroup;
-			children = (
-				CAC72303EDCF1D4F028D0C47 /* NSMethodSignature+EXT.h */,
-				33CD191D3924727035FE0E99 /* NSMethodSignature+EXT.m */,
-			);
-			name = "NSMethodSignature+EXT";
-			sourceTree = "<group>";
-		};
-		9F331AED08E92A1021AB1D8B /* libextobjc */ = {
-			isa = PBXGroup;
-			children = (
-				7A803F4FABFE649FCF1A763A /* EXTADT */,
-				B43BC746FE2977D7C96A24E4 /* EXTConcreteProtocol */,
-				D72AB0602B5206CFD83672CD /* EXTKeyPathCoding */,
-				5988F44C4E1B560E1B0D12DC /* EXTNil */,
-				ECEA3EA98DE998EF88CFAB5D /* EXTSafeCategory */,
-				A5C9050C2278776B7EFEF4AB /* EXTScope */,
-				141E8D8442279E577E67FA8D /* EXTSelectorChecking */,
-				15F4E104F59B87371A8349C7 /* EXTSynthesize */,
-				1298A8E6F792976EB9B14892 /* NSInvocation+EXT */,
-				96FBC804CABBBA90AA213420 /* NSMethodSignature+EXT */,
-				EF0AD9C091D361DEC5A02C97 /* RuntimeExtensions */,
-				FF81573CFB2C7489AFECEA83 /* Support Files */,
-				6345A4503D5A300F56CFAA5C /* UmbrellaHeader */,
-			);
-			path = libextobjc;
-			sourceTree = "<group>";
-		};
-		A4EF6B2AA6FC8EB20DA0EBE5 /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				D6D180B4D28E851626CBD02E /* GoogleAnalytics-iOS-SDK */,
-				180212EFB52560630BDDFB82 /* MarqueeLabel */,
-				BC1461470E92A905947CC8BC /* TWSReleaseNotesView */,
-				9F331AED08E92A1021AB1D8B /* libextobjc */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
-		A5C9050C2278776B7EFEF4AB /* EXTScope */ = {
-			isa = PBXGroup;
-			children = (
-				601D4425CD17071C7BE209DB /* EXTScope.h */,
-				09B722D97579A71450045F37 /* EXTScope.m */,
-			);
-			name = EXTScope;
-			sourceTree = "<group>";
-		};
-		B43BC746FE2977D7C96A24E4 /* EXTConcreteProtocol */ = {
-			isa = PBXGroup;
-			children = (
-				6E8539001D52DC5738A9267B /* EXTConcreteProtocol.h */,
-				BB61F1C8C1C396162A69B3FB /* EXTConcreteProtocol.m */,
-			);
-			name = EXTConcreteProtocol;
-			sourceTree = "<group>";
-		};
-		BC1461470E92A905947CC8BC /* TWSReleaseNotesView */ = {
-			isa = PBXGroup;
-			children = (
-				F059398EE8115F55752F2E80 /* TWSReleaseNotesDownloadOperation.h */,
-				B1914E63CA74A4981152DE89 /* TWSReleaseNotesDownloadOperation.m */,
-				E43AF682E326B35D9EF80A2B /* TWSReleaseNotesView.h */,
-				2E768BBD17893D8DE4E1CC2B /* TWSReleaseNotesView.m */,
-				B21C3C2345FC4E2C1D578466 /* UIImage+ImageEffects.h */,
-				AAF3BCE6713BDBCAC3E7E16C /* UIImage+ImageEffects.m */,
-				6DF43A8FEA0CF5B507B15327 /* Support Files */,
-			);
-			path = TWSReleaseNotesView;
-			sourceTree = "<group>";
-		};
-		D6D180B4D28E851626CBD02E /* GoogleAnalytics-iOS-SDK */ = {
-			isa = PBXGroup;
-			children = (
-				4A7C2AE1A010E37C5511255A /* Core */,
-			);
-			path = "GoogleAnalytics-iOS-SDK";
-			sourceTree = "<group>";
-		};
-		D72AB0602B5206CFD83672CD /* EXTKeyPathCoding */ = {
-			isa = PBXGroup;
-			children = (
-				0708CB8733750540B013C54E /* EXTKeyPathCoding.h */,
-			);
-			name = EXTKeyPathCoding;
-			sourceTree = "<group>";
-		};
-		ECEA3EA98DE998EF88CFAB5D /* EXTSafeCategory */ = {
-			isa = PBXGroup;
-			children = (
-				DDD6E8721A172E989214C1CD /* EXTSafeCategory.h */,
-				B901F7CE5F4F3F437F04AEF4 /* EXTSafeCategory.m */,
-			);
-			name = EXTSafeCategory;
-			sourceTree = "<group>";
-		};
-		ED06DBF02D36CE907C7B4FF6 /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				35AED058DA702BDFFF390530 /* Pods-acknowledgements.markdown */,
-				548047DFC1733025091BBF4B /* Pods-acknowledgements.plist */,
-				EE6D08611DBE0F3D3FAFFD21 /* Pods-dummy.m */,
-				D2F0307525E036AFC24A13A7 /* Pods-environment.h */,
-				91150E100B617842DBAFEA7A /* Pods-resources.sh */,
-				F2C5E014231056C41F1BF545 /* Pods.adhocdistribution.xcconfig */,
-				0D715BC25A6E8CB4FF62C54E /* Pods.appstoredistribution.xcconfig */,
-				F0216D99F63DE66DBB58C5CA /* Pods.debug.xcconfig */,
-				69A9A663DA6FB2DEA631D410 /* Pods.release.xcconfig */,
+				B1FA73E56874D3A3538CCF8C /* Pods-acknowledgements.markdown */,
+				98F752C2607DCCB5DAA2D428 /* Pods-acknowledgements.plist */,
+				C45BAF949438C831A1B5355E /* Pods-dummy.m */,
+				DA9C4C1616FFDFE5779C3B63 /* Pods-environment.h */,
+				0FF71F6E3D5CEADEE3BEF151 /* Pods-resources.sh */,
+				CAA9812938AF2647B0999409 /* Pods.adhocdistribution.xcconfig */,
+				6D91020BAA5B0C3A47FA40F4 /* Pods.appstoredistribution.xcconfig */,
+				1923AB4C80B13F1E226A9D4D /* Pods.debug.xcconfig */,
+				A57DE3E1C2EC2B31975DEA78 /* Pods.release.xcconfig */,
 			);
 			name = Pods;
 			path = "Target Support Files/Pods";
 			sourceTree = "<group>";
 		};
-		EF0AD9C091D361DEC5A02C97 /* RuntimeExtensions */ = {
+		189A5FBEAEAAEF9B4907580F /* EXTKeyPathCoding */ = {
 			isa = PBXGroup;
 			children = (
-				8D5EAAAC683D699499CEE8CE /* EXTRuntimeExtensions.h */,
-				EBCE9E010602D0D9165C816A /* EXTRuntimeExtensions.m */,
-				C158A6D65D6732E444FB5B10 /* metamacros.h */,
+				88B856D1185DB4A9579950B5 /* EXTKeyPathCoding.h */,
+			);
+			name = EXTKeyPathCoding;
+			sourceTree = "<group>";
+		};
+		21BCED4551F1065FDC8198AE /* GoogleAnalytics-iOS-SDK */ = {
+			isa = PBXGroup;
+			children = (
+				48FC1D08DFD6575D233DB0ED /* Core */,
+			);
+			path = "GoogleAnalytics-iOS-SDK";
+			sourceTree = "<group>";
+		};
+		2B83F41225C4EB4521A7CAE8 /* EXTConcreteProtocol */ = {
+			isa = PBXGroup;
+			children = (
+				1008DD84732663CC3F8933B6 /* EXTConcreteProtocol.h */,
+				FE7A63ADB9006ADDFDFBF66F /* EXTConcreteProtocol.m */,
+			);
+			name = EXTConcreteProtocol;
+			sourceTree = "<group>";
+		};
+		3A5D210DE3494411BAB8C946 /* libextobjc */ = {
+			isa = PBXGroup;
+			children = (
+				9051B30DB935D0DF2DF421C7 /* EXTADT */,
+				2B83F41225C4EB4521A7CAE8 /* EXTConcreteProtocol */,
+				189A5FBEAEAAEF9B4907580F /* EXTKeyPathCoding */,
+				79C5D33532F6076F73476310 /* EXTNil */,
+				3DB744526DEC0FCF283E57F1 /* EXTSafeCategory */,
+				530A44E7B8475772952BED4A /* EXTScope */,
+				795D04C1D6540F57675FFBED /* EXTSelectorChecking */,
+				FC81272BD736619AABCB01A2 /* EXTSynthesize */,
+				906B0E3858F5CEB881E7B364 /* NSInvocation+EXT */,
+				A39FCDFF9F2BDF1FC1E00C2A /* NSMethodSignature+EXT */,
+				AB6E1ED7502223ACDF11A713 /* RuntimeExtensions */,
+				F5F52E54DC774374B72BCC2D /* Support Files */,
+				880CC306C0A2EAAF209E5D8C /* UmbrellaHeader */,
+			);
+			path = libextobjc;
+			sourceTree = "<group>";
+		};
+		3DB744526DEC0FCF283E57F1 /* EXTSafeCategory */ = {
+			isa = PBXGroup;
+			children = (
+				EA7311AB5410321C2D679D07 /* EXTSafeCategory.h */,
+				AE4BF29B282541CB79E5665F /* EXTSafeCategory.m */,
+			);
+			name = EXTSafeCategory;
+			sourceTree = "<group>";
+		};
+		48FC1D08DFD6575D233DB0ED /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				549E3BD8EF5EFDB173C4AFAD /* GAI.h */,
+				2142A80816C2C0C9A649A6D8 /* GAIDictionaryBuilder.h */,
+				CF1E9DD695C98C3B9782E3E7 /* GAIEcommerceFields.h */,
+				D8B96EA818825B1F4B28CAEF /* GAIEcommerceProduct.h */,
+				E394934C550774D955A23F3A /* GAIEcommerceProductAction.h */,
+				36506C549071A864ABE9A4AF /* GAIEcommercePromotion.h */,
+				9C596A1EFCEBF89C5265F977 /* GAIFields.h */,
+				F52633F3B3FEA1AECE8569AC /* GAILogger.h */,
+				E83C38BA57545C2922141738 /* GAITrackedViewController.h */,
+				95C9620860D7DD8C30473BCC /* GAITracker.h */,
+				3EA1FE2AC4295C5E3D6EA979 /* TAGContainer.h */,
+				ED573AC019589D45B70A05B1 /* TAGContainerOpener.h */,
+				D4F6E8B47F0B7721082DE162 /* TAGDataLayer.h */,
+				7FA8A74AE6E12A2A3E3C182D /* TAGLogger.h */,
+				48FD56A309AED6C2D20EADC2 /* TAGManager.h */,
+			);
+			name = Core;
+			sourceTree = "<group>";
+		};
+		530A44E7B8475772952BED4A /* EXTScope */ = {
+			isa = PBXGroup;
+			children = (
+				AD912E7212E24F137F58FAD6 /* EXTScope.h */,
+				015184D163D3755FD5D0C5B9 /* EXTScope.m */,
+			);
+			name = EXTScope;
+			sourceTree = "<group>";
+		};
+		6E4F6C551A6ADE48248F3202 /* Targets Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				148F2BB2AA6D0C747B10E76D /* Pods */,
+			);
+			name = "Targets Support Files";
+			sourceTree = "<group>";
+		};
+		795D04C1D6540F57675FFBED /* EXTSelectorChecking */ = {
+			isa = PBXGroup;
+			children = (
+				912B3F7F48B223381E8D4597 /* EXTSelectorChecking.h */,
+				CF43940F7FA301ADC20EABDD /* EXTSelectorChecking.m */,
+			);
+			name = EXTSelectorChecking;
+			sourceTree = "<group>";
+		};
+		79C5D33532F6076F73476310 /* EXTNil */ = {
+			isa = PBXGroup;
+			children = (
+				C4BD07DB4DE5C0812798CC6D /* EXTNil.h */,
+				3DC8DAC82EE9D94C808B33B2 /* EXTNil.m */,
+			);
+			name = EXTNil;
+			sourceTree = "<group>";
+		};
+		7F2E57B8D43DCAF39EE88EDB /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				58A065FB1C7DC8E6D89B10BB /* libPods.a */,
+				F92F540EE0A833F8DF79E1B3 /* libPods-MarqueeLabel.a */,
+				5D7C97C9BB1DEE09F82E6901 /* libPods-TWSReleaseNotesView.a */,
+				A7D5D829B980E2034534B4E6 /* libPods-libextobjc.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		880CC306C0A2EAAF209E5D8C /* UmbrellaHeader */ = {
+			isa = PBXGroup;
+			children = (
+				D4E97C7719AD5C6BD100E11C /* extobjc.h */,
+			);
+			name = UmbrellaHeader;
+			sourceTree = "<group>";
+		};
+		8EF95EA85F67A03D8AA70E99 = {
+			isa = PBXGroup;
+			children = (
+				249539CE95312D2028E2844F /* Podfile */,
+				C29D286418396ADA92C0E156 /* Frameworks */,
+				B982BF29B1116A5061036B0A /* Pods */,
+				7F2E57B8D43DCAF39EE88EDB /* Products */,
+				6E4F6C551A6ADE48248F3202 /* Targets Support Files */,
+			);
+			sourceTree = "<group>";
+		};
+		9051B30DB935D0DF2DF421C7 /* EXTADT */ = {
+			isa = PBXGroup;
+			children = (
+				69AC7035759423D160885BAE /* EXTADT.h */,
+				26B2B0345486422841F5377A /* EXTADT.m */,
+			);
+			name = EXTADT;
+			sourceTree = "<group>";
+		};
+		906B0E3858F5CEB881E7B364 /* NSInvocation+EXT */ = {
+			isa = PBXGroup;
+			children = (
+				BA0666F2CF046D526A7D47C6 /* NSInvocation+EXT.h */,
+				A365214D5338564459A1F649 /* NSInvocation+EXT.m */,
+			);
+			name = "NSInvocation+EXT";
+			sourceTree = "<group>";
+		};
+		A39FCDFF9F2BDF1FC1E00C2A /* NSMethodSignature+EXT */ = {
+			isa = PBXGroup;
+			children = (
+				65F72378D4FC1F9727A94E6D /* NSMethodSignature+EXT.h */,
+				FDA2F5E258BF7A9BAC0F0ABA /* NSMethodSignature+EXT.m */,
+			);
+			name = "NSMethodSignature+EXT";
+			sourceTree = "<group>";
+		};
+		AB6E1ED7502223ACDF11A713 /* RuntimeExtensions */ = {
+			isa = PBXGroup;
+			children = (
+				2D4DB67FF764EB4F3C5CCC47 /* EXTRuntimeExtensions.h */,
+				D3A623C49D4E1B61D3317818 /* EXTRuntimeExtensions.m */,
+				E830350106B6C4D34BA446D1 /* metamacros.h */,
 			);
 			name = RuntimeExtensions;
 			sourceTree = "<group>";
 		};
-		FF81573CFB2C7489AFECEA83 /* Support Files */ = {
+		B982BF29B1116A5061036B0A /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				A7F143BABD5842980F4BCADF /* Pods-libextobjc.xcconfig */,
-				67FE525B989A3D3C1BC8B8F3 /* Pods-libextobjc-Private.xcconfig */,
-				F6E00B072FD12A1DFA537DEC /* Pods-libextobjc-dummy.m */,
-				7B76D116B2FD42C2E6E10334 /* Pods-libextobjc-prefix.pch */,
+				21BCED4551F1065FDC8198AE /* GoogleAnalytics-iOS-SDK */,
+				F0799D08B0F4232E4E8E3F5E /* MarqueeLabel */,
+				C790E555222E2DA2AC3ADD1B /* TWSReleaseNotesView */,
+				3A5D210DE3494411BAB8C946 /* libextobjc */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		C0CCCF64885B3E4F11D34BAC /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				1CDF91F77CF78C92C6E87462 /* Accelerate.framework */,
+				6514539EE85CB6F4E80DCE74 /* CoreGraphics.framework */,
+				C69F07D43498D1C322D58647 /* Foundation.framework */,
+				8EA3DA92F4ED4A0233E5519E /* QuartzCore.framework */,
+				C4B09F900783BEE9AB6B8552 /* UIKit.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
+		C29D286418396ADA92C0E156 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				C0CCCF64885B3E4F11D34BAC /* iOS */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		C790E555222E2DA2AC3ADD1B /* TWSReleaseNotesView */ = {
+			isa = PBXGroup;
+			children = (
+				6AB2FD3D822405055946ED65 /* TWSReleaseNotesDownloadOperation.h */,
+				392470CCC81916956294990A /* TWSReleaseNotesDownloadOperation.m */,
+				DC9B6CF1037DB7F2267CB6C9 /* TWSReleaseNotesView.h */,
+				2FBE084B8A7D3A0635F7DA68 /* TWSReleaseNotesView.m */,
+				39A0A583D34A3B8B54E22374 /* UIImage+ImageEffects.h */,
+				9EABDB738D2C395520473315 /* UIImage+ImageEffects.m */,
+				F1A21B7C4941B57BEE3E27EF /* Support Files */,
+			);
+			path = TWSReleaseNotesView;
+			sourceTree = "<group>";
+		};
+		CD2D6253BBBD4FAE8B45ACC4 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				3CCB6B1EF4491E7A5BC518F0 /* Pods-MarqueeLabel.xcconfig */,
+				7A4B714055BF777B977F9F7A /* Pods-MarqueeLabel-Private.xcconfig */,
+				4579799711C11E659F46F72A /* Pods-MarqueeLabel-dummy.m */,
+				04C24AFBA0A7E63E231E3823 /* Pods-MarqueeLabel-prefix.pch */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/Pods-MarqueeLabel";
+			sourceTree = "<group>";
+		};
+		F0799D08B0F4232E4E8E3F5E /* MarqueeLabel */ = {
+			isa = PBXGroup;
+			children = (
+				0C846AC391E7ABD748856AD3 /* MarqueeLabel.h */,
+				0B80F145EF54D5E6C34D94CB /* MarqueeLabel.m */,
+				CD2D6253BBBD4FAE8B45ACC4 /* Support Files */,
+			);
+			path = MarqueeLabel;
+			sourceTree = "<group>";
+		};
+		F1A21B7C4941B57BEE3E27EF /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				EBE849972449CD8BF3DF9D41 /* Pods-TWSReleaseNotesView.xcconfig */,
+				32E1B01A64F4ADCA31E258FF /* Pods-TWSReleaseNotesView-Private.xcconfig */,
+				239B232F5243EAFC70F9B50E /* Pods-TWSReleaseNotesView-dummy.m */,
+				99446CCDA0D71763FAD8ABD5 /* Pods-TWSReleaseNotesView-prefix.pch */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/Pods-TWSReleaseNotesView";
+			sourceTree = "<group>";
+		};
+		F5F52E54DC774374B72BCC2D /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				26A1A5E03A87C0A2226E1FB8 /* Pods-libextobjc.xcconfig */,
+				7BFB73D8B189485E38041DC6 /* Pods-libextobjc-Private.xcconfig */,
+				9FAE56AFDA92571CFCC4E6F3 /* Pods-libextobjc-dummy.m */,
+				8F8AD78F6E5D7827679B33FF /* Pods-libextobjc-prefix.pch */,
 			);
 			name = "Support Files";
 			path = "../Target Support Files/Pods-libextobjc";
 			sourceTree = "<group>";
 		};
+		FC81272BD736619AABCB01A2 /* EXTSynthesize */ = {
+			isa = PBXGroup;
+			children = (
+				C02B9EE3BC92A6AC605F5C25 /* EXTSynthesize.h */,
+			);
+			name = EXTSynthesize;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		34329AE873765654C8A7FEA3 /* Headers */ = {
+		3F6666064208C842AAAC0C58 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E0650A0ABDAF80154D4B3935 /* EXTADT.h in Headers */,
-				3826504A16D23E599134AD04 /* EXTConcreteProtocol.h in Headers */,
-				91BD743F5A67C2FA4F44A1D3 /* EXTKeyPathCoding.h in Headers */,
-				B1EAF26B8C5E656C54239B75 /* EXTNil.h in Headers */,
-				A2F6D96DD114284E88D161A9 /* EXTRuntimeExtensions.h in Headers */,
-				26E639A382FD739E9D0EB046 /* EXTSafeCategory.h in Headers */,
-				BF429EC357A420E181D3829A /* EXTScope.h in Headers */,
-				786C531B4FF96B035D470347 /* EXTSelectorChecking.h in Headers */,
-				BC96A1AD6001C8054A80B37C /* EXTSynthesize.h in Headers */,
-				7BE0558286E348A6AE6A3DC6 /* NSInvocation+EXT.h in Headers */,
-				0886B8CC116202D56C4C7EF8 /* NSMethodSignature+EXT.h in Headers */,
-				0AA81BF58DA770C17C4B4AD7 /* extobjc.h in Headers */,
-				633524DBE1E4E45BCA7FC00F /* metamacros.h in Headers */,
+				C73FC113B8E89838243D595D /* TWSReleaseNotesDownloadOperation.h in Headers */,
+				5A5042A7EE7263B7B2F7528A /* TWSReleaseNotesView.h in Headers */,
+				406F30285E5F1FA8A3E5BF46 /* UIImage+ImageEffects.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		A781CCE0FD2CE036DFC5F128 /* Headers */ = {
+		AF6B1773F833D0F2849FF744 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				887E16A59B8F16413F633465 /* TWSReleaseNotesDownloadOperation.h in Headers */,
-				50D59143EB31B81BEC94D834 /* TWSReleaseNotesView.h in Headers */,
-				4B2A89ECCEFB29E2089FABB0 /* UIImage+ImageEffects.h in Headers */,
+				3E0132154407390FBC265616 /* EXTADT.h in Headers */,
+				237B0FD66A2A82F06A958831 /* EXTConcreteProtocol.h in Headers */,
+				A752DF1183C683F310E937A3 /* EXTKeyPathCoding.h in Headers */,
+				2F76ADB9E48ADD1FF02E6831 /* EXTNil.h in Headers */,
+				31BA04C74D164BFDA68C0207 /* EXTRuntimeExtensions.h in Headers */,
+				D65961ED5DAB8FC1991B648E /* EXTSafeCategory.h in Headers */,
+				8B447B52D033550F94F768E9 /* EXTScope.h in Headers */,
+				53592C1F3D855B4C4DF5AB0C /* EXTSelectorChecking.h in Headers */,
+				2ACDE089F5264D8B1709CEBC /* EXTSynthesize.h in Headers */,
+				D9861AC93AFE16A74A1D165B /* NSInvocation+EXT.h in Headers */,
+				419D5B8CD593F36C33EDE537 /* NSMethodSignature+EXT.h in Headers */,
+				48C752E8E1B97C22815F2C2F /* extobjc.h in Headers */,
+				C72209938DC877016BFCA1C8 /* metamacros.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FAB201B6AA122E248540DBB2 /* Headers */ = {
+		B5BC6CAFAA98E09983D5AFEB /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				31A401E2B4D43F102B4664D0 /* MarqueeLabel.h in Headers */,
+				D168EFEA468154C519508F76 /* MarqueeLabel.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		3F8AD37200ACC174D2334FE3 /* Pods-TWSReleaseNotesView */ = {
+		1EA29FE494B647B1CA5B1F04 /* Pods-TWSReleaseNotesView */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 4749C754E84C399548CF64BD /* Build configuration list for PBXNativeTarget "Pods-TWSReleaseNotesView" */;
+			buildConfigurationList = 212C757C8970D72F57D0D678 /* Build configuration list for PBXNativeTarget "Pods-TWSReleaseNotesView" */;
 			buildPhases = (
-				0AA0B855A2DC84931ABA1810 /* Sources */,
-				0790DE054B70D8F5BD68C8A5 /* Frameworks */,
-				A781CCE0FD2CE036DFC5F128 /* Headers */,
+				9D49990D1E63A870024BA5AA /* Sources */,
+				8322D9A8E9F7D5CC4D981FE4 /* Frameworks */,
+				3F6666064208C842AAAC0C58 /* Headers */,
 			);
 			buildRules = (
 			);
@@ -548,52 +548,16 @@
 			);
 			name = "Pods-TWSReleaseNotesView";
 			productName = "Pods-TWSReleaseNotesView";
-			productReference = BB5DA0671F9399685550440D /* libPods-TWSReleaseNotesView.a */;
+			productReference = 5D7C97C9BB1DEE09F82E6901 /* libPods-TWSReleaseNotesView.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		6FD5298282F9BA9113635801 /* Pods */ = {
+		387E3EAAE60CCBA7E53D7CCE /* Pods-MarqueeLabel */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = DFA52E71DE7D8D41A939E83D /* Build configuration list for PBXNativeTarget "Pods" */;
+			buildConfigurationList = D279F0CD0345BE986899744E /* Build configuration list for PBXNativeTarget "Pods-MarqueeLabel" */;
 			buildPhases = (
-				69838DD12F41A4DA26425A22 /* Sources */,
-				43F7A9DDDB998A83C1309A86 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				227EC3AFAFF93ACD458D846F /* PBXTargetDependency */,
-				81E2B02B4575C13D98573943 /* PBXTargetDependency */,
-				414D2244A34A4F6B4ABEAC72 /* PBXTargetDependency */,
-			);
-			name = Pods;
-			productName = Pods;
-			productReference = BFA7D0AE64CC9547D69CAD2B /* libPods.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		B8A3A151E97B9FDB05163D89 /* Pods-libextobjc */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 56409D7311587A6BF8791B29 /* Build configuration list for PBXNativeTarget "Pods-libextobjc" */;
-			buildPhases = (
-				70A3D531B2DB7AE03FD0145D /* Sources */,
-				CFD93F41F64DF2026A253BE4 /* Frameworks */,
-				34329AE873765654C8A7FEA3 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "Pods-libextobjc";
-			productName = "Pods-libextobjc";
-			productReference = 13C36616246758F815C35FC5 /* libPods-libextobjc.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		E1BCB5CD685D8FB20D6D3235 /* Pods-MarqueeLabel */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 198BCB08311152A3C9FDBF63 /* Build configuration list for PBXNativeTarget "Pods-MarqueeLabel" */;
-			buildPhases = (
-				8A10F512FC85971B64FAA670 /* Sources */,
-				9C5B568189AA3FD773445B88 /* Frameworks */,
-				FAB201B6AA122E248540DBB2 /* Headers */,
+				00C56F9427C3932EE29F664F /* Sources */,
+				788431196C5DE6B8246E4B36 /* Frameworks */,
+				B5BC6CAFAA98E09983D5AFEB /* Headers */,
 			);
 			buildRules = (
 			);
@@ -601,242 +565,166 @@
 			);
 			name = "Pods-MarqueeLabel";
 			productName = "Pods-MarqueeLabel";
-			productReference = D2E4D157A777486E768F5B9A /* libPods-MarqueeLabel.a */;
+			productReference = F92F540EE0A833F8DF79E1B3 /* libPods-MarqueeLabel.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		BFA059C29BCBD304424764E8 /* Pods */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C1D0656A2F9B894EFCE8A9E1 /* Build configuration list for PBXNativeTarget "Pods" */;
+			buildPhases = (
+				1A69CF3D55CDFBF230AC3837 /* Sources */,
+				206EF4F034CBE1AEDB2246C3 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				BEACDED476957E7D809C6621 /* PBXTargetDependency */,
+				4D8076D12E887FEF76DF56C3 /* PBXTargetDependency */,
+				D34DBCC5A712D9D569291E86 /* PBXTargetDependency */,
+			);
+			name = Pods;
+			productName = Pods;
+			productReference = 58A065FB1C7DC8E6D89B10BB /* libPods.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		DF469E6643E129BDD3EF381A /* Pods-libextobjc */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2677F261653753207EF523B7 /* Build configuration list for PBXNativeTarget "Pods-libextobjc" */;
+			buildPhases = (
+				7117858B0284B00C87F4D2B8 /* Sources */,
+				E1D2A4CC1E1BFEE45EBE6AE8 /* Frameworks */,
+				AF6B1773F833D0F2849FF744 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Pods-libextobjc";
+			productName = "Pods-libextobjc";
+			productReference = A7D5D829B980E2034534B4E6 /* libPods-libextobjc.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-		1C1EF5A24F379EACE93B041B /* Project object */ = {
+		32401927A4BBDCDCB49BCF14 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 0640;
 			};
-			buildConfigurationList = 4DC1A80303EE7269A1AB812B /* Build configuration list for PBXProject "Pods" */;
+			buildConfigurationList = D9A7277CC48B0DE9E49CA316 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
 			);
-			mainGroup = 1BC849E247A0A97765EF6B5F;
-			productRefGroup = 5D0F93B46E1E28E542CC7A5C /* Products */;
+			mainGroup = 8EF95EA85F67A03D8AA70E99;
+			productRefGroup = 7F2E57B8D43DCAF39EE88EDB /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				6FD5298282F9BA9113635801 /* Pods */,
-				E1BCB5CD685D8FB20D6D3235 /* Pods-MarqueeLabel */,
-				3F8AD37200ACC174D2334FE3 /* Pods-TWSReleaseNotesView */,
-				B8A3A151E97B9FDB05163D89 /* Pods-libextobjc */,
+				BFA059C29BCBD304424764E8 /* Pods */,
+				387E3EAAE60CCBA7E53D7CCE /* Pods-MarqueeLabel */,
+				1EA29FE494B647B1CA5B1F04 /* Pods-TWSReleaseNotesView */,
+				DF469E6643E129BDD3EF381A /* Pods-libextobjc */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXSourcesBuildPhase section */
-		0AA0B855A2DC84931ABA1810 /* Sources */ = {
+		00C56F9427C3932EE29F664F /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				35FBD641301C99FF4F6CC86A /* Pods-TWSReleaseNotesView-dummy.m in Sources */,
-				2F629A85B508E42EA03AD17B /* TWSReleaseNotesDownloadOperation.m in Sources */,
-				B19357B331DB8A28A57094D5 /* TWSReleaseNotesView.m in Sources */,
-				96A72230F5565B280873E7A9 /* UIImage+ImageEffects.m in Sources */,
+				F4054EA2D7AC23F47B647D82 /* MarqueeLabel.m in Sources */,
+				98A2D4569400276ACF451C44 /* Pods-MarqueeLabel-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		69838DD12F41A4DA26425A22 /* Sources */ = {
+		1A69CF3D55CDFBF230AC3837 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0CF45B9E64E565849CE8314A /* Pods-dummy.m in Sources */,
+				8D4CC136B22CEADD4F280C49 /* Pods-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		70A3D531B2DB7AE03FD0145D /* Sources */ = {
+		7117858B0284B00C87F4D2B8 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8F9594642E468AD5324BB650 /* EXTADT.m in Sources */,
-				989F1337C97C4D3A4924EDA4 /* EXTConcreteProtocol.m in Sources */,
-				83F74F20DD0E256685483CAD /* EXTNil.m in Sources */,
-				D3B37797F09D4B5940D4A7F7 /* EXTRuntimeExtensions.m in Sources */,
-				473ABB64D075DFCCB6CFE14C /* EXTSafeCategory.m in Sources */,
-				E15C90F37294EE615A47F80B /* EXTScope.m in Sources */,
-				136CFB10847379341FD454C7 /* EXTSelectorChecking.m in Sources */,
-				81E2602B2263896493A3A40F /* NSInvocation+EXT.m in Sources */,
-				8F114E3E275C1AFA8B4C3671 /* NSMethodSignature+EXT.m in Sources */,
-				33B1C19125019F7687E1422C /* Pods-libextobjc-dummy.m in Sources */,
+				97ADDA189148B5DD43DB805E /* EXTADT.m in Sources */,
+				621ED145912749E968D8138B /* EXTConcreteProtocol.m in Sources */,
+				586AE409A6CFBBA59CDD1F9E /* EXTNil.m in Sources */,
+				997475F15BA74FF553F81CCA /* EXTRuntimeExtensions.m in Sources */,
+				CCD83C76F7759E1CB6DF9F99 /* EXTSafeCategory.m in Sources */,
+				44B18D488716AAC17D76DF3A /* EXTScope.m in Sources */,
+				DF82EFA36204D48E90D47008 /* EXTSelectorChecking.m in Sources */,
+				8E42057D3FB037ECAA32AA8E /* NSInvocation+EXT.m in Sources */,
+				B263B250FC8360130591DB25 /* NSMethodSignature+EXT.m in Sources */,
+				178915188B014556ED55FD08 /* Pods-libextobjc-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		8A10F512FC85971B64FAA670 /* Sources */ = {
+		9D49990D1E63A870024BA5AA /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DED8AA60288F2DC77F4B0A10 /* MarqueeLabel.m in Sources */,
-				AE634BF46D25C1B197F9B6F8 /* Pods-MarqueeLabel-dummy.m in Sources */,
+				A8DB5D8BBA34269B35AC0535 /* Pods-TWSReleaseNotesView-dummy.m in Sources */,
+				6EB59EE836C1A46C04590237 /* TWSReleaseNotesDownloadOperation.m in Sources */,
+				91123F2D9A357DBD86FECCCD /* TWSReleaseNotesView.m in Sources */,
+				C9D239B5596EAB63DC249E1D /* UIImage+ImageEffects.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		227EC3AFAFF93ACD458D846F /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Pods-MarqueeLabel";
-			target = E1BCB5CD685D8FB20D6D3235 /* Pods-MarqueeLabel */;
-			targetProxy = 192A51FE74B1E297CC969A14 /* PBXContainerItemProxy */;
-		};
-		414D2244A34A4F6B4ABEAC72 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Pods-libextobjc";
-			target = B8A3A151E97B9FDB05163D89 /* Pods-libextobjc */;
-			targetProxy = 185907D2E1AA4F711682A95D /* PBXContainerItemProxy */;
-		};
-		81E2B02B4575C13D98573943 /* PBXTargetDependency */ = {
+		4D8076D12E887FEF76DF56C3 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Pods-TWSReleaseNotesView";
-			target = 3F8AD37200ACC174D2334FE3 /* Pods-TWSReleaseNotesView */;
-			targetProxy = 07A3ACF885A9FB453CD2BB87 /* PBXContainerItemProxy */;
+			target = 1EA29FE494B647B1CA5B1F04 /* Pods-TWSReleaseNotesView */;
+			targetProxy = 0201D100C180E7ACB2A5A85A /* PBXContainerItemProxy */;
+		};
+		BEACDED476957E7D809C6621 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-MarqueeLabel";
+			target = 387E3EAAE60CCBA7E53D7CCE /* Pods-MarqueeLabel */;
+			targetProxy = 3E813D32C04D97AB45DE8881 /* PBXContainerItemProxy */;
+		};
+		D34DBCC5A712D9D569291E86 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-libextobjc";
+			target = DF469E6643E129BDD3EF381A /* Pods-libextobjc */;
+			targetProxy = 27970B028C46F9F93A52217B /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		09C4A3BBC0D3635B0E48DC40 /* Release */ = {
+		11EE031634CF1A7F86D853B5 /* AdHocDistribution */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A3FEBA243AC9096CE50C6159 /* Pods-MarqueeLabel-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-MarqueeLabel/Pods-MarqueeLabel-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		2DBEC3FBC0FD67FCA4307137 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = C0F17F418B16670D9C0D014F /* Pods-TWSReleaseNotesView-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-TWSReleaseNotesView/Pods-TWSReleaseNotesView-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
-		6AA83CCFBFD7287231F56B73 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = A3FEBA243AC9096CE50C6159 /* Pods-MarqueeLabel-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-MarqueeLabel/Pods-MarqueeLabel-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
-		727AAD3DB4982C2F8EA1CABB /* AdHocDistribution */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = C0F17F418B16670D9C0D014F /* Pods-TWSReleaseNotesView-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-TWSReleaseNotesView/Pods-TWSReleaseNotesView-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = AdHocDistribution;
-		};
-		75B754CB74DA242D94B9F8C8 /* AppStoreDistribution */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0D715BC25A6E8CB4FF62C54E /* Pods.appstoredistribution.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = AppStoreDistribution;
-		};
-		86F0AA1DC714DAD160613D1C /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = F0216D99F63DE66DBB58C5CA /* Pods.debug.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
-		8B4F8D0EF4367B8B37DA67DF /* AppStoreDistribution */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = A3FEBA243AC9096CE50C6159 /* Pods-MarqueeLabel-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-MarqueeLabel/Pods-MarqueeLabel-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = AppStoreDistribution;
-		};
-		8B830CDD11DC5FF826EE0DE8 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 67FE525B989A3D3C1BC8B8F3 /* Pods-libextobjc-Private.xcconfig */;
+			baseConfigurationReference = 7BFB73D8B189485E38041DC6 /* Pods-libextobjc-Private.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_PREFIX_HEADER = "Target Support Files/Pods-libextobjc/Pods-libextobjc-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
-				MTL_ENABLE_DEBUG_INFO = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 			};
-			name = Debug;
+			name = AdHocDistribution;
 		};
-		904987A9DC0D47FB2E299670 /* Release */ = {
+		1B6946698523C36FDE5265E5 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C0F17F418B16670D9C0D014F /* Pods-TWSReleaseNotesView-Private.xcconfig */;
+			baseConfigurationReference = 7BFB73D8B189485E38041DC6 /* Pods-libextobjc-Private.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-TWSReleaseNotesView/Pods-TWSReleaseNotesView-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-libextobjc/Pods-libextobjc-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
@@ -846,13 +734,29 @@
 			};
 			name = Release;
 		};
-		92D458F84EE8F4FD6BE0F268 /* AppStoreDistribution */ = {
+		350D7C8DD083CC5A69D1F78B /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C0F17F418B16670D9C0D014F /* Pods-TWSReleaseNotesView-Private.xcconfig */;
+			baseConfigurationReference = 1923AB4C80B13F1E226A9D4D /* Pods.debug.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		41DD9BA6548981B7B773AD8E /* AppStoreDistribution */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 32E1B01A64F4ADCA31E258FF /* Pods-TWSReleaseNotesView-Private.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_PREFIX_HEADER = "Target Support Files/Pods-TWSReleaseNotesView/Pods-TWSReleaseNotesView-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
@@ -862,12 +766,12 @@
 			};
 			name = AppStoreDistribution;
 		};
-		94ED277ED12AD45D45978909 /* AdHocDistribution */ = {
+		4A5F1D2D41882191BEE59A6E /* AppStoreDistribution */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F2C5E014231056C41F1BF545 /* Pods.adhocdistribution.xcconfig */;
+			baseConfigurationReference = 6D91020BAA5B0C3A47FA40F4 /* Pods.appstoredistribution.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
@@ -876,41 +780,42 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 			};
+			name = AppStoreDistribution;
+		};
+		52089E4CFC38F9670C944229 /* AdHocDistribution */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_PREPROCESSOR_DEFINITIONS = "ADHOCDISTRIBUTION=1";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				STRIP_INSTALLED_PRODUCT = NO;
+				VALIDATE_PRODUCT = YES;
+			};
 			name = AdHocDistribution;
 		};
-		A1A26CB4F868C6DBC10BA809 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 69A9A663DA6FB2DEA631D410 /* Pods.release.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		B14C472C93E90ECF416DA56E /* AdHocDistribution */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = A3FEBA243AC9096CE50C6159 /* Pods-MarqueeLabel-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-MarqueeLabel/Pods-MarqueeLabel-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = AdHocDistribution;
-		};
-		B4BE22A0D158A546C897CE3C /* Debug */ = {
+		59F5BF3133FBEF28BE8C82CD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -942,69 +847,36 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				ONLY_ACTIVE_ARCH = YES;
 				STRIP_INSTALLED_PRODUCT = NO;
 				SYMROOT = "${SRCROOT}/../build";
 			};
 			name = Debug;
 		};
-		C2E21E3CDF1CC9186C479484 /* AdHocDistribution */ = {
+		73DE13800654ACF7EE46A8CE /* Debug */ = {
 			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = YES;
-				ENABLE_NS_ASSERTIONS = NO;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_PREPROCESSOR_DEFINITIONS = "ADHOCDISTRIBUTION=1";
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
-				STRIP_INSTALLED_PRODUCT = NO;
-				VALIDATE_PRODUCT = YES;
-			};
-			name = AdHocDistribution;
-		};
-		CFAA443D86CE12E04CF8C477 /* AppStoreDistribution */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 67FE525B989A3D3C1BC8B8F3 /* Pods-libextobjc-Private.xcconfig */;
+			baseConfigurationReference = 7A4B714055BF777B977F9F7A /* Pods-MarqueeLabel-Private.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-libextobjc/Pods-libextobjc-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-MarqueeLabel/Pods-MarqueeLabel-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 			};
-			name = AppStoreDistribution;
+			name = Debug;
 		};
-		E626ED17064DF9F42907DE95 /* AdHocDistribution */ = {
+		7646A40A8D55A3F5D070C040 /* AdHocDistribution */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 67FE525B989A3D3C1BC8B8F3 /* Pods-libextobjc-Private.xcconfig */;
+			baseConfigurationReference = 7A4B714055BF777B977F9F7A /* Pods-MarqueeLabel-Private.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-libextobjc/Pods-libextobjc-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-MarqueeLabel/Pods-MarqueeLabel-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
@@ -1014,40 +886,55 @@
 			};
 			name = AdHocDistribution;
 		};
-		E986135D94087457A2D20E00 /* AppStoreDistribution */ = {
+		7B47C074B7CB1C2D5468F2BC /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 32E1B01A64F4ADCA31E258FF /* Pods-TWSReleaseNotesView-Private.xcconfig */;
 			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = YES;
-				ENABLE_NS_ASSERTIONS = NO;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_PREPROCESSOR_DEFINITIONS = "APPSTOREDISTRIBUTION=1";
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
-				STRIP_INSTALLED_PRODUCT = NO;
-				VALIDATE_PRODUCT = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-TWSReleaseNotesView/Pods-TWSReleaseNotesView-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
 			};
-			name = AppStoreDistribution;
+			name = Debug;
 		};
-		EADC78D44B7C5A1DE45BA30B /* Release */ = {
+		7C7A66ADB35FFD4E4F8FBB65 /* AdHocDistribution */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = CAA9812938AF2647B0999409 /* Pods.adhocdistribution.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = AdHocDistribution;
+		};
+		7FD3EB3B63E9EE98445A06E5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 32E1B01A64F4ADCA31E258FF /* Pods-TWSReleaseNotesView-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-TWSReleaseNotesView/Pods-TWSReleaseNotesView-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		8ED8262DD6A0553E93E9FD17 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1074,20 +961,69 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				STRIP_INSTALLED_PRODUCT = NO;
 				SYMROOT = "${SRCROOT}/../build";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
 		};
-		F488DE7265012937BAC26EF0 /* Release */ = {
+		91DCD8DA252E4D968040592C /* AppStoreDistribution */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 67FE525B989A3D3C1BC8B8F3 /* Pods-libextobjc-Private.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_PREPROCESSOR_DEFINITIONS = "APPSTOREDISTRIBUTION=1";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				STRIP_INSTALLED_PRODUCT = NO;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = AppStoreDistribution;
+		};
+		B109F69074F36CFDBE52061E /* AppStoreDistribution */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7A4B714055BF777B977F9F7A /* Pods-MarqueeLabel-Private.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-libextobjc/Pods-libextobjc-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-MarqueeLabel/Pods-MarqueeLabel-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = AppStoreDistribution;
+		};
+		B28763DF3254C2A577132199 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7A4B714055BF777B977F9F7A /* Pods-MarqueeLabel-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-MarqueeLabel/Pods-MarqueeLabel-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
@@ -1097,65 +1033,129 @@
 			};
 			name = Release;
 		};
+		C3D7B4251180A80729B1A30E /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A57DE3E1C2EC2B31975DEA78 /* Pods.release.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		DEAEF710FB70E5CEA7B0F76B /* AppStoreDistribution */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7BFB73D8B189485E38041DC6 /* Pods-libextobjc-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-libextobjc/Pods-libextobjc-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = AppStoreDistribution;
+		};
+		F799F8984E8C022DF70AB30F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7BFB73D8B189485E38041DC6 /* Pods-libextobjc-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-libextobjc/Pods-libextobjc-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		FAD42CDB8543DBE972D9790F /* AdHocDistribution */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 32E1B01A64F4ADCA31E258FF /* Pods-TWSReleaseNotesView-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-TWSReleaseNotesView/Pods-TWSReleaseNotesView-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = AdHocDistribution;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		198BCB08311152A3C9FDBF63 /* Build configuration list for PBXNativeTarget "Pods-MarqueeLabel" */ = {
+		212C757C8970D72F57D0D678 /* Build configuration list for PBXNativeTarget "Pods-TWSReleaseNotesView" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				B14C472C93E90ECF416DA56E /* AdHocDistribution */,
-				8B4F8D0EF4367B8B37DA67DF /* AppStoreDistribution */,
-				6AA83CCFBFD7287231F56B73 /* Debug */,
-				09C4A3BBC0D3635B0E48DC40 /* Release */,
+				FAD42CDB8543DBE972D9790F /* AdHocDistribution */,
+				41DD9BA6548981B7B773AD8E /* AppStoreDistribution */,
+				7B47C074B7CB1C2D5468F2BC /* Debug */,
+				7FD3EB3B63E9EE98445A06E5 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		4749C754E84C399548CF64BD /* Build configuration list for PBXNativeTarget "Pods-TWSReleaseNotesView" */ = {
+		2677F261653753207EF523B7 /* Build configuration list for PBXNativeTarget "Pods-libextobjc" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				727AAD3DB4982C2F8EA1CABB /* AdHocDistribution */,
-				92D458F84EE8F4FD6BE0F268 /* AppStoreDistribution */,
-				2DBEC3FBC0FD67FCA4307137 /* Debug */,
-				904987A9DC0D47FB2E299670 /* Release */,
+				11EE031634CF1A7F86D853B5 /* AdHocDistribution */,
+				DEAEF710FB70E5CEA7B0F76B /* AppStoreDistribution */,
+				F799F8984E8C022DF70AB30F /* Debug */,
+				1B6946698523C36FDE5265E5 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		4DC1A80303EE7269A1AB812B /* Build configuration list for PBXProject "Pods" */ = {
+		C1D0656A2F9B894EFCE8A9E1 /* Build configuration list for PBXNativeTarget "Pods" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				C2E21E3CDF1CC9186C479484 /* AdHocDistribution */,
-				E986135D94087457A2D20E00 /* AppStoreDistribution */,
-				B4BE22A0D158A546C897CE3C /* Debug */,
-				EADC78D44B7C5A1DE45BA30B /* Release */,
+				7C7A66ADB35FFD4E4F8FBB65 /* AdHocDistribution */,
+				4A5F1D2D41882191BEE59A6E /* AppStoreDistribution */,
+				350D7C8DD083CC5A69D1F78B /* Debug */,
+				C3D7B4251180A80729B1A30E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		56409D7311587A6BF8791B29 /* Build configuration list for PBXNativeTarget "Pods-libextobjc" */ = {
+		D279F0CD0345BE986899744E /* Build configuration list for PBXNativeTarget "Pods-MarqueeLabel" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				E626ED17064DF9F42907DE95 /* AdHocDistribution */,
-				CFAA443D86CE12E04CF8C477 /* AppStoreDistribution */,
-				8B830CDD11DC5FF826EE0DE8 /* Debug */,
-				F488DE7265012937BAC26EF0 /* Release */,
+				7646A40A8D55A3F5D070C040 /* AdHocDistribution */,
+				B109F69074F36CFDBE52061E /* AppStoreDistribution */,
+				73DE13800654ACF7EE46A8CE /* Debug */,
+				B28763DF3254C2A577132199 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		DFA52E71DE7D8D41A939E83D /* Build configuration list for PBXNativeTarget "Pods" */ = {
+		D9A7277CC48B0DE9E49CA316 /* Build configuration list for PBXProject "Pods" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				94ED277ED12AD45D45978909 /* AdHocDistribution */,
-				75B754CB74DA242D94B9F8C8 /* AppStoreDistribution */,
-				86F0AA1DC714DAD160613D1C /* Debug */,
-				A1A26CB4F868C6DBC10BA809 /* Release */,
+				52089E4CFC38F9670C944229 /* AdHocDistribution */,
+				91DCD8DA252E4D968040592C /* AppStoreDistribution */,
+				59F5BF3133FBEF28BE8C82CD /* Debug */,
+				8ED8262DD6A0553E93E9FD17 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};
-	rootObject = 1C1EF5A24F379EACE93B041B /* Project object */;
+	rootObject = 32401927A4BBDCDCB49BCF14 /* Project object */;
 }

--- a/controls/progress/OBAProgressIndicatorView.m
+++ b/controls/progress/OBAProgressIndicatorView.m
@@ -79,19 +79,12 @@
     
     CGRect labelFrame = CGRectMake(0, 0, r.size.width, r.size.height);
     CGRect progressLabelFrame = CGRectMake(25, 0, r.size.width-25, r.size.height);
-    CGRect acitivityIndicatorFrame = CGRectMake(0, (r.size.height-20) / 2, 20, 20);
-    CGRect progressViewFrame;
-    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"7.0")) {
-        progressViewFrame = CGRectMake(0, (r.size.height-1)/2, r.size.width, 11);
-    } else {
-        progressViewFrame = CGRectMake(0, (r.size.height-11)/2, r.size.width, 11);
-    }
-    
+    CGRect activityIndicatorFrame = CGRectMake(0, (r.size.height-20) / 2, 20, 20);
+    CGRect progressViewFrame = CGRectMake(0, (r.size.height-1)/2, r.size.width, 11);
     
     _label = [[UILabel alloc] initWithFrame:labelFrame];        
     _progressLabel = [[UILabel alloc] initWithFrame:progressLabelFrame];
-    _activityIndicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:
-                          SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"7.0") ? UIActivityIndicatorViewStyleGray : UIActivityIndicatorViewStyleWhite];
+    _activityIndicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleGray];
     _progressView = [[UIProgressView alloc] initWithFrame:progressViewFrame];    
 
     self.backgroundColor = [UIColor clearColor];
@@ -99,7 +92,7 @@
     
     [self setupLabel:_label];
     [self setupLabel:_progressLabel];
-    _activityIndicator.frame = acitivityIndicatorFrame;
+    _activityIndicator.frame = activityIndicatorFrame;
     _label.textAlignment = NSTextAlignmentCenter;
     _progressLabel.textAlignment = NSTextAlignmentCenter;    
     
@@ -117,15 +110,8 @@
 - (void) setupLabel:(UILabel*)label {
     label.autoresizingMask = UIViewAutoresizingFlexibleWidth;
     label.backgroundColor = [UIColor clearColor];
-    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"7.0")) {
-        label.font = [UIFont boldSystemFontOfSize:16.0];
-        label.textColor = [UIColor blackColor];
-    } else {
-        label.font = [UIFont fontWithName:@"Helvetica-Bold" size:17.0];
-        label.textColor = [UIColor whiteColor];
-        label.shadowColor = [UIColor colorWithWhite:0.0 alpha:0.5];
-        label.shadowOffset = CGSizeMake(0,-1);
-    }
+    label.font = [UIFont boldSystemFontOfSize:16.0];
+    label.textColor = [UIColor blackColor];
 }
 
 @end

--- a/controls/toolbars/OBASearchResultsMapFilterToolbar.m
+++ b/controls/toolbars/OBASearchResultsMapFilterToolbar.m
@@ -36,7 +36,7 @@
         // set up filter toolbar, with "cancel filter" button
         //-------------------------------------------------
         UIBarButtonItem * clearItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemStop target:_filterDelegate action:@selector(onFilterClear)];
-        clearItem.style = UIBarButtonItemStyleBordered;
+        clearItem.style = UIBarButtonItemStylePlain;
         
         // right align the clear buttom
         UIBarButtonItem * flexItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil];
@@ -68,11 +68,11 @@
     // Find size for the title text
     NSString* filterLabelText     = NSLocalizedString(@"Search: ",@"setupLabels text");
     UIFont*   filterLabelFont     = [UIFont boldSystemFontOfSize:filterFontSize];
-    CGSize    filterLabelTextSize = [filterLabelText sizeWithFont:filterLabelFont];
+    CGSize    filterLabelTextSize = [filterLabelText sizeWithAttributes:@{NSFontAttributeName: filterLabelFont}];
     
     // Find size for the description text
     UIFont*   filterDescFont     = [UIFont systemFontOfSize:filterFontSize];
-    CGSize    filterDescTextSize = [self.filterDescription sizeWithFont:filterLabelFont];
+    CGSize    filterDescTextSize = [self.filterDescription sizeWithAttributes:@{NSFontAttributeName: filterLabelFont}];
     
     // Find total width of concatenated strings
     const CGFloat filterLabelAndDescSeparation = 0.0;

--- a/org.onebusaway.iphone.xcodeproj/project.pbxproj
+++ b/org.onebusaway.iphone.xcodeproj/project.pbxproj
@@ -192,11 +192,11 @@
 		932BE4AC1AB66D5C0011F2FB /* OBAGenericStopViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAGenericStopViewController.h; sourceTree = "<group>"; };
 		932BE4AD1AB66D5C0011F2FB /* OBAGenericStopViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAGenericStopViewController.m; sourceTree = "<group>"; };
 		932BE4AE1AB66D5C0011F2FB /* OBAReportProblemViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAReportProblemViewController.h; sourceTree = "<group>"; };
-		932BE4AF1AB66D5C0011F2FB /* OBAReportProblemViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAReportProblemViewController.m; sourceTree = "<group>"; };
+		932BE4AF1AB66D5C0011F2FB /* OBAReportProblemViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = OBAReportProblemViewController.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		932BE4B01AB66D5C0011F2FB /* OBAReportProblemWithRecentTripsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAReportProblemWithRecentTripsViewController.h; sourceTree = "<group>"; };
 		932BE4B11AB66D5C0011F2FB /* OBAReportProblemWithRecentTripsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAReportProblemWithRecentTripsViewController.m; sourceTree = "<group>"; };
 		932BE4B21AB66D5C0011F2FB /* OBAReportProblemWithStopViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAReportProblemWithStopViewController.h; sourceTree = "<group>"; };
-		932BE4B31AB66D5C0011F2FB /* OBAReportProblemWithStopViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAReportProblemWithStopViewController.m; sourceTree = "<group>"; };
+		932BE4B31AB66D5C0011F2FB /* OBAReportProblemWithStopViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = OBAReportProblemWithStopViewController.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		932BE4B41AB66D5C0011F2FB /* OBAStopViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAStopViewController.h; sourceTree = "<group>"; };
 		932BE4B51AB66D5C0011F2FB /* OBAStopViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAStopViewController.m; sourceTree = "<group>"; };
 		932BE4B61AB66D5C0011F2FB /* OBAStopWebViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAStopWebViewController.h; sourceTree = "<group>"; };
@@ -204,13 +204,13 @@
 		932BE4C31AB66D710011F2FB /* OBAArrivalAndDepartureViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAArrivalAndDepartureViewController.h; sourceTree = "<group>"; };
 		932BE4C41AB66D710011F2FB /* OBAArrivalAndDepartureViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAArrivalAndDepartureViewController.m; sourceTree = "<group>"; };
 		932BE4C51AB66D710011F2FB /* OBAReportProblemWithTripViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAReportProblemWithTripViewController.h; sourceTree = "<group>"; };
-		932BE4C61AB66D710011F2FB /* OBAReportProblemWithTripViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAReportProblemWithTripViewController.m; sourceTree = "<group>"; };
+		932BE4C61AB66D710011F2FB /* OBAReportProblemWithTripViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = OBAReportProblemWithTripViewController.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		932BE4C71AB66D710011F2FB /* OBATripDetailsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBATripDetailsViewController.h; sourceTree = "<group>"; };
 		932BE4C81AB66D710011F2FB /* OBATripDetailsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBATripDetailsViewController.m; sourceTree = "<group>"; };
 		932BE4C91AB66D710011F2FB /* OBATripScheduleListViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBATripScheduleListViewController.h; sourceTree = "<group>"; };
 		932BE4CA1AB66D710011F2FB /* OBATripScheduleListViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBATripScheduleListViewController.m; sourceTree = "<group>"; };
 		932BE4CB1AB66D710011F2FB /* OBATripScheduleMapViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBATripScheduleMapViewController.h; sourceTree = "<group>"; };
-		932BE4CC1AB66D710011F2FB /* OBATripScheduleMapViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBATripScheduleMapViewController.m; sourceTree = "<group>"; };
+		932BE4CC1AB66D710011F2FB /* OBATripScheduleMapViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = OBATripScheduleMapViewController.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		932BE4D31AB66D890011F2FB /* OBADiversionViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBADiversionViewController.h; sourceTree = "<group>"; };
 		932BE4D41AB66D890011F2FB /* OBADiversionViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBADiversionViewController.m; sourceTree = "<group>"; };
 		932BE4D51AB66D890011F2FB /* OBASituationsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBASituationsViewController.h; sourceTree = "<group>"; };
@@ -232,9 +232,9 @@
 		932BE4F01AB66E990011F2FB /* OBASearchController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBASearchController.h; sourceTree = "<group>"; };
 		932BE4F11AB66E990011F2FB /* OBASearchController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBASearchController.m; sourceTree = "<group>"; };
 		932BE4F21AB66E990011F2FB /* OBASearchResultsListViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBASearchResultsListViewController.h; sourceTree = "<group>"; };
-		932BE4F31AB66E990011F2FB /* OBASearchResultsListViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBASearchResultsListViewController.m; sourceTree = "<group>"; };
+		932BE4F31AB66E990011F2FB /* OBASearchResultsListViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = OBASearchResultsListViewController.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		932BE4F41AB66E990011F2FB /* OBASearchResultsMapViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBASearchResultsMapViewController.h; sourceTree = "<group>"; };
-		932BE4F51AB66E990011F2FB /* OBASearchResultsMapViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBASearchResultsMapViewController.m; sourceTree = "<group>"; };
+		932BE4F51AB66E990011F2FB /* OBASearchResultsMapViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = OBASearchResultsMapViewController.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		932BE4F91AB66EDD0011F2FB /* OBAVehicleDetailsController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAVehicleDetailsController.h; sourceTree = "<group>"; };
 		932BE4FA1AB66EDD0011F2FB /* OBAVehicleDetailsController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAVehicleDetailsController.m; sourceTree = "<group>"; };
 		932BE4FD1AB66EF20011F2FB /* OBARecentStopsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBARecentStopsViewController.h; sourceTree = "<group>"; };
@@ -280,7 +280,7 @@
 		93631E7B1604F9A200CB7209 /* OBANetworkErrorAlertViewDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBANetworkErrorAlertViewDelegate.h; sourceTree = "<group>"; };
 		93631E7C1604F9A200CB7209 /* OBANetworkErrorAlertViewDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBANetworkErrorAlertViewDelegate.m; sourceTree = "<group>"; };
 		93631E7E1604F9A200CB7209 /* OBASearchResultsMapFilterToolbar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBASearchResultsMapFilterToolbar.h; sourceTree = "<group>"; };
-		93631E7F1604F9A200CB7209 /* OBASearchResultsMapFilterToolbar.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBASearchResultsMapFilterToolbar.m; sourceTree = "<group>"; };
+		93631E7F1604F9A200CB7209 /* OBASearchResultsMapFilterToolbar.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = OBASearchResultsMapFilterToolbar.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		9388E9DC1A9BCC8900C9F6CE /* feedback_message_body.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; name = feedback_message_body.html; path = Resources/feedback_message_body.html; sourceTree = "<group>"; };
 		93AD36391603FE7E00BDF03F /* OBAArrivalEntryTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAArrivalEntryTableViewCell.h; sourceTree = "<group>"; };
 		93AD363A1603FE7E00BDF03F /* OBAArrivalEntryTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAArrivalEntryTableViewCell.m; sourceTree = "<group>"; };
@@ -1147,7 +1147,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				INFOPLIST_PREFIX_HEADER = $PROJECT_TEMP_DIR/infoplist.prefix;
 				INFOPLIST_PREPROCESS = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-weak_framework",
@@ -1201,7 +1201,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				INFOPLIST_PREFIX_HEADER = $PROJECT_TEMP_DIR/infoplist.prefix;
 				INFOPLIST_PREPROCESS = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-weak_framework",
@@ -1503,7 +1503,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				INFOPLIST_PREFIX_HEADER = $PROJECT_TEMP_DIR/infoplist.prefix;
 				INFOPLIST_PREPROCESS = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-weak_framework",
@@ -1574,7 +1574,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				INFOPLIST_PREFIX_HEADER = $PROJECT_TEMP_DIR/infoplist.prefix;
 				INFOPLIST_PREPROCESS = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-weak_framework",

--- a/sdk/sdk/Models/unmanaged/OBAPlacemark.m
+++ b/sdk/sdk/Models/unmanaged/OBAPlacemark.m
@@ -35,7 +35,7 @@
         _address =  [coder decodeObjectForKey:@"address"];
         _icon =  [coder decodeObjectForKey:@"icon"];
         NSData * data = [coder decodeObjectForKey:@"coordinate"];
-        [data getBytes:&_coordinate];
+        [data getBytes:&_coordinate length:sizeof(CLLocationCoordinate2D)];
     }
     return self;
 }

--- a/sdk/sdk/Services/OBAJsonDataSource.m
+++ b/sdk/sdk/Services/OBAJsonDataSource.m
@@ -238,7 +238,7 @@
         self.responseEncoding = NSUTF8StringEncoding;
     }
 
-    self.expectedLength = [response expectedContentLength];
+    self.expectedLength = (NSInteger)response.expectedContentLength;
 }
 
 - (void)connection:(NSURLConnection *)connection didReceiveData:(NSMutableData *)data {

--- a/sdk/sdk/Services/OBAModelService.h
+++ b/sdk/sdk/Services/OBAModelService.h
@@ -102,7 +102,7 @@
  *  @return The OBAModelServiceRequest object that allows request cancellation
  */
 - (id<OBAModelServiceRequest>)requestStopsForQuery:(NSString *)stopQuery
-                                        withRegion:(CLRegion *)region
+                                        withRegion:(CLCircularRegion *)region
                                    completionBlock:(OBADataSourceCompletion)completion;
 /**
  *  Makes an asynchronous request to fetch a set of stops that belong to a particular route.
@@ -144,7 +144,7 @@
  *  @return The OBAModelServiceRequest object that allows request cancellation
  */
 - (id<OBAModelServiceRequest>)requestRoutesForQuery:(NSString *)routeQuery
-                                         withRegion:(CLRegion *)region
+                                         withRegion:(CLCircularRegion *)region
                                     completionBlock:(OBADataSourceCompletion)completion;
 /**
  *  Makes an asynchronous request to fetch a set of placemarks based on address string

--- a/sdk/sdk/Services/OBAModelService.m
+++ b/sdk/sdk/Services/OBAModelService.m
@@ -44,7 +44,7 @@ static const CLLocationAccuracy kBigSearchRadius = 15000;
     return [self requestStopsForQuery:stopQuery withRegion:nil completionBlock:completion];
 }
 
-- (id<OBAModelServiceRequest>)requestStopsForQuery:(NSString *)stopQuery withRegion:(CLRegion *)region completionBlock:(OBADataSourceCompletion)completion {
+- (id<OBAModelServiceRequest>)requestStopsForQuery:(NSString *)stopQuery withRegion:(CLCircularRegion *)region completionBlock:(OBADataSourceCompletion)completion {
     CLLocationDistance radius = kBigSearchRadius;
     CLLocationCoordinate2D coord;
 
@@ -89,7 +89,7 @@ static const CLLocationAccuracy kBigSearchRadius = 15000;
     return [self requestRoutesForQuery:routeQuery withRegion:nil completionBlock:completion];
 }
 
-- (id<OBAModelServiceRequest>)requestRoutesForQuery:(NSString *)routeQuery withRegion:(CLRegion *)region completionBlock:(OBADataSourceCompletion)completion {
+- (id<OBAModelServiceRequest>)requestRoutesForQuery:(NSString *)routeQuery withRegion:(CLCircularRegion *)region completionBlock:(OBADataSourceCompletion)completion {
     CLLocationDistance radius = kBigSearchRadius;
     CLLocationCoordinate2D coord;
 
@@ -131,7 +131,10 @@ static const CLLocationAccuracy kBigSearchRadius = 15000;
 - (id<OBAModelServiceRequest>)requestRegions:(OBADataSourceCompletion)completion {
     NSString *url = @"/regions-v3.json";
     NSString *args = @"";
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
     SEL selector = @selector(getRegionsV2FromJson:error:);
+#pragma clang diagnostic pop
 
     return [self request:self.obaRegionJsonDataSource url:url args:args selector:selector completionBlock:completion progressBlock:nil];
 }

--- a/ui/search/OBASearchController.h
+++ b/ui/search/OBASearchController.h
@@ -49,7 +49,7 @@
 @property (strong,readonly) OBASearchResult * result;
 
 @property (weak, nonatomic,readonly) CLLocation * searchLocation;
-@property (nonatomic,strong) CLRegion *searchRegion;
+@property (nonatomic,strong) CLCircularRegion *searchRegion;
 
 @property (nonatomic,strong) NSObject<OBAProgressIndicatorSource>* progress;
 @property (nonatomic,strong) NSError * error;

--- a/ui/search/OBASearchController.m
+++ b/ui/search/OBASearchController.m
@@ -148,7 +148,7 @@
         case OBASearchTypeRegion: {
             NSData *data = [OBASearch getSearchTypeParameterForNagivationTarget:target];
             MKCoordinateRegion region;
-            [data getBytes:&region];
+            [data getBytes:&region length:sizeof(MKCoordinateRegion)];
 
             return [_modelService requestStopsForRegion:region
                                         completionBlock:^(id jsonData, NSUInteger responseCode, NSError *error) {

--- a/ui/search/OBASearchResultsListViewController.m
+++ b/ui/search/OBASearchResultsListViewController.m
@@ -47,7 +47,7 @@
     [super viewDidLoad];
 
     if (self.isModal) {
-        self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithImage:[UIImage imageNamed:@"map"] style:UIBarButtonItemStyleBordered target:self action:@selector(dismissModal)];
+        self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithImage:[UIImage imageNamed:@"map"] style:UIBarButtonItemStylePlain target:self action:@selector(dismissModal)];
     }
 
     CGFloat height = 2.f * CGRectGetHeight(self.view.frame);

--- a/ui/search/OBASearchResultsMapViewController.m
+++ b/ui/search/OBASearchResultsMapViewController.m
@@ -122,7 +122,7 @@ static NSString *kOBAIncreaseContrastKey = @"OBAIncreaseContrastDefaultsKey";
 - (BOOL)outOfServiceArea;
 
 - (CLLocationDistance)getDistanceFrom:(CLLocationCoordinate2D)start to:(CLLocationCoordinate2D)end;
-- (CLRegion *)convertVisibleMapIntoCLRegion;
+- (CLCircularRegion *)convertVisibleMapIntoCLCircularRegion;
 
 - (BOOL)checkStopsInRegion;
 @end
@@ -150,11 +150,7 @@ static NSString *kOBAIncreaseContrastKey = @"OBAIncreaseContrastDefaultsKey";
     self.networkErrorAlertViewDelegate = [[OBANetworkErrorAlertViewDelegate alloc] initWithContext:self.appDelegate];
 
     CGRect indicatorBounds = CGRectMake(12, 12, 36, 36);
-
-    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"7.0")) {
-        indicatorBounds.origin.y += self.navigationController.navigationBar.frame.size.height +
-            [UIApplication sharedApplication].statusBarFrame.size.height;
-    }
+    indicatorBounds.origin.y += self.navigationController.navigationBar.frame.size.height + [UIApplication sharedApplication].statusBarFrame.size.height;
 
     self.activityIndicatorWrapper = [[UIView alloc] initWithFrame:indicatorBounds];
     self.activityIndicatorWrapper.backgroundColor = OBARGBACOLOR(0, 0, 0, 0.5);
@@ -191,22 +187,17 @@ static NSString *kOBAIncreaseContrastKey = @"OBAIncreaseContrastDefaultsKey";
 
     self.navigationItem.leftBarButtonItem = [self getArrowButton];
 
-    self.listBarButtonItem = [[UIBarButtonItem alloc] initWithImage:[UIImage imageNamed:@"lines"] style:UIBarButtonItemStyleBordered target:self action:@selector(showListView:)];
+    self.listBarButtonItem = [[UIBarButtonItem alloc] initWithImage:[UIImage imageNamed:@"lines"] style:UIBarButtonItemStylePlain target:self action:@selector(showListView:)];
     self.listBarButtonItem.accessibilityLabel = NSLocalizedString(@"Nearby stops list", @"self.listBarButtonItem.accessibilityLabel");
     self.navigationItem.rightBarButtonItem = self.listBarButtonItem;
 
-    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"7.0")) {
-        self.titleView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 320, 44)];
-        self.searchBar.searchBarStyle = UISearchBarStyleMinimal;
-        [self.titleView addSubview:self.searchBar];
-        self.navigationItem.titleView = self.titleView;
-
-        if ([[NSUserDefaults standardUserDefaults] boolForKey:kOBAIncreaseContrastKey]) {
-            [self setHighContrastStyle];
-        }
-    }
-    else {
-        self.navigationItem.titleView = self.searchBar;
+    self.titleView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 320, 44)];
+    self.searchBar.searchBarStyle = UISearchBarStyleMinimal;
+    [self.titleView addSubview:self.searchBar];
+    self.navigationItem.titleView = self.titleView;
+    
+    if ([[NSUserDefaults standardUserDefaults] boolForKey:kOBAIncreaseContrastKey]) {
+        [self setHighContrastStyle];
     }
 
     self.mapLabel.hidden = YES;
@@ -223,33 +214,21 @@ static NSString *kOBAIncreaseContrastKey = @"OBAIncreaseContrastDefaultsKey";
     labelLayer.shadowOffset = CGSizeMake(0, 0);
     labelLayer.shadowRadius = 7;
 
-    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"7.0")) {
-        CGRect mapLabelFrame = self.mapLabel.frame;
-        mapLabelFrame.origin.y += self.navigationController.navigationBar.frame.size.height +
-            [UIApplication sharedApplication].statusBarFrame.size.height;
-        self.mapLabel.frame = mapLabelFrame;
-    }
+    CGRect mapLabelFrame = self.mapLabel.frame;
+    mapLabelFrame.origin.y += self.navigationController.navigationBar.frame.size.height +
+    [UIApplication sharedApplication].statusBarFrame.size.height;
+    self.mapLabel.frame = mapLabelFrame;
 
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(contrastToggled) name:OBAIncreaseContrastToggledNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onMapTabBarButton) name:@"OBAMapButtonRecenterNotification" object:nil];
 }
 
-- (void)viewDidAppear:(BOOL)animated {
-    [super viewDidAppear:animated];
-    
-    if (!SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"8.0")) {
-        self.mapView.showsUserLocation = YES;
-    }
-}
-
 - (void)contrastToggled {
-    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"7.0")) {
-        if ([[NSUserDefaults standardUserDefaults] boolForKey:kOBAIncreaseContrastKey]) {
-            [self setHighContrastStyle];
-        }
-        else {
-            [self setRegularStyle];
-        }
+    if ([[NSUserDefaults standardUserDefaults] boolForKey:kOBAIncreaseContrastKey]) {
+        [self setHighContrastStyle];
+    }
+    else {
+        [self setRegularStyle];
     }
 
     for (id<MKAnnotation> annotation in [self.mapView annotations]) {
@@ -316,7 +295,7 @@ static NSString *kOBAIncreaseContrastKey = @"OBAIncreaseContrastDefaultsKey";
 }
 
 - (UIBarButtonItem *)getArrowButton {
-    UIBarButtonItem *arrowButton = [[UIBarButtonItem alloc] initWithImage:[UIImage imageNamed:@"lbs_arrow"] style:UIBarButtonItemStyleBordered target:self action:@selector(onCrossHairsButton:)];
+    UIBarButtonItem *arrowButton = [[UIBarButtonItem alloc] initWithImage:[UIImage imageNamed:@"lbs_arrow"] style:UIBarButtonItemStylePlain target:self action:@selector(onCrossHairsButton:)];
 
     arrowButton.accessibilityLabel = NSLocalizedString(@"my location", @"arrowButton.accessibilityLabel");
     arrowButton.accessibilityHint = NSLocalizedString(@"centers the map on current location", @"arrowButton.accessibilityHint");
@@ -357,7 +336,7 @@ static NSString *kOBAIncreaseContrastKey = @"OBAIncreaseContrastDefaultsKey";
     [OBAAnalytics reportEventWithCategory:OBAAnalyticsCategoryUIAction action:@"button_press" label:@"Search button clicked" value:nil];
 
     OBANavigationTarget *target = nil;
-    self.searchController.searchRegion = [self convertVisibleMapIntoCLRegion];
+    self.searchController.searchRegion = [self convertVisibleMapIntoCLCircularRegion];
 
     if (kRouteSegmentIndex == self.searchTypeSegmentedControl.selectedSegmentIndex) {
         target = [OBASearch getNavigationTargetForSearchRoute:searchBar.text];
@@ -385,13 +364,7 @@ static NSString *kOBAIncreaseContrastKey = @"OBAIncreaseContrastDefaultsKey";
 
     CGRect finalScopeFrame = self.scopeView.frame;
 
-    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"7.0")) {
-        finalScopeFrame.origin.y = self.navigationController.navigationBar.frame.size.height +
-            [UIApplication sharedApplication].statusBarFrame.size.height;
-    }
-    else {
-        finalScopeFrame.origin.y = 0;
-    }
+    finalScopeFrame.origin.y = self.navigationController.navigationBar.frame.size.height + [UIApplication sharedApplication].statusBarFrame.size.height;
 
     [UIView animateWithDuration:kScopeViewAnimationDuration
                      animations:^{
@@ -434,7 +407,7 @@ static NSString *kOBAIncreaseContrastKey = @"OBAIncreaseContrastDefaultsKey";
         NSDictionary *parameters = target.parameters;
         NSData *data = parameters[kOBASearchControllerSearchArgumentParameter];
         MKCoordinateRegion region;
-        [data getBytes:&region];
+        [data getBytes:&region length:sizeof(MKCoordinateRegion)];
         [self.mapRegionManager setRegion:region changeWasProgramatic:NO];
     }
     else {
@@ -710,13 +683,13 @@ static NSString *kOBAIncreaseContrastKey = @"OBAIncreaseContrastDefaultsKey";
     }
 }
 
-- (MKOverlayView *)mapView:(MKMapView *)mapView viewForOverlay:(id)overlay {
+- (MKOverlayRenderer*)mapView:(MKMapView *)mapView rendererForOverlay:(id<MKOverlay>)overlay {
     if ([overlay isKindOfClass:[MKPolyline class]]) {
-        MKPolylineView *polylineView  = [[MKPolylineView alloc] initWithPolyline:overlay];
-        polylineView.fillColor = [UIColor blackColor];
-        polylineView.strokeColor = [UIColor blackColor];
-        polylineView.lineWidth = 5;
-        return polylineView;
+        MKPolylineRenderer *renderer = [[MKPolylineRenderer alloc] initWithPolyline:overlay];
+        renderer.fillColor = [UIColor blackColor];
+        renderer.strokeColor = [UIColor blackColor];
+        renderer.lineWidth = 5;
+        return renderer;
     }
     else {
         return nil;
@@ -1363,12 +1336,7 @@ NSInteger sortStopsByDistanceFromLocation(OBAStopV2* stop1, OBAStopV2* stop2, vo
 }
 
 - (void)cancelPressed {
-    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"7.0")) {
-        self.navigationItem.titleView = self.titleView;
-    }
-    else {
-        self.navigationItem.titleView = self.searchBar;
-    }
+    self.navigationItem.titleView = self.titleView;
 
     [self.searchController searchWithTarget:[OBASearch getNavigationTargetForSearchNone]];
     [self refreshStopsInRegion];
@@ -1442,15 +1410,15 @@ MKMapRect MKMapRectForCoordinateRegion(MKCoordinateRegion region) {
     return distance;
 }
 
-- (CLRegion *)convertVisibleMapIntoCLRegion {
+- (CLCircularRegion *)convertVisibleMapIntoCLCircularRegion {
     MKMapRect mRect = self.mapView.visibleMapRect;
     MKMapPoint neMapPoint = MKMapPointMake(MKMapRectGetMaxX(mRect), mRect.origin.y);
     MKMapPoint swMapPoint = MKMapPointMake(mRect.origin.x, MKMapRectGetMaxY(mRect));
     CLLocationCoordinate2D neCoord = MKCoordinateForMapPoint(neMapPoint);
     CLLocationCoordinate2D swCoord = MKCoordinateForMapPoint(swMapPoint);
     CLLocationDistance diameter = [self getDistanceFrom:neCoord to:swCoord];
-
-    return [[CLRegion alloc] initCircularRegionWithCenter:self.mapView.centerCoordinate radius:(diameter / 2) identifier:@"mapRegion"];
+    
+    return [[CLCircularRegion alloc] initWithCenter:self.mapView.centerCoordinate radius:(diameter / 2.0) identifier:@"mapRegion"];
 }
 
 - (BOOL)checkStopsInRegion {
@@ -1463,50 +1431,14 @@ MKMapRect MKMapRectForCoordinateRegion(MKCoordinateRegion region) {
     if (self.mapView.userLocation) {
         [annotations removeObject:self.mapView.userLocation];
     }
-
-    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"7.0")) {
-        for (id <MKAnnotation> annotation in annotations) {
-            MKAnnotationView *annotationView = [self.mapView viewForAnnotation:annotation];
-            MKCoordinateRegion annotationRegion = [self.mapView convertRect:annotationView.frame toRegionFromView:self.mapView];
-            MKMapRect annotationRect = MKMapRectForCoordinateRegion(annotationRegion);
-
-            if (MKMapRectIntersectsRect(self.mapView.visibleMapRect, annotationRect)) {
-                return YES;
-            }
-        }
-    }
-    else {
-        for (id <MKAnnotation> annotation in annotations) {
-            if ([annotation isKindOfClass:[OBAStopV2 class]]) {
-                OBAStopV2 *stop = (OBAStopV2 *)annotation;
-                CLLocationCoordinate2D annotationCoord = stop.coordinate;
-
-                CGPoint annotationPoint = [self.mapView convertCoordinate:annotationCoord toPointToView:self.mapView];
-                CGRect annotationFrame;
-
-                if (stop.direction.length == 2) {
-                    annotationFrame = CGRectMake(annotationPoint.x - 17.5f, annotationPoint.y - 17.5f, 35.f, 35.f);
-                }
-                else if (stop.direction.length == 1) {
-                    if ([stop.direction isEqualToString:@"E"] || [stop.direction isEqualToString:@"W"]) {
-                        annotationFrame = CGRectMake(annotationPoint.x - 20.5f, annotationPoint.y - 15.f, 41.f, 30.f);
-                    }
-                    else {
-                        annotationFrame = CGRectMake(annotationPoint.x - 15.f, annotationPoint.y - 20.5f, 30.f, 41.f);
-                    }
-                }
-                else {
-                    annotationFrame = CGRectMake(annotationPoint.x - 15.f, annotationPoint.y - 15.f, 30.f, 30.f);
-                }
-
-                MKCoordinateRegion annotationRegion = [self.mapView convertRect:annotationFrame toRegionFromView:self.mapView];
-
-                MKMapRect annotationRect = MKMapRectForCoordinateRegion(annotationRegion);
-
-                if (MKMapRectIntersectsRect(self.mapView.visibleMapRect, annotationRect)) {
-                    return YES;
-                }
-            }
+    
+    for (id <MKAnnotation> annotation in annotations) {
+        MKAnnotationView *annotationView = [self.mapView viewForAnnotation:annotation];
+        MKCoordinateRegion annotationRegion = [self.mapView convertRect:annotationView.frame toRegionFromView:self.mapView];
+        MKMapRect annotationRect = MKMapRectForCoordinateRegion(annotationRegion);
+        
+        if (MKMapRectIntersectsRect(self.mapView.visibleMapRect, annotationRect)) {
+            return YES;
         }
     }
 

--- a/ui/situations/OBADiversionViewController.m
+++ b/ui/situations/OBADiversionViewController.m
@@ -10,10 +10,10 @@
 @property (nonatomic, strong) NSString *tripEncodedPolyline;
 
 @property (nonatomic, strong) MKPolyline *routePolyline;
-@property (nonatomic, strong) MKPolylineView *routePolylineView;
+@property (nonatomic, strong) MKPolylineRenderer *routePolylineRenderer;
 
 @property (nonatomic, strong) MKPolyline *reroutePolyline;
-@property (nonatomic, strong) MKPolylineView *reroutePolylineView;
+@property (nonatomic, strong) MKPolylineRenderer *reroutePolylineRenderer;
 
 @property (nonatomic, strong) id<OBAModelServiceRequest> request;
 
@@ -106,30 +106,30 @@
 - (void)mapView:(MKMapView *)mapView annotationView:(MKAnnotationView *)view calloutAccessoryControlTapped:(UIControl *)control {
 }
 
-- (MKOverlayView *)mapView:(MKMapView *)mapView viewForOverlay:(id)overlay {
-    MKOverlayView *overlayView = nil;
+- (MKOverlayRenderer *)mapView:(MKMapView *)mapView rendererForOverlay:(id<MKOverlay>)overlay {
+    MKOverlayRenderer *overlayView = nil;
 
     if (overlay == _reroutePolyline) {
         //if we have not yet created an overlay view for this overlay, create it now.
-        if (_reroutePolylineView == nil) {
-            _reroutePolylineView = [[MKPolylineView alloc] initWithPolyline:_reroutePolyline];
-            _reroutePolylineView.fillColor = [UIColor redColor];
-            _reroutePolylineView.strokeColor = [UIColor redColor];
-            _reroutePolylineView.lineWidth = 5;
+        if (_reroutePolylineRenderer == nil) {
+            _reroutePolylineRenderer = [[MKPolylineRenderer alloc] initWithPolyline:_reroutePolyline];
+            _reroutePolylineRenderer.fillColor = [UIColor redColor];
+            _reroutePolylineRenderer.strokeColor = [UIColor redColor];
+            _reroutePolylineRenderer.lineWidth = 5;
         }
 
-        overlayView = _reroutePolylineView;
+        overlayView = _reroutePolylineRenderer;
     }
     else if (overlay == _routePolyline) {
         //if we have not yet created an overlay view for this overlay, create it now.
-        if (_routePolylineView == nil) {
-            _routePolylineView = [[MKPolylineView alloc] initWithPolyline:_routePolyline];
-            _routePolylineView.fillColor = [UIColor blackColor];
-            _routePolylineView.strokeColor = [UIColor blackColor];
-            _routePolylineView.lineWidth = 5;
+        if (_routePolylineRenderer == nil) {
+            _routePolylineRenderer = [[MKPolylineRenderer alloc] initWithPolyline:_routePolyline];
+            _routePolylineRenderer.fillColor = [UIColor blackColor];
+            _routePolylineRenderer.strokeColor = [UIColor blackColor];
+            _routePolylineRenderer.lineWidth = 5;
         }
 
-        overlayView = _routePolylineView;
+        overlayView = _routePolylineRenderer;
     }
 
     return overlayView;

--- a/ui/stop_details/OBAGenericStopViewController.m
+++ b/ui/stop_details/OBAGenericStopViewController.m
@@ -154,7 +154,7 @@ static NSString *kOBASurveyURL = @"http://tinyurl.com/stopinfo";
         self.stopRoutes.backgroundColor = [UIColor clearColor];
         self.stopRoutes.textColor = [UIColor whiteColor];
         self.stopRoutes.font = [UIFont boldSystemFontOfSize:14];
-        self.stopRoutes.continuousMarqueeExtraBuffer = 80;
+        self.stopRoutes.trailingBuffer = 80;
         self.stopRoutes.tapToScroll = YES;
         self.stopRoutes.animationDelay = 0;
         self.stopRoutes.animationCurve = UIViewAnimationOptionCurveLinear;
@@ -171,7 +171,7 @@ static NSString *kOBASurveyURL = @"http://tinyurl.com/stopinfo";
         self.stopName.backgroundColor = [UIColor clearColor];
         self.stopName.textColor = [UIColor whiteColor];
         self.stopName.font = [UIFont boldSystemFontOfSize:19];
-        self.stopName.continuousMarqueeExtraBuffer = 80;
+        self.stopName.trailingBuffer = 80;
         self.stopName.tapToScroll = YES;
         self.stopName.animationDelay = 0;
         self.stopName.animationCurve = UIViewAnimationOptionCurveLinear;
@@ -313,57 +313,55 @@ static NSString *kOBASurveyURL = @"http://tinyurl.com/stopinfo";
 
 // This method should be used only when there is a survey being conducted.
 - (void)showSurveyPopup {
-    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"8.0.0")){
-        UIAlertController *surveyAlert = [UIAlertController alertControllerWithTitle:@"Help us improve OneBusAway!"
-                                                                       message:@"Tell us why you might contribute information about bus stops, and you could win a $50 gift card!"
-                                                                preferredStyle:UIAlertControllerStyleAlert];
-        
-        UIAlertAction *ok = [UIAlertAction actionWithTitle:@"Take survey"
+    UIAlertController *surveyAlert = [UIAlertController alertControllerWithTitle:@"Help us improve OneBusAway!"
+                                                                         message:@"Tell us why you might contribute information about bus stops, and you could win a $50 gift card!"
+                                                                  preferredStyle:UIAlertControllerStyleAlert];
+    
+    UIAlertAction *ok = [UIAlertAction actionWithTitle:@"Take survey"
+                                                 style:UIAlertActionStyleDefault
+                                               handler:^(UIAlertAction *action) {
+                                                   //Open survey in external browser
+                                                   [[UIApplication sharedApplication] openURL:[NSURL URLWithString:kOBASurveyURL]];
+                                                   [[NSUserDefaults standardUserDefaults] setBool:NO
+                                                                                           forKey:kOBAShowSurveyAlertKey];
+                                                   [[NSUserDefaults standardUserDefaults] synchronize];
+                                                   [surveyAlert dismissViewControllerAnimated:YES
+                                                                                   completion:nil];
+                                                   
+                                                   [OBAAnalytics reportEventWithCategory:OBAAnalyticsCategoryUIAction
+                                                                                  action:@"button_press"
+                                                                                   label:@"Loaded UW StopInfo survey"
+                                                                                   value:nil];
+                                               }];
+    
+    UIAlertAction *notNow = [UIAlertAction actionWithTitle:@"Not right now"
                                                      style:UIAlertActionStyleDefault
                                                    handler:^(UIAlertAction *action) {
-                                                       //Open survey in external browser
-                                                       [[UIApplication sharedApplication] openURL:[NSURL URLWithString:kOBASurveyURL]];
-                                                       [[NSUserDefaults standardUserDefaults] setBool:NO
-                                                                                               forKey:kOBAShowSurveyAlertKey];
-                                                       [[NSUserDefaults standardUserDefaults] synchronize];
                                                        [surveyAlert dismissViewControllerAnimated:YES
                                                                                        completion:nil];
-                                                       
-                                                       [OBAAnalytics reportEventWithCategory:OBAAnalyticsCategoryUIAction
-                                                                                      action:@"button_press"
-                                                                                       label:@"Loaded UW StopInfo survey"
-                                                                                       value:nil];
                                                    }];
-        
-        UIAlertAction *notNow = [UIAlertAction actionWithTitle:@"Not right now"
-                                                         style:UIAlertActionStyleDefault
-                                                       handler:^(UIAlertAction *action) {
-                                                           [surveyAlert dismissViewControllerAnimated:YES
-                                                                                           completion:nil];
-                                                       }];
-        
-        UIAlertAction *neverShow = [UIAlertAction actionWithTitle:@"Don't show this again"
-                                                         style:UIAlertActionStyleDefault
-                                                       handler:^(UIAlertAction *action) {
-                                                           [[NSUserDefaults standardUserDefaults] setBool:NO
-                                                                                                   forKey:kOBAShowSurveyAlertKey];
-                                                           [[NSUserDefaults standardUserDefaults] synchronize];
-                                                           [surveyAlert dismissViewControllerAnimated:YES
-                                                                                           completion:nil];
-                                                           [OBAAnalytics reportEventWithCategory:OBAAnalyticsCategoryUIAction
-                                                                                          action:@"button_press"
-                                                                                           label:@"Never show survey alert"
-                                                                                           value:nil];
-                                                       }];
-        
-        
-        
-        [surveyAlert addAction:ok];
-        [surveyAlert addAction:notNow];
-        [surveyAlert addAction:neverShow];
-        
-        [self presentViewController:surveyAlert animated:YES completion:nil];
-    }
+    
+    UIAlertAction *neverShow = [UIAlertAction actionWithTitle:@"Don't show this again"
+                                                        style:UIAlertActionStyleDefault
+                                                      handler:^(UIAlertAction *action) {
+                                                          [[NSUserDefaults standardUserDefaults] setBool:NO
+                                                                                                  forKey:kOBAShowSurveyAlertKey];
+                                                          [[NSUserDefaults standardUserDefaults] synchronize];
+                                                          [surveyAlert dismissViewControllerAnimated:YES
+                                                                                          completion:nil];
+                                                          [OBAAnalytics reportEventWithCategory:OBAAnalyticsCategoryUIAction
+                                                                                         action:@"button_press"
+                                                                                          label:@"Never show survey alert"
+                                                                                          value:nil];
+                                                      }];
+    
+    
+    
+    [surveyAlert addAction:ok];
+    [surveyAlert addAction:notNow];
+    [surveyAlert addAction:neverShow];
+    
+    [self presentViewController:surveyAlert animated:YES completion:nil];
 }
 
 - (OBABookmarkV2*)existingBookmark {

--- a/ui/stop_details/OBAReportProblemViewController.m
+++ b/ui/stop_details/OBAReportProblemViewController.m
@@ -18,7 +18,7 @@
         
         self.navigationItem.title = NSLocalizedString(@"Report a Problem",@"self.navigationItem.title");
         
-        UIBarButtonItem * item = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Report",@"UIBarButtonItem initWithTitle") style:UIBarButtonItemStyleBordered target:nil action:nil];
+        UIBarButtonItem * item = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Report",@"UIBarButtonItem initWithTitle") style:UIBarButtonItemStylePlain target:nil action:nil];
         self.navigationItem.backBarButtonItem = item;
     }
     return self;

--- a/ui/stop_details/OBAReportProblemWithStopViewController.m
+++ b/ui/stop_details/OBAReportProblemWithStopViewController.m
@@ -38,7 +38,7 @@ typedef NS_ENUM(NSInteger, OBASectionType) {
         self.navigationItem.title = NSLocalizedString(@"Report a Problem", @"self.navigationItem.title");
 
         UIBarButtonItem *item = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Custom Title", @"UIBarButtonItem * item")
-                                                                 style:UIBarButtonItemStyleBordered
+                                                                 style:UIBarButtonItemStylePlain
                                                                 target:nil
                                                                 action:nil];
         self.navigationItem.backBarButtonItem = item;

--- a/ui/trip_details/OBAReportProblemWithTripViewController.m
+++ b/ui/trip_details/OBAReportProblemWithTripViewController.m
@@ -47,7 +47,7 @@ typedef NS_ENUM(NSInteger, OBASectionType) {
         self.navigationItem.title = NSLocalizedString(@"Report a Problem", @"self.navigationItem.title");
 
         UIBarButtonItem *item = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Custom Title", @"initWithTitle")
-                                                                 style:UIBarButtonItemStyleBordered
+                                                                 style:UIBarButtonItemStylePlain
                                                                 target:nil
                                                                 action:nil];
         self.navigationItem.backBarButtonItem = item;

--- a/ui/trip_details/OBATripScheduleListViewController.m
+++ b/ui/trip_details/OBATripScheduleListViewController.m
@@ -55,11 +55,11 @@ typedef NS_ENUM(NSInteger, OBASectionType) {
         CGRect r = CGRectMake(0, 0, 160, 33);
         _progressView = [[OBAProgressIndicatorView alloc] initWithFrame:r];
         [self.navigationItem setTitleView:_progressView];
-        UIBarButtonItem *item = [[UIBarButtonItem alloc] initWithImage:[UIImage imageNamed:@"map"] style:UIBarButtonItemStyleBordered target:self action:@selector(showMap:)];
+        UIBarButtonItem *item = [[UIBarButtonItem alloc] initWithImage:[UIImage imageNamed:@"map"] style:UIBarButtonItemStylePlain target:self action:@selector(showMap:)];
         item.accessibilityLabel = NSLocalizedString(@"Map", @"initWithTitle");
         self.navigationItem.rightBarButtonItem = item;
 
-        UIBarButtonItem *backItem = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Schedule", @"initWithTitle") style:UIBarButtonItemStyleBordered target:nil action:nil];
+        UIBarButtonItem *backItem = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Schedule", @"initWithTitle") style:UIBarButtonItemStylePlain target:nil action:nil];
         self.navigationItem.backBarButtonItem = backItem;
     }
 

--- a/ui/trip_details/OBATripScheduleMapViewController.m
+++ b/ui/trip_details/OBATripScheduleMapViewController.m
@@ -22,7 +22,7 @@ static const NSString *kShapeContext = @"ShapeContext";
 @property (nonatomic, strong) NSDateFormatter *timeFormatter;
 
 @property (nonatomic, strong) MKPolyline *routePolyline;
-@property (nonatomic, strong) MKPolylineView *routePolylineView;
+@property (nonatomic, strong) MKPolylineRenderer *routePolylineRenderer;
 
 @end
 
@@ -52,7 +52,7 @@ static const NSString *kShapeContext = @"ShapeContext";
     self.navigationItem.rightBarButtonItem.accessibilityLabel = NSLocalizedString(@"Nearby stops list", @"self.navigationItem.rightBarButtonItem.accessibilityLabel");
     self.progressView = [[OBAProgressIndicatorView alloc] initWithFrame:CGRectMake(80, 6, 160, 33)];
     self.navigationItem.titleView = self.progressView;
-    UIBarButtonItem *backItem = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Schedule", @"initWithTitle") style:UIBarButtonItemStyleBordered target:nil action:nil];
+    UIBarButtonItem *backItem = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Schedule", @"initWithTitle") style:UIBarButtonItemStylePlain target:nil action:nil];
     self.navigationItem.backBarButtonItem = backItem;
 }
 
@@ -168,22 +168,20 @@ static const NSString *kShapeContext = @"ShapeContext";
     }
 }
 
-- (MKOverlayView *)mapView:(MKMapView *)mapView viewForOverlay:(id)overlay {
-    MKOverlayView *overlayView = nil;
-
-    if (overlay == _routePolyline) {
-        //if we have not yet created an overlay view for this overlay, create it now.
-        if (_routePolylineView == nil) {
-            _routePolylineView = [[MKPolylineView alloc] initWithPolyline:_routePolyline];
-            _routePolylineView.fillColor = [UIColor blackColor];
-            _routePolylineView.strokeColor = [UIColor blackColor];
-            _routePolylineView.lineWidth = 5;
+- (MKOverlayRenderer*)mapView:(MKMapView *)mapView rendererForOverlay:(id<MKOverlay>)overlay {
+    if (overlay == self.routePolyline) {
+        if (!self.routePolylineRenderer) {
+            self.routePolylineRenderer = [[MKPolylineRenderer alloc] initWithPolyline:self.routePolyline];
+            self.routePolylineRenderer.fillColor = [UIColor blackColor];
+            self.routePolylineRenderer.strokeColor = [UIColor blackColor];
+            self.routePolylineRenderer.lineWidth = 5;
         }
 
-        overlayView = _routePolylineView;
+        return self.routePolylineRenderer;
     }
-
-    return overlayView;
+    else {
+        return nil;
+    }
 }
 
 - (void)mapView:(MKMapView *)mapView regionDidChangeAnimated:(BOOL)animated {

--- a/utilities/OBAAnalytics.m
+++ b/utilities/OBAAnalytics.m
@@ -43,7 +43,7 @@ NSInteger const OBAAnalyticsDimensionVoiceOver = 4;
 
 + (void)reportScreenView:(NSString *)label {
     [[GAI sharedInstance].defaultTracker set:kGAIScreenName value:label];
-    [[GAI sharedInstance].defaultTracker send:[[GAIDictionaryBuilder createAppView] build]];
+    [[GAI sharedInstance].defaultTracker send:[[GAIDictionaryBuilder createScreenView] build]];
 }
 
 + (void)reportViewController:(UIViewController*)viewController {


### PR DESCRIPTION
- Upgrade the app to version 2.4.0
- Fix deprecations and warnings
- Remove outmoded checks for system version
- Specify explicit versions of Cocoapods
- Change minimum version of iOS in Podfile to 8.0