### PR TITLE
Fixes #413 — Blurry pins on iOS 8.3+

### DIFF
--- a/OBAApplicationDelegate.m
+++ b/OBAApplicationDelegate.m
@@ -54,8 +54,6 @@ static NSString *const kAllowTracking = @"allowTracking";
     if (self) {
         self.active = NO;
 
-        _stopIconFactory = [[OBAStopIconFactory alloc] init];
-    
         @weakify(self);
         self.regionObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kOBAApplicationSettingsRegionRefreshNotification
                                                                                 object:nil
@@ -163,6 +161,8 @@ static NSString *const kAllowTracking = @"allowTracking";
 #pragma mark UIApplicationDelegate Methods
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    _stopIconFactory = [[OBAStopIconFactory alloc] init];
+    
     //Register a background handler with the model service
     [OBAModelService addBackgroundExecutor:self];
 

--- a/sdk/sdk/Helpers/OBAStopIconFactory.h
+++ b/sdk/sdk/Helpers/OBAStopIconFactory.h
@@ -2,10 +2,7 @@
 #import "OBARouteV2.h"
 
 
-@interface OBAStopIconFactory : NSObject {
-    NSMutableDictionary * _stopIcons;
-    UIImage * _defaultStopIcon;
-}
+@interface OBAStopIconFactory : NSObject
 
 - (UIImage*) getIconForStop:(OBAStopV2*)stop;
 - (UIImage*) getIconForStop:(OBAStopV2*)stop includeDirection:(BOOL)includeDirection;

--- a/sdk/sdk/Helpers/OBAStopIconFactory.m
+++ b/sdk/sdk/Helpers/OBAStopIconFactory.m
@@ -3,112 +3,92 @@
 
 @implementation OBAStopIconFactory
 
-- (id) init {
-    self = [super init];
-    if( self ) {
-        [self loadIcons];
-    }
-    return self;
-}
-
-
-- (UIImage*) getIconForStop:(OBAStopV2*)stop {
+- (UIImage *)getIconForStop:(OBAStopV2 *)stop {
     return [self getIconForStop:stop includeDirection:YES];
 }
 
-- (UIImage*) getIconForStop:(OBAStopV2*)stop includeDirection:(BOOL)includeDirection {
-    NSString * routeIconType = [self getRouteIconTypeForStop:stop];
-    NSString * direction = @"";
-    
-    if( includeDirection && stop.direction )
+- (UIImage *)getIconForStop:(OBAStopV2 *)stop includeDirection:(BOOL)includeDirection {
+    NSString *routeIconType = [self getRouteIconTypeForStop:stop];
+    NSString *direction = @"";
+
+    if (includeDirection && stop.direction) {
         direction = stop.direction;
-    
-    NSString * key = [NSString stringWithFormat:@"%@StopIcon%@",routeIconType,direction];
-    
-    UIImage * image = _stopIcons[key];
-    
-    if( ! image || [image isEqual:[NSNull null]] )
-        return _defaultStopIcon;
-    
-    return image;
+    }
+
+    NSString *key = [NSString stringWithFormat:@"%@StopIcon%@", routeIconType, direction];
+
+    return [UIImage imageNamed:key];
 }
 
-- (UIImage*) getModeIconForRoute:(OBARouteV2*)route {
+- (UIImage *)getModeIconForRoute:(OBARouteV2 *)route {
     return [self getModeIconForRoute:route selected:NO];
 }
 
-- (UIImage*) getModeIconForRoute:(OBARouteV2*)route selected:(BOOL)selected {
-    NSString * type = [self getRouteIconTypeForRoute:route];
+- (UIImage *)getModeIconForRoute:(OBARouteV2 *)route selected:(BOOL)selected {
+    NSString *type = [self getRouteIconTypeForRoute:route];
+
     return [self getModeIconForRouteIconType:type selected:selected];
 }
 
-- (UIImage*) getModeIconForRouteIconType:(NSString*)routeType selected:(BOOL)selected {
-    NSString * format = selected ? @"Mode-%@-Selected.png" : @"Mode-%@.png";
-    return [UIImage imageNamed:[NSString stringWithFormat:format,routeType]];
+- (UIImage *)getModeIconForRouteIconType:(NSString *)routeType selected:(BOOL)selected {
+    NSString *format = selected ? @"Mode-%@-Selected" : @"Mode-%@";
+
+    return [UIImage imageNamed:[NSString stringWithFormat:format, routeType]];
 }
 
-- (NSString*) getRouteIconTypeForRoutes:(NSArray*)routes {
-    NSMutableSet * routeTypes = [NSMutableSet set];
-    for( OBARouteV2 * route in routes ) {
-        if( route.routeType )
+- (NSString *)getRouteIconTypeForRoutes:(NSArray *)routes {
+    NSMutableSet *routeTypes = [NSMutableSet set];
+
+    for (OBARouteV2 *route in routes) {
+        if (route.routeType) {
             [routeTypes addObject:route.routeType];
+        }
     }
+
     return [self getRouteIconTypeForRouteTypes:routeTypes];
 }
 
 #pragma mark - Private
 
-- (void) loadIcons {
-    
-    _stopIcons = [[NSMutableDictionary alloc] init];
-    
-    NSArray * directionIds = @[@"",@"N",@"NE",@"E",@"SE",@"S",@"SW",@"W",@"NW"];
-    NSArray * iconTypeIds = @[@"Bus",@"LightRail",@"Rail",@"Ferry"];
-    
-    for( int j=0; j<[iconTypeIds count]; j++) {
-        NSString * iconType = iconTypeIds[j];
-        for( int i=0; i<[directionIds count]; i++) {        
-            NSString * directionId = directionIds[i];
-            NSString * key = [NSString stringWithFormat:@"%@StopIcon%@",iconType,directionId];
-            NSString * imageName = [NSString stringWithFormat:@"%@.png",key];
-            UIImage * image = [UIImage imageNamed:imageName];
-            _stopIcons[key] = image;
-        }        
-    }    
-    
-    _defaultStopIcon = _stopIcons[@"BusStopIcon"];
-}
+- (NSString *)getRouteIconTypeForStop:(OBAStopV2 *)stop {
+    NSMutableSet *routeTypes = [NSMutableSet set];
 
-- (NSString*) getRouteIconTypeForStop:(OBAStopV2*)stop {
-    NSMutableSet * routeTypes = [NSMutableSet set];
-    for( OBARouteV2 * route in stop.routes ) {
-        if( route.routeType )
+    for (OBARouteV2 *route in stop.routes) {
+        if (route.routeType) {
             [routeTypes addObject:route.routeType];
+        }
     }
+
     return [self getRouteIconTypeForRouteTypes:routeTypes];
 }
 
-- (NSString*) getRouteIconTypeForRouteTypes:(NSSet*)routeTypes {
-    
+- (NSString *)getRouteIconTypeForRouteTypes:(NSSet *)routeTypes {
     // Heay rail dominations
-    if( [routeTypes containsObject:@4] )
+    if ([routeTypes containsObject:@4]) {
         return @"Ferry";
-    else if( [routeTypes containsObject:@2] )
+    }
+    else if ([routeTypes containsObject:@2]) {
         return @"Rail";
-    else if( [routeTypes containsObject:@0] )
+    }
+    else if ([routeTypes containsObject:@0]) {
         return @"LightRail";
-    else
-        return @"Bus";    
+    }
+    else {
+        return @"Bus";
+    }
 }
 
-- (NSString*) getRouteIconTypeForRoute:(OBARouteV2*)route {
+- (NSString *)getRouteIconTypeForRoute:(OBARouteV2 *)route {
     switch (route.routeType.integerValue) {
         case 4:
             return @"Ferry";
+
         case 2:
             return @"Rail";
+
         case 0:
             return @"LightRail";
+
         default:
             return @"Bus";
     }


### PR DESCRIPTION
The stop icon factory was being instantiated *way* too early in the application's lifecycle. Loading images too early caused the UIScreen's scale factor to not be properly set (it was reporting as 1.0 on a retina device). In general we shouldn't really be overriding the application delegate's init method, as this is run before the underlying infrastructure is even spun up (run loop, window, etc.). There must've been a change in the UIScreen initialization sequence in iOS 8.3.

Additionally, the OBAStopIconFactory was unnecessarily caching the UIImage objects for each icon. [UIImage imageNamed:] is already cached by the system.

There's some additional clean-up that can be done here — using enums for the different stop types, using a singleton instead of a factory (that is essentially what is happening anyway), etc. I'll submit another PR for those once this is merged.