### PR TITLE
Replace calls to -openURL: with SFSafariViewController

### DIFF
--- a/controls/view_controllers/OBAWebViewController.m
+++ b/controls/view_controllers/OBAWebViewController.m
@@ -1,12 +1,10 @@
-#import "OBAWebViewController.h"
 
+#import "OBAWebViewController.h"
+#import <SafariServices/SafariServices.h>
 
 @interface OBAWebViewController (Private)
-
--(UIWebView*) webView;
-
+- (UIWebView*) webView;
 @end
-
 
 @implementation OBAWebViewController
 
@@ -32,15 +30,16 @@
 
 #pragma mark UIWebViewDelegate
 
--(BOOL) webView:(UIWebView *)inWeb shouldStartLoadWithRequest:(NSURLRequest *)inRequest navigationType:(UIWebViewNavigationType)inType {
-    
-    if( inType == UIWebViewNavigationTypeLinkClicked ) {
-        [[UIApplication sharedApplication] openURL:[inRequest URL]];
-        return NO;
-    }
-    else {
+- (BOOL)webView:(UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)type {
+
+    if (type != UIWebViewNavigationTypeLinkClicked) {
         return YES;
     }
+
+    SFSafariViewController *safari = [[SFSafariViewController alloc] initWithURL:request.URL];
+    safari.modalPresentationStyle = UIModalPresentationOverFullScreen;
+    [self presentViewController:safari animated:YES completion:nil];
+    return NO;
 }
 
 @end

--- a/org.onebusaway.iphone.xcodeproj/project.pbxproj
+++ b/org.onebusaway.iphone.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		936D3EBD1C14E83200091DC9 /* OBATableRow.m in Sources */ = {isa = PBXBuildFile; fileRef = 936D3EBC1C14E83200091DC9 /* OBATableRow.m */; };
 		936D3EC01C14E94A00091DC9 /* OBAStaticTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 936D3EBF1C14E94900091DC9 /* OBAStaticTableViewController.m */; };
 		9388E9DD1A9BCC8900C9F6CE /* feedback_message_body.html in Resources */ = {isa = PBXBuildFile; fileRef = 9388E9DC1A9BCC8900C9F6CE /* feedback_message_body.html */; };
+		93A923A21C21DCD600A657C8 /* SafariServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 93A923A11C21DCD600A657C8 /* SafariServices.framework */; };
 		93AD36431603FE7E00BDF03F /* OBAArrivalEntryTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 93AD363A1603FE7E00BDF03F /* OBAArrivalEntryTableViewCell.m */; };
 		93AD36441603FE7E00BDF03F /* OBAArrivalEntryTableViewCellFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 93AD363C1603FE7E00BDF03F /* OBAArrivalEntryTableViewCellFactory.m */; };
 		93AD36451603FE7E00BDF03F /* OBALabelAndTextFieldTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 93AD363E1603FE7E00BDF03F /* OBALabelAndTextFieldTableViewCell.m */; };
@@ -249,6 +250,7 @@
 		936D3EBF1C14E94900091DC9 /* OBAStaticTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAStaticTableViewController.m; sourceTree = "<group>"; };
 		9388E9DC1A9BCC8900C9F6CE /* feedback_message_body.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; name = feedback_message_body.html; path = Resources/feedback_message_body.html; sourceTree = "<group>"; };
 		939CEB241C0E406500E1D2B7 /* rvtd.gpx */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = rvtd.gpx; sourceTree = "<group>"; };
+		93A923A11C21DCD600A657C8 /* SafariServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SafariServices.framework; path = System/Library/Frameworks/SafariServices.framework; sourceTree = SDKROOT; };
 		93AD36391603FE7E00BDF03F /* OBAArrivalEntryTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAArrivalEntryTableViewCell.h; sourceTree = "<group>"; };
 		93AD363A1603FE7E00BDF03F /* OBAArrivalEntryTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAArrivalEntryTableViewCell.m; sourceTree = "<group>"; };
 		93AD363B1603FE7E00BDF03F /* OBAArrivalEntryTableViewCellFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAArrivalEntryTableViewCellFactory.h; sourceTree = "<group>"; };
@@ -287,6 +289,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				93A923A21C21DCD600A657C8 /* SafariServices.framework in Frameworks */,
 				669B2F8C1AEC049D00CF2367 /* libOneBusAwaySDK.a in Frameworks */,
 				77F1DF137D15E0B33B6AC7F6 /* libPods.a in Frameworks */,
 			);
