### PR TITLE
Enable deep-linking into the Settings app to let users re-enable location services

### DIFF
--- a/org.onebusaway.iphone.xcodeproj/project.pbxproj
+++ b/org.onebusaway.iphone.xcodeproj/project.pbxproj
@@ -91,6 +91,7 @@
 		93E0954719CE051700A31BA6 /* OBALaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 93E0954619CE051700A31BA6 /* OBALaunchScreen.xib */; };
 		93F152F61A9AE91A0015C141 /* OneBusAway_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 93F152F51A9AE91A0015C141 /* OneBusAway_Tests.m */; };
 		93F153021A9AEA500015C141 /* OBAURLHelpers_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 93F153011A9AEA500015C141 /* OBAURLHelpers_Tests.m */; };
+		93F64E971BE5ACC300323527 /* OBAAlerts.m in Sources */ = {isa = PBXBuildFile; fileRef = 93F64E961BE5ACC300323527 /* OBAAlerts.m */; };
 		D651BB2811C9D5DE001BE733 /* iTunesArtwork in Resources */ = {isa = PBXBuildFile; fileRef = D651BB2711C9D5DE001BE733 /* iTunesArtwork */; };
 		D6575AEC0FEE13CF00D6D987 /* Entitlements.plist in Resources */ = {isa = PBXBuildFile; fileRef = D6575AEB0FEE13CF00D6D987 /* Entitlements.plist */; };
 /* End PBXBuildFile section */
