### PR TITLE
Fix issue where table header text overlaps with cell text

### DIFF
--- a/sdk/sdk/Helpers/OBACommonV1.h
+++ b/sdk/sdk/Helpers/OBACommonV1.h
@@ -27,7 +27,7 @@ typedef NS_ENUM(NSInteger, OBASearchViewType) {
 #define OBARGBACOLOR(__r, __g, __b, __a) [UIColor colorWithRed:(__r / 255.f) green:(__g / 255.f) blue:(__b / 255.f) alpha:__a]
 #define OBAGREENWITHALPHA(__a) [UIColor colorWithHue:(86.f/360.f) saturation:0.68f brightness:0.67f alpha:__a]
 #define OBAGREEN [UIColor colorWithHue:(86.f/360.f) saturation:0.68f brightness:0.67f alpha:1.f]
-#define OBAGREENBACKGROUND [UIColor colorWithHue:(86.f/360.f) saturation:0.68f brightness:0.67f alpha:0.1f]
+#define OBAGREENBACKGROUND [UIColor colorWithRed:0.92f green:0.95f blue:0.88f alpha:.67f]
 #define OBADARKGREEN [UIColor colorWithRed:0.2f green:.4f blue:0.f alpha:1.f]
 #define OBALABELGREEN [UIColor colorWithRed:0.f green:0.478f blue:0.f alpha:1.f]
 


### PR DESCRIPTION
Fixes #436. 

Before | After
---------|------------
![img_5715](https://cloud.githubusercontent.com/assets/6173427/9421402/788d3f78-4827-11e5-8356-f636069e8171.PNG)|![img_5718](https://cloud.githubusercontent.com/assets/6173427/9421401/6c6370dc-4827-11e5-9f80-06d99fe19a46.PNG)

 I can make it even more opaque, if you prefer.