@@ -378,6 +381,7 @@
 		29B97323FDCFA39411CA2CEA /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				93A923A11C21DCD600A657C8 /* SafariServices.framework */,
 				669B2F8B1AEC049D00CF2367 /* libOneBusAwaySDK.a */,
 				A2B89E834A0C9E7F5B8FE39B /* libPods.a */,
 			);

--- a/ui/alerts/OBAAlerts.m
+++ b/ui/alerts/OBAAlerts.m
@@ -18,6 +18,7 @@
     [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Dismiss", @"Dismiss button") style:UIAlertActionStyleDefault handler:nil]];
     [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Fix It", @"Location services alert button.") style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
         NSURL *appSettings = [NSURL URLWithString:UIApplicationOpenSettingsURLString];
+        // Appropriate use of -openURL:. Don't replace.
         [[UIApplication sharedApplication] openURL:appSettings];
     }]];
 

--- a/ui/info/OBAAgenciesListViewController.m
+++ b/ui/info/OBAAgenciesListViewController.m
@@ -5,6 +5,7 @@
 #import "OBASearch.h"
 #import "OBAAnalytics.h"
 #import "UITableViewCell+oba_Additions.h"
+#import <SafariServices/SafariServices.h>
 
 typedef NS_ENUM (NSInteger, OBASectionType) {
     OBASectionTypeNone,
@@ -229,7 +230,10 @@ typedef NS_ENUM (NSInteger, OBASectionType) {
 - (void)didSelectAgencyRowAtIndexPath:(NSIndexPath *)indexPath tableView:(UITableView *)tableView {
     OBAAgencyWithCoverageV2 *awc = self.agencies[indexPath.row];
     OBAAgencyV2 *agency = awc.agency;
-    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:agency.url]];
+
+    SFSafariViewController *safari = [[SFSafariViewController alloc] initWithURL:[NSURL URLWithString:agency.url]];
+    safari.modalPresentationStyle = UIModalPresentationOverFullScreen;
+    [self presentViewController:safari animated:YES completion:nil];
     [tableView deselectRowAtIndexPath:indexPath animated:YES];
 }
 

--- a/ui/info/OBAContactUsViewController.m
+++ b/ui/info/OBAContactUsViewController.m
@@ -21,6 +21,7 @@
 #import <MessageUI/MFMailComposeViewController.h>
 #import "OBAAnalytics.h"
 #import "UITableViewCell+oba_Additions.h"
+#import <SafariServices/SafariServices.h>
 
 #define kEmailRow    0
 #define kTwitterRow  1
@@ -181,13 +182,16 @@ static NSString *kOBADefaultTwitterURL = @"http://twitter.com/onebusaway";
 
             if ([[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:@"twitter://"]]) {
                 [OBAAnalytics reportEventWithCategory:OBAAnalyticsCategoryUIAction action:@"app_switch" label:@"Loaded Twitter via App" value:nil];
-                NSString *url = [NSString stringWithFormat:@"twitter://user?screen_name=%@", twitterName ];
+                NSString *url = [NSString stringWithFormat:@"twitter://user?screen_name=%@", twitterName];
+                // Appropriate use of -openURL:. Don't replace.
                 [[UIApplication sharedApplication] openURL:[NSURL URLWithString:url]];
             }
             else {
                 [OBAAnalytics reportEventWithCategory:OBAAnalyticsCategoryUIAction action:@"app_switch" label:@"Loaded Twitter via Web" value:nil];
                 NSString *url = [NSString stringWithFormat:@"http://twitter.com/%@", twitterName];
-                [[UIApplication sharedApplication] openURL:[NSURL URLWithString:url]];
+                SFSafariViewController *safari = [[SFSafariViewController alloc] initWithURL:[NSURL URLWithString:url]];
+                safari.modalPresentationStyle = UIModalPresentationOverFullScreen;
+                [self presentViewController:safari animated:YES completion:nil];
             }
         }
         break;
@@ -201,13 +205,17 @@ static NSString *kOBADefaultTwitterURL = @"http://twitter.com/onebusaway";
 
                 if ([[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:@"fb://"]]) {
                     [OBAAnalytics reportEventWithCategory:OBAAnalyticsCategoryUIAction action:@"app_switch" label:@"Loaded Facebook via App" value:nil];
-                    NSString *url = [NSString stringWithFormat:@"fb://profile/%@", facebookPage ];
+                    NSString *url = [NSString stringWithFormat:@"fb://profile/%@", facebookPage];
+
+                    // Appropriate use of -openURL:. Don't replace.
                     [[UIApplication sharedApplication] openURL:[NSURL URLWithString:url]];
                 }
                 else {
                     [OBAAnalytics reportEventWithCategory:OBAAnalyticsCategoryUIAction action:@"app_switch" label:@"Loaded Facebook via Web" value:nil];
                     NSString *url = [NSString stringWithFormat:@"http://facebook.com/%@", facebookPage];
-                    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:url]];
+                    SFSafariViewController *safari = [[SFSafariViewController alloc] initWithURL:[NSURL URLWithString:url]];
+                    safari.modalPresentationStyle = UIModalPresentationOverFullScreen;
+                    [self presentViewController:safari animated:YES completion:nil];
                 }
             }
 