@@ -264,6 +265,8 @@
 		93F152F41A9AE91A0015C141 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		93F152F51A9AE91A0015C141 /* OneBusAway_Tests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OneBusAway_Tests.m; sourceTree = "<group>"; };
 		93F153011A9AEA500015C141 /* OBAURLHelpers_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAURLHelpers_Tests.m; sourceTree = "<group>"; };
+		93F64E951BE5ACC300323527 /* OBAAlerts.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAAlerts.h; sourceTree = "<group>"; };
+		93F64E961BE5ACC300323527 /* OBAAlerts.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAAlerts.m; sourceTree = "<group>"; };
 		9896748DE4027B647D4D41F0 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
 		A2B89E834A0C9E7F5B8FE39B /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		AF4665CA06626C1076EEEE33 /* Pods.appstoredistribution.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.appstoredistribution.xcconfig; path = "Pods/Target Support Files/Pods/Pods.appstoredistribution.xcconfig"; sourceTree = "<group>"; };
@@ -421,6 +424,7 @@
 		932BE4901AB66D320011F2FB /* ui */ = {
 			isa = PBXGroup;
 			children = (
+				93F64E921BE5ACB900323527 /* alerts */,
 				932BE4FC1AB66EF20011F2FB /* recent_stops */,
 				932BE4EF1AB66E990011F2FB /* search */,
 				932BE4E21AB66E3C0011F2FB /* bookmarks */,
@@ -685,6 +689,15 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
+		93F64E921BE5ACB900323527 /* alerts */ = {
+			isa = PBXGroup;
+			children = (
+				93F64E951BE5ACC300323527 /* OBAAlerts.h */,
+				93F64E961BE5ACC300323527 /* OBAAlerts.m */,
+			);
+			path = alerts;
+			sourceTree = "<group>";
+		};
 		B58A05701AFF5F6F007C9E4A /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -938,6 +951,7 @@
 				934446D91AB12C5D005B3333 /* OBAModalActivityIndicator.m in Sources */,
 				93AD36441603FE7E00BDF03F /* OBAArrivalEntryTableViewCellFactory.m in Sources */,
 				932BE4D01AB66D710011F2FB /* OBATripScheduleListViewController.m in Sources */,
+				93F64E971BE5ACC300323527 /* OBAAlerts.m in Sources */,
 				934446D41AB12C0C005B3333 /* OBAListSelectionViewController.m in Sources */,
 				932BE4EE1AB66E640011F2FB /* OBABookmarksViewController.m in Sources */,
 				932BE4BD1AB66D5C0011F2FB /* OBAReportProblemViewController.m in Sources */,
@@ -1058,7 +1072,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_LDFLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = org.onebusaway.iphone;
+				PRODUCT_BUNDLE_IDENTIFIER = org.onebusaway.iphone.dev;
 				PRODUCT_NAME = OneBusAway;
 				PROVISIONING_PROFILE = "";
 				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "";
@@ -1106,7 +1120,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_LDFLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = org.onebusaway.iphone;
+				PRODUCT_BUNDLE_IDENTIFIER = org.onebusaway.iphone.dev;
 				PRODUCT_NAME = OneBusAway;
 				PROVISIONING_PROFILE = "";
 				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "";
@@ -1382,7 +1396,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_LDFLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = org.onebusaway.iphone;
+				PRODUCT_BUNDLE_IDENTIFIER = org.onebusaway.iphone.dev;
 				PRODUCT_NAME = OneBusAway;
 				PROVISIONING_PROFILE = "";
 				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "";
@@ -1448,7 +1462,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_LDFLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = org.onebusaway.iphone;
+				PRODUCT_BUNDLE_IDENTIFIER = org.onebusaway.iphone.dev;
 				PRODUCT_NAME = OneBusAway;
 				PROVISIONING_PROFILE = "";
 				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "";

--- a/sdk/sdk/Location/OBALocationManager.h
+++ b/sdk/sdk/Location/OBALocationManager.h
@@ -37,8 +37,6 @@ NS_ASSUME_NONNULL_BEGIN
     NSMutableArray * _delegates;
     
     CLLocation * _currentLocation;
-    BOOL _disabled;
-    
 }
 
 - (id) initWithModelDao:(OBAModelDAO*)modelDao;

--- a/ui/alerts/OBAAlerts.h
+++ b/ui/alerts/OBAAlerts.h
@@ -1,0 +1,13 @@
+//
+//  OBAAlerts.h
+//  org.onebusaway.iphone
+//
+//  Created by Aaron Brethorst on 10/31/15.
+//  Copyright © 2015 OneBusAway. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface OBAAlerts : NSObject
++ (UIAlertController*)locationServicesDisabledAlert;
+@end

--- a/ui/alerts/OBAAlerts.m
+++ b/ui/alerts/OBAAlerts.m
@@ -1,0 +1,27 @@
+//
+//  OBAAlerts.m
+//  org.onebusaway.iphone
+//
+//  Created by Aaron Brethorst on 10/31/15.
+//  Copyright © 2015 OneBusAway. All rights reserved.
+//
+
+#import "OBAAlerts.h"
+
+@implementation OBAAlerts
+
++ (UIAlertController*)locationServicesDisabledAlert
+{
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"Location Services Disabled", @"view.title")
+                                                                   message:NSLocalizedString(@"Location Services are disabled for this app. Some location-aware functionality will be missing.", @"view.message") preferredStyle:UIAlertControllerStyleAlert];
+
+    [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Dismiss", @"Dismiss button") style:UIAlertActionStyleDefault handler:nil]];
+    [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Fix It", @"Location services alert button.") style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+        NSURL *appSettings = [NSURL URLWithString:UIApplicationOpenSettingsURLString];
+        [[UIApplication sharedApplication] openURL:appSettings];
+    }]];
+
+    return alert;
+}
+
+@end

--- a/ui/info/OBAContactUsViewController.m
+++ b/ui/info/OBAContactUsViewController.m
@@ -59,7 +59,7 @@ static NSString *kOBADefaultTwitterURL = @"http://twitter.com/onebusaway";
                                                     message:NSLocalizedString(@"Please setup your Mail app before trying to send an email.", @"view.message")
                                                    delegate:nil
                                           cancelButtonTitle:nil
-                                          otherButtonTitles:NSLocalizedString(@"Okay", @"Ok button"), nil];
+                                          otherButtonTitles:NSLocalizedString(@"OK", @"OK button"), nil];
 
     [alert show];
 }

--- a/ui/info/OBARegionListViewController.m
+++ b/ui/info/OBARegionListViewController.m
@@ -11,6 +11,7 @@
 #import "OBACustomApiViewController.h"
 #import "OBAAnalytics.h"
 #import "UITableViewCell+oba_Additions.h"
