### PR TITLE
Remove survey

### DIFF
--- a/OBAApplicationDelegate.m
+++ b/OBAApplicationDelegate.m
@@ -40,7 +40,6 @@ static NSString * kOBAShowExperimentalRegionsDefaultsKey = @"kOBAShowExperimenta
 static NSString * kOBADefaultRegionApiServerName = @"regions.onebusaway.org";
 static NSString *const kTrackingId = @"UA-2423527-17";
 static NSString *const kAllowTracking = @"allowTracking";
-static NSString *kOBAShowSurveyAlertKey = @"OBASurveyAlertDefaultsKey";
 
 @interface OBAApplicationDelegate () <OBABackgroundTaskExecutor>
 @property(nonatomic,readwrite) BOOL active;
@@ -219,10 +218,6 @@ static NSString *kOBAShowSurveyAlertKey = @"OBASurveyAlertDefaultsKey";
 
     //Register a background handler with the model service
     [OBAModelService addBackgroundExecutor:self];
-    
-    //Register alert defaults
-    NSDictionary *alertDefaults = @{kOBAShowSurveyAlertKey: @(YES)};
-    [[NSUserDefaults standardUserDefaults] registerDefaults:alertDefaults];
 
     //setup Google Analytics
     NSDictionary *appDefaults = @{kAllowTracking: @(YES)};

--- a/ui/stop_details/OBAGenericStopViewController.m
+++ b/ui/stop_details/OBAGenericStopViewController.m
@@ -43,9 +43,6 @@
 
 static NSString *kOBANoStopInformationURL = @"http://stopinfo.pugetsound.onebusaway.org/testing";
 static NSString *kOBAIncreaseContrastKey = @"OBAIncreaseContrastDefaultsKey";
-static NSString *kOBAShowSurveyAlertKey = @"OBASurveyAlertDefaultsKey";
-static NSString *kOBASurveyURL = @"http://tinyurl.com/stopinfo";
-
 
 @interface OBAGenericStopViewController ()
 @property (strong, readwrite) OBAApplicationDelegate *appDelegate;
@@ -62,7 +59,6 @@ static NSString *kOBASurveyURL = @"http://tinyurl.com/stopinfo";
 @property (nonatomic, strong) UIButton *highContrastStopInfoButton;
 
 @property (nonatomic, assign) BOOL showInHighContrast;
-@property (nonatomic, assign) BOOL showSurveyAlert;
 @end
 
 @interface OBAGenericStopViewController ()
@@ -294,74 +290,7 @@ static NSString *kOBASurveyURL = @"http://tinyurl.com/stopinfo";
 
         OBAStopWebViewController *webViewController = [[OBAStopWebViewController alloc] initWithURL:[NSURL URLWithString:url]];
         [self.navigationController pushViewController:webViewController animated:YES];
-        
-        // Show popup for research survey. Should only be implemented
-        // when a survey is currently being conducted.
-        self.showSurveyAlert = [[NSUserDefaults standardUserDefaults] boolForKey:kOBAShowSurveyAlertKey];
-        if (self.showSurveyAlert) {
-            [self showSurveyPopup];
-        }
-        
-        // Show popup for research survey. Should only be implemented
-        // when a survey is currently being conducted.
-        self.showSurveyAlert = [[NSUserDefaults standardUserDefaults] boolForKey:kOBAShowSurveyAlertKey];
-        if (self.showSurveyAlert) {
-            [self showSurveyPopup];
-        }
     }
-}
-
-// This method should be used only when there is a survey being conducted.
-- (void)showSurveyPopup {
-    UIAlertController *surveyAlert = [UIAlertController alertControllerWithTitle:@"Help us improve OneBusAway!"
-                                                                         message:@"Tell us why you might contribute information about bus stops, and you could win a $50 gift card!"
-                                                                  preferredStyle:UIAlertControllerStyleAlert];
-    
-    UIAlertAction *ok = [UIAlertAction actionWithTitle:@"Take survey"
-                                                 style:UIAlertActionStyleDefault
-                                               handler:^(UIAlertAction *action) {
-                                                   //Open survey in external browser
-                                                   [[UIApplication sharedApplication] openURL:[NSURL URLWithString:kOBASurveyURL]];
-                                                   [[NSUserDefaults standardUserDefaults] setBool:NO
-                                                                                           forKey:kOBAShowSurveyAlertKey];
-                                                   [[NSUserDefaults standardUserDefaults] synchronize];
-                                                   [surveyAlert dismissViewControllerAnimated:YES
-                                                                                   completion:nil];
-                                                   
-                                                   [OBAAnalytics reportEventWithCategory:OBAAnalyticsCategoryUIAction
-                                                                                  action:@"button_press"
-                                                                                   label:@"Loaded UW StopInfo survey"
-                                                                                   value:nil];
-                                               }];
-    
-    UIAlertAction *notNow = [UIAlertAction actionWithTitle:@"Not right now"
-                                                     style:UIAlertActionStyleDefault
-                                                   handler:^(UIAlertAction *action) {
-                                                       [surveyAlert dismissViewControllerAnimated:YES
-                                                                                       completion:nil];
-                                                   }];
-    
-    UIAlertAction *neverShow = [UIAlertAction actionWithTitle:@"Don't show this again"
-                                                        style:UIAlertActionStyleDefault
-                                                      handler:^(UIAlertAction *action) {
-                                                          [[NSUserDefaults standardUserDefaults] setBool:NO
-                                                                                                  forKey:kOBAShowSurveyAlertKey];
-                                                          [[NSUserDefaults standardUserDefaults] synchronize];
-                                                          [surveyAlert dismissViewControllerAnimated:YES
-                                                                                          completion:nil];
-                                                          [OBAAnalytics reportEventWithCategory:OBAAnalyticsCategoryUIAction
-                                                                                         action:@"button_press"
-                                                                                          label:@"Never show survey alert"
-                                                                                          value:nil];
-                                                      }];
-    
-    
-    
-    [surveyAlert addAction:ok];
-    [surveyAlert addAction:notNow];
-    [surveyAlert addAction:neverShow];
-    
-    [self presentViewController:surveyAlert animated:YES completion:nil];
 }
 
 - (OBABookmarkV2*)existingBookmark {


### PR DESCRIPTION
* Depends on #423 
* Obviates #379 

Remove the stop info user survey from the codebase completely. We can always restore it via Git history if/when it's needed again. I don't like keeping unused code lingering in the codebase.