--- a/ui/info/OBACreditsViewController.m
+++ b/ui/info/OBACreditsViewController.m
@@ -8,6 +8,7 @@
 
 #import "OBACreditsViewController.h"
 #import "OBAAnalytics.h"
+#import <SafariServices/SafariServices.h>
 
 @interface OBACreditsViewController ()
 
@@ -37,7 +38,9 @@
     
     NSArray *nonLocalSchemes = @[@"http", @"https"];
     if (NSNotFound != [nonLocalSchemes indexOfObject:request.URL.scheme]) {
-        [[UIApplication sharedApplication] openURL:request.URL];
+        SFSafariViewController *safari = [[SFSafariViewController alloc] initWithURL:request.URL];
+        safari.modalPresentationStyle = UIModalPresentationOverFullScreen;
+        [self presentViewController:safari animated:YES completion:nil];
         return NO;
     }
     else {

--- a/ui/info/OBAInfoViewController.m
+++ b/ui/info/OBAInfoViewController.m
@@ -13,6 +13,7 @@
 #import "OBAAnalytics.h"
 #import "OBARegionListViewController.h"
 #import "OBAApplicationDelegate.h"
+#import <SafariServices/SafariServices.h>
 
 static NSString * const kDonateURLString = @"http://onebusaway.org/donate/";
 static NSString * const kPrivacyURLString = @"http://onebusaway.org/privacy/";
@@ -80,13 +81,6 @@ static NSString * const kFeatureRequestsURLString = @"http://onebusaway.ideascal
 
 - (OBATableSection*)aboutTableSection {
 
-#if 0
-    OBATableRow *featureRequests = [OBATableRow tableRowWithTitle:NSLocalizedString(@"Feature Requests", @"Info Page Feature Requests Row Title") action:^{
-        [OBAAnalytics reportEventWithCategory:OBAAnalyticsCategoryUIAction action:@"button_press" label:@"Clicked Feature Request Link" value:nil];
-        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:kFeatureRequestsURLString]];
-    }];
-#endif
-
     OBATableRow *contactUs = [OBATableRow tableRowWithTitle:NSLocalizedString(@"Contact Us", @"Info Page Contact Us Row Title") action:^{
         [self openContactUs];
     }];
@@ -99,13 +93,17 @@ static NSString * const kFeatureRequestsURLString = @"http://onebusaway.ideascal
 
     OBATableRow *privacy = [OBATableRow tableRowWithTitle:NSLocalizedString(@"Privacy Policy", @"Info Page Privacy Policy Row Title") action:^{
         [OBAAnalytics reportEventWithCategory:OBAAnalyticsCategoryUIAction action:@"button_press" label:@"Clicked Privacy Policy Link" value:nil];
-        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:kPrivacyURLString]];
+        SFSafariViewController *safari = [[SFSafariViewController alloc] initWithURL:[NSURL URLWithString:kPrivacyURLString]];
+        safari.modalPresentationStyle = UIModalPresentationOverFullScreen;
+        [self presentViewController:safari animated:YES completion:nil];
     }];
     privacy.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
 
     OBATableRow *donate = [OBATableRow tableRowWithTitle:NSLocalizedString(@"Donate", @"Info Page Donate Row Title") action:^{
         [OBAAnalytics reportEventWithCategory:OBAAnalyticsCategoryUIAction action:@"button_press" label:@"Clicked Donate Link" value:nil];
-        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:kDonateURLString]];
+        SFSafariViewController *safari = [[SFSafariViewController alloc] initWithURL:[NSURL URLWithString:kDonateURLString]];
+        safari.modalPresentationStyle = UIModalPresentationOverFullScreen;
+        [self presentViewController:safari animated:YES completion:nil];
     }];
     donate.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
 
@@ -176,4 +174,5 @@ static NSString * const kFeatureRequestsURLString = @"http://onebusaway.ideascal
 
     return label.frame;
 }
+
 @end


### PR DESCRIPTION
Fixes #484

* Link in SafariServices.framework
* Replace all relevant calls to -[UIApplication openURL:] with SFSafariViewController