### PR TITLE
Uncrustify should always put braces around single-line if/do/else/for/while

### DIFF
--- a/.uncrustifyconfig
+++ b/.uncrustifyconfig
@@ -92,16 +92,16 @@ eat_blanks_before_close_brace           = true          # boolean (false/true)
 mod_full_brace_nl                       = 3             # number
 
 # Braces on single-line do statement
-mod_full_brace_do                       = ignore        # string (add/force/ignore/remove)
+mod_full_brace_do                       = add           # string (add/force/ignore/remove)
 
 # Braces on single-line else statement
-mod_full_brace_if                       = ignore        # string (add/force/ignore/remove)
+mod_full_brace_if                       = add           # string (add/force/ignore/remove)
 
 # Braces on single-line for statement
 mod_full_brace_for                      = add           # string (add/force/ignore/remove)
 
 # Braces on single-line while statement
-mod_full_brace_while                    = remove        # string (add/force/ignore/remove)
+mod_full_brace_while                    = add           # string (add/force/ignore/remove)
 
 ## Comments
 


### PR DESCRIPTION
According to https://github.com/NYTimes/objective-c-style-guide