### PR TITLE
Workaround for #442

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -59,5 +59,10 @@
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
#442 
>2015-09-13 12:27:15.433 OneBusAway[6454:21032400] url=http://regions.onebusaway.org/regions-v3.json?key=org.onebusaway.iphone&app_uid=CA1F7332-AC98-48A8-A596-3BD44C7EA029&app_ver=ca71c6b+&
2015-09-13 12:27:15.451 OneBusAway[6454:21032861] App Transport Security has blocked a cleartext HTTP (http://) resource load since it is insecure. Temporary exceptions can be configured via your app's Info.plist file.

This is a workaround