+#import "OBAAlerts.h"
 
 typedef NS_ENUM (NSInteger, OBASectionType) {
     OBASectionTypeNone,
@@ -336,15 +337,11 @@ typedef NS_ENUM (NSInteger, OBASectionType) {
 }
 
 - (void)showLocationServicesAlert {
-    if (![[OBAApplication sharedApplication].modelDao hideFutureLocationWarnings]) {
-        [[OBAApplication sharedApplication].modelDao setHideFutureLocationWarnings:TRUE];
+    if (![OBAApplication sharedApplication].modelDao.hideFutureLocationWarnings) {
+        [OBAApplication sharedApplication].modelDao.hideFutureLocationWarnings = YES;
 
-        UIAlertView *view = [[UIAlertView alloc] init];
-        view.title = NSLocalizedString(@"Location Services Disabled", @"view.title");
-        view.message = NSLocalizedString(@"Location Services are disabled for this app. Some location-aware functionality will be missing.", @"view.message");
-        [view addButtonWithTitle:NSLocalizedString(@"Dismiss", @"view addButtonWithTitle")];
-        view.cancelButtonIndex = 0;
-        [view show];
+        UIAlertController *alert = [OBAAlerts locationServicesDisabledAlert];
+        [self presentViewController:alert animated:YES completion:nil];
     }
 }
 
@@ -484,7 +481,7 @@ typedef NS_ENUM (NSInteger, OBASectionType) {
                                                                       message:@"Experimental regions may be unstable and without real-time info!"
                                                                      delegate:self
                                                             cancelButtonTitle:@"Cancel"
-                                                            otherButtonTitles:@"OK", nil];
+                                                            otherButtonTitles:NSLocalizedString(@"OK", @"OK button"), nil];
         [unstableRegionAlert show];
     }
     else {
@@ -494,7 +491,7 @@ typedef NS_ENUM (NSInteger, OBASectionType) {
                                                                                     message:@"Your current experimental region won't be available! Proceed anyway?"
                                                                                    delegate:self
                                                                           cancelButtonTitle:@"Cancel"
-                                                                          otherButtonTitles:@"OK", nil];
+                                                                          otherButtonTitles:NSLocalizedString(@"OK", @"OK button"), nil];
 
             [currentRegionUnavailableAlert show];
         }
@@ -507,7 +504,7 @@ typedef NS_ENUM (NSInteger, OBASectionType) {
 - (void)alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex {
     NSString *title = [alertView buttonTitleAtIndex:buttonIndex];
 
-    if ([title isEqualToString:@"OK"]) {
+    if ([title isEqualToString:NSLocalizedString(@"OK", @"OK button")]) {
         [self doNeedToUpdateRegionsList];
     }
     else if ([title isEqualToString:@"Cancel"]) {
@@ -544,7 +541,7 @@ typedef NS_ENUM (NSInteger, OBASectionType) {
         }
         //Set region to nil if list is empty
         else if (![self isLoading]) {
-            UIAlertView *noAvailableRegionsAlert = [[UIAlertView alloc] initWithTitle:@"No Regions Found" message:@"No available regions were found, recheck your connection and try again" delegate:nil cancelButtonTitle:@"OK" otherButtonTitles:nil];
+            UIAlertView *noAvailableRegionsAlert = [[UIAlertView alloc] initWithTitle:@"No Regions Found" message:@"No available regions were found, recheck your connection and try again" delegate:nil cancelButtonTitle:NSLocalizedString(@"OK", @"OK button") otherButtonTitles:nil];
             [[OBAApplication sharedApplication].modelDao setOBARegion:nil];
             [noAvailableRegionsAlert show];
         }


### PR DESCRIPTION
* Show an alert when location services are disabled for the app
* Create a utility class to store that alert, and future global alerts
* Remove OBALocationManager's `disabled` property. Rely solely upon `CLLocationManager` for that information.
* Always keep the map view's left location button enabled. Show the "Fix It" deep linking dialog every time it's tapped when location services are disabled.