### PR TITLE
Modernize HTTP GETs

### DIFF
--- a/OBAApplicationDelegate.h
+++ b/OBAApplicationDelegate.h
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-#import "OBADataSourceConfig.h"
 #import "OBANavigationTarget.h"
 #import "GAI.h"
 #import "OBAApplication.h"

--- a/OneBusAway Tests/OBADataSourceConfig_Tests.m
+++ b/OneBusAway Tests/OBADataSourceConfig_Tests.m
@@ -1,0 +1,37 @@
+//
+//  OBADataSourceConfig_Tests.m
+//  org.onebusaway.iphone
+//
+//  Created by Aaron Brethorst on 12/16/15.
+//  Copyright © 2015 OneBusAway. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "OBADataSourceConfig.h"
+
+@interface OBADataSourceConfig_Tests : XCTestCase
+
+@end
+
+@implementation OBADataSourceConfig_Tests
+
+- (void)testExample {
+    NSURL *URL = [NSURL URLWithString:@"http://api.pugetsound.onebusaway.org"];
+    OBADataSourceConfig *config = [[OBADataSourceConfig alloc] initWithURL:URL args:nil];
+    NSURL *fooURL = [config constructURL:@"/foo.json" withArgs:nil];
+
+    XCTAssertEqualObjects([NSURL URLWithString:@"http://api.pugetsound.onebusaway.org/foo.json"], fooURL);
+}
+
+- (void)testDefaultParameters {
+    OBADataSourceConfig *googleMapsDataSourceConfig = [[OBADataSourceConfig alloc] initWithURL:[NSURL URLWithString:@"https://maps.googleapis.com"] args:@{@"sensor": @"true"}];
+
+    NSURL *testURL = [googleMapsDataSourceConfig constructURL:@"/something-goes-here.json" withArgs:@{@"hello": @"world", @"foo": @"bar"}];
+
+    BOOL nonDeterminismSucks = ([testURL.absoluteString isEqual:@"https://maps.googleapis.com/something-goes-here.json?sensor=true&foo=bar&hello=world"] ||
+          [testURL.absoluteString isEqual:@"https://maps.googleapis.com/something-goes-here.json?sensor=true&hello=world&foo=bar"]);
+
+    XCTAssert(nonDeterminismSucks);
+}
+
+@end

--- a/OneBusAway Tests/OBAURLHelpers_Tests.m
+++ b/OneBusAway Tests/OBAURLHelpers_Tests.m
@@ -16,26 +16,6 @@
 
 @implementation OBAURLHelpers_Tests
 
-- (void)test3rdAndPike
-{
-    XCTAssertEqualObjects(@"3rd%20and%20Pike", [OBAURLHelpers escapeStringForUrl:@"3rd and Pike"]);
-}
-
-- (void)test3rdAmpPike
-{
-    XCTAssertEqualObjects(@"3rd%20%26%20Pike", [OBAURLHelpers escapeStringForUrl:@"3rd & Pike"]);
-}
-
-- (void)testFullAddress
-{
-    XCTAssertEqualObjects(@"915%20Northwest%2045th%20Street%2C%20Seattle%2C%20WA%2098107", [OBAURLHelpers escapeStringForUrl:@"915 Northwest 45th Street, Seattle, WA 98107"]);
-}
-
-- (void)testPartialAddress
-{
-    XCTAssertEqualObjects(@"915%20Northwest%2045th%20Street", [OBAURLHelpers escapeStringForUrl:@"915 Northwest 45th Street"]);
-}
-
 #pragma mark - URL Normalization
 
 static NSString * const kOBACurrentTimeURLPath = @"/where/current-time.json";

--- a/Podfile
+++ b/Podfile
@@ -1,7 +1,11 @@
 platform :ios, '9.0'
 
+use_frameworks!
+inhibit_all_warnings!
+
 link_with 'OneBusAway', 'OneBusAway Tests'
-pod 'TWSReleaseNotesView', '1.2.0', :inhibit_warnings => true
+
+pod 'TWSReleaseNotesView', '1.2.0'
 pod 'GoogleAnalytics-iOS-SDK', '3.11'
 pod 'libextobjc', '0.4.1'
 pod 'SVProgressHUD', '2.0-beta'

--- a/org.onebusaway.iphone.xcodeproj/project.pbxproj
+++ b/org.onebusaway.iphone.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		1D60589B0D05DD56006BFB54 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; };
-		60E26094D209E76D5D037634 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A2B89E834A0C9E7F5B8FE39B /* libPods.a */; };
+		60E26094D209E76D5D037634 /* (null) in Frameworks */ = {isa = PBXBuildFile; };
 		669B2F741AEBF92E00CF2367 /* OBAReleaseNotesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 669B2F731AEBF92E00CF2367 /* OBAReleaseNotesManager.m */; };
 		669B2F751AEBF92E00CF2367 /* OBAReleaseNotesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 669B2F731AEBF92E00CF2367 /* OBAReleaseNotesManager.m */; };
 		669B2F781AEBFCB300CF2367 /* OBAAnalytics.m in Sources */ = {isa = PBXBuildFile; fileRef = 669B2F771AEBFCB300CF2367 /* OBAAnalytics.m */; };
@@ -17,7 +17,6 @@
 		669B2F811AEBFEBF00CF2367 /* OBARegionHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 669B2F7F1AEBFEBF00CF2367 /* OBARegionHelper.m */; };
 		669B2F8C1AEC049D00CF2367 /* libOneBusAwaySDK.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 669B2F8B1AEC049D00CF2367 /* libOneBusAwaySDK.a */; };
 		669B2F8D1AEC04A100CF2367 /* libOneBusAwaySDK.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 669B2F8B1AEC049D00CF2367 /* libOneBusAwaySDK.a */; };
-		77F1DF137D15E0B33B6AC7F6 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A2B89E834A0C9E7F5B8FE39B /* libPods.a */; };
 		923FE680176082A7009AFDE8 /* UITableViewController+oba_Additions.m in Sources */ = {isa = PBXBuildFile; fileRef = 923FE67F176082A7009AFDE8 /* UITableViewController+oba_Additions.m */; };
 		928E12B217D7863400FD855E /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 928E12B117D7863400FD855E /* Images.xcassets */; };
 		931C42C2160E4B2A00435CD3 /* MKMapView+oba_Additions.m in Sources */ = {isa = PBXBuildFile; fileRef = 931C42C1160E4B2A00435CD3 /* MKMapView+oba_Additions.m */; };
@@ -83,6 +82,7 @@
 		9388E9DD1A9BCC8900C9F6CE /* feedback_message_body.html in Resources */ = {isa = PBXBuildFile; fileRef = 9388E9DC1A9BCC8900C9F6CE /* feedback_message_body.html */; };
 		93A923A21C21DCD600A657C8 /* SafariServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 93A923A11C21DCD600A657C8 /* SafariServices.framework */; };
 		93A923A81C21ED6A00A657C8 /* OBAModelService_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 93A923A71C21ED6A00A657C8 /* OBAModelService_Tests.m */; };
+		93A923B91C22154600A657C8 /* OBADataSourceConfig_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 93A923B81C22154600A657C8 /* OBADataSourceConfig_Tests.m */; };
 		93AD36431603FE7E00BDF03F /* OBAArrivalEntryTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 93AD363A1603FE7E00BDF03F /* OBAArrivalEntryTableViewCell.m */; };
 		93AD36441603FE7E00BDF03F /* OBAArrivalEntryTableViewCellFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 93AD363C1603FE7E00BDF03F /* OBAArrivalEntryTableViewCellFactory.m */; };
 		93AD36451603FE7E00BDF03F /* OBALabelAndTextFieldTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 93AD363E1603FE7E00BDF03F /* OBALabelAndTextFieldTableViewCell.m */; };
@@ -92,6 +92,8 @@
 		93F152F61A9AE91A0015C141 /* OneBusAway_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 93F152F51A9AE91A0015C141 /* OneBusAway_Tests.m */; };
 		93F153021A9AEA500015C141 /* OBAURLHelpers_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 93F153011A9AEA500015C141 /* OBAURLHelpers_Tests.m */; };
 		93F64E971BE5ACC300323527 /* OBAAlerts.m in Sources */ = {isa = PBXBuildFile; fileRef = 93F64E961BE5ACC300323527 /* OBAAlerts.m */; };
+		9B1767F94A5051BDFCE96F9D /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 57F2834D37D00C38D9A5A117 /* Pods.framework */; };
+		D026E9B444F4E9FC8C97C400 /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 57F2834D37D00C38D9A5A117 /* Pods.framework */; };
 		D651BB2811C9D5DE001BE733 /* iTunesArtwork in Resources */ = {isa = PBXBuildFile; fileRef = D651BB2711C9D5DE001BE733 /* iTunesArtwork */; };
 		D6575AEC0FEE13CF00D6D987 /* Entitlements.plist in Resources */ = {isa = PBXBuildFile; fileRef = D6575AEB0FEE13CF00D6D987 /* Entitlements.plist */; };
 /* End PBXBuildFile section */
@@ -127,6 +129,7 @@
 		28A0AB4B0D9B1048005BE974 /* org_onebusaway_iphone_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = org_onebusaway_iphone_Prefix.pch; sourceTree = "<group>"; };
 		29B97316FDCFA39411CA2CEA /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		54CB67407CF2B898E5D99654 /* Pods-OneBusAway.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OneBusAway.release.xcconfig"; path = "Pods/Target Support Files/Pods-OneBusAway/Pods-OneBusAway.release.xcconfig"; sourceTree = "<group>"; };
+		57F2834D37D00C38D9A5A117 /* Pods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		669B2D5A1AEBE63800CF2367 /* OneBusAwaySDK.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = OneBusAwaySDK.xcodeproj; path = sdk/OneBusAwaySDK.xcodeproj; sourceTree = "<group>"; };
 		669B2F721AEBF92E00CF2367 /* OBAReleaseNotesManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAReleaseNotesManager.h; sourceTree = "<group>"; };
 		669B2F731AEBF92E00CF2367 /* OBAReleaseNotesManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAReleaseNotesManager.m; sourceTree = "<group>"; };
@@ -253,6 +256,7 @@
 		939CEB241C0E406500E1D2B7 /* rvtd.gpx */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = rvtd.gpx; sourceTree = "<group>"; };
 		93A923A11C21DCD600A657C8 /* SafariServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SafariServices.framework; path = System/Library/Frameworks/SafariServices.framework; sourceTree = SDKROOT; };
 		93A923A71C21ED6A00A657C8 /* OBAModelService_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAModelService_Tests.m; sourceTree = "<group>"; };
+		93A923B81C22154600A657C8 /* OBADataSourceConfig_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBADataSourceConfig_Tests.m; sourceTree = "<group>"; };
 		93AD36391603FE7E00BDF03F /* OBAArrivalEntryTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAArrivalEntryTableViewCell.h; sourceTree = "<group>"; };
 		93AD363A1603FE7E00BDF03F /* OBAArrivalEntryTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAArrivalEntryTableViewCell.m; sourceTree = "<group>"; };
 		93AD363B1603FE7E00BDF03F /* OBAArrivalEntryTableViewCellFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAArrivalEntryTableViewCellFactory.h; sourceTree = "<group>"; };
@@ -272,7 +276,6 @@
 		93F64E951BE5ACC300323527 /* OBAAlerts.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAAlerts.h; sourceTree = "<group>"; };
 		93F64E961BE5ACC300323527 /* OBAAlerts.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAAlerts.m; sourceTree = "<group>"; };
 		9896748DE4027B647D4D41F0 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
-		A2B89E834A0C9E7F5B8FE39B /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		AF4665CA06626C1076EEEE33 /* Pods.appstoredistribution.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.appstoredistribution.xcconfig; path = "Pods/Target Support Files/Pods/Pods.appstoredistribution.xcconfig"; sourceTree = "<group>"; };
 		B565A40323F4842FC230AA07 /* Pods-OneBusAway.appstoredistribution.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OneBusAway.appstoredistribution.xcconfig"; path = "Pods/Target Support Files/Pods-OneBusAway/Pods-OneBusAway.appstoredistribution.xcconfig"; sourceTree = "<group>"; };
 		D651BB2711C9D5DE001BE733 /* iTunesArtwork */ = {isa = PBXFileReference; lastKnownFileType = file; name = iTunesArtwork; path = Resources/iTunesArtwork; sourceTree = "<group>"; };
@@ -293,7 +296,7 @@
 			files = (
 				93A923A21C21DCD600A657C8 /* SafariServices.framework in Frameworks */,
 				669B2F8C1AEC049D00CF2367 /* libOneBusAwaySDK.a in Frameworks */,
-				77F1DF137D15E0B33B6AC7F6 /* libPods.a in Frameworks */,
+				D026E9B444F4E9FC8C97C400 /* Pods.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -302,7 +305,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				669B2F8D1AEC04A100CF2367 /* libOneBusAwaySDK.a in Frameworks */,
-				60E26094D209E76D5D037634 /* libPods.a in Frameworks */,
+				60E26094D209E76D5D037634 /* (null) in Frameworks */,
+				9B1767F94A5051BDFCE96F9D /* Pods.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -385,7 +389,7 @@
 			children = (
 				93A923A11C21DCD600A657C8 /* SafariServices.framework */,
 				669B2F8B1AEC049D00CF2367 /* libOneBusAwaySDK.a */,
-				A2B89E834A0C9E7F5B8FE39B /* libPods.a */,
+				57F2834D37D00C38D9A5A117 /* Pods.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -694,6 +698,7 @@
 				93A923A71C21ED6A00A657C8 /* OBAModelService_Tests.m */,
 				93F152F31A9AE91A0015C141 /* Supporting Files */,
 				93F153011A9AEA500015C141 /* OBAURLHelpers_Tests.m */,
+				93A923B81C22154600A657C8 /* OBADataSourceConfig_Tests.m */,
 			);
 			path = "OneBusAway Tests";
 			sourceTree = "<group>";
@@ -1056,6 +1061,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				93A923B91C22154600A657C8 /* OBADataSourceConfig_Tests.m in Sources */,
 				93A923A81C21ED6A00A657C8 /* OBAModelService_Tests.m in Sources */,
 				93F153021A9AEA500015C141 /* OBAURLHelpers_Tests.m in Sources */,
 				669B2F751AEBF92E00CF2367 /* OBAReleaseNotesManager.m in Sources */,

--- a/sdk/sdk/Helpers/OBAURLHelpers.h
+++ b/sdk/sdk/Helpers/OBAURLHelpers.h
@@ -11,7 +11,6 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface OBAURLHelpers : NSObject
-+ (NSString *)escapeStringForUrl:(NSString *)url;
 + (NSURL*)normalizeURLPath:(NSString*)path relativeToBaseURL:(NSString*)baseURLString parameters:(NSDictionary*)params;
 @end
 

--- a/sdk/sdk/Helpers/OBAURLHelpers.m
+++ b/sdk/sdk/Helpers/OBAURLHelpers.m
@@ -10,18 +10,6 @@
 
 @implementation OBAURLHelpers
 
-+ (NSString *)escapeStringForUrl:(NSString *)url {
-    // http://stackoverflow.com/questions/8088473/url-encode-an-nsstring
-    NSString *encodedString = (NSString *)CFBridgingRelease(CFURLCreateStringByAddingPercentEscapes(
-                                                                                                    NULL,
-                                                                                                    (CFStringRef)url,
-                                                                                                    NULL,
-                                                                                                    (CFStringRef)@"!*'();:@&=+$,/?%#[]",
-                                                                                                    kCFStringEncodingUTF8 ));
-    
-    return encodedString;
-}
-
 + (NSURL*)normalizeURLPath:(NSString*)path relativeToBaseURL:(NSString*)baseURLString parameters:(NSDictionary*)params {
     
     if (![baseURLString hasPrefix:@"http://"] && ![baseURLString hasPrefix:@"https://"]) {

--- a/sdk/sdk/OBAApplication.m
+++ b/sdk/sdk/OBAApplication.m
@@ -81,15 +81,16 @@ NSString *const kOBAApplicationSettingsRegionRefreshNotification = @"kOBAApplica
         [[NSNotificationCenter defaultCenter] postNotificationName:kOBAApplicationSettingsRegionRefreshNotification object:nil];
     }
 
-    NSString *userId = [self userIdFromDefaults:[NSUserDefaults standardUserDefaults]];
-    NSString *appVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"];
-    NSString *obaArgs = [NSString stringWithFormat:@"key=org.onebusaway.iphone&app_uid=%@&app_ver=%@", userId, appVersion];
+    NSDictionary *obaArgs = @{ @"key":     @"org.onebusaway.iphone",
+                               @"app_uid": [self userIdFromDefaults:[NSUserDefaults standardUserDefaults]],
+                               @"app_ver": [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"],
+                               @"version": @"2"};
 
-    OBADataSourceConfig *obaDataSourceConfig = [[OBADataSourceConfig alloc] initWithUrl:apiServerName args:obaArgs];
+    OBADataSourceConfig *obaDataSourceConfig = [[OBADataSourceConfig alloc] initWithURL:[NSURL URLWithString:apiServerName] args:obaArgs];
     OBAJsonDataSource *obaJsonDataSource = [[OBAJsonDataSource alloc] initWithConfig:obaDataSourceConfig];
     _modelService.obaJsonDataSource = obaJsonDataSource;
 
-    OBADataSourceConfig *googleMapsDataSourceConfig = [[OBADataSourceConfig alloc] initWithUrl:@"https://maps.googleapis.com" args:@"&sensor=true"];
+    OBADataSourceConfig *googleMapsDataSourceConfig = [[OBADataSourceConfig alloc] initWithURL:[NSURL URLWithString:@"https://maps.googleapis.com"] args:@{@"sensor": @"true"}];
     OBAJsonDataSource *googleMapsJsonDataSource = [[OBAJsonDataSource alloc] initWithConfig:googleMapsDataSourceConfig];
     _modelService.googleMapsJsonDataSource = googleMapsJsonDataSource;
 
@@ -101,11 +102,9 @@ NSString *const kOBAApplicationSettingsRegionRefreshNotification = @"kOBAApplica
 
     regionApiServerName = [NSString stringWithFormat:@"http://%@", regionApiServerName];
 
-    OBADataSourceConfig *obaRegionDataSourceConfig = [[OBADataSourceConfig alloc] initWithUrl:regionApiServerName args:obaArgs];
+    OBADataSourceConfig *obaRegionDataSourceConfig = [[OBADataSourceConfig alloc] initWithURL:[NSURL URLWithString:regionApiServerName] args:obaArgs];
     OBAJsonDataSource *obaRegionJsonDataSource = [[OBAJsonDataSource alloc] initWithConfig:obaRegionDataSourceConfig];
     _modelService.obaRegionJsonDataSource = obaRegionJsonDataSource;
-
-    [[NSUserDefaults standardUserDefaults] setObject:appVersion forKey:@"oba_application_version"];
 }
 
 - (NSString *)userIdFromDefaults:(NSUserDefaults *)userDefaults {

--- a/sdk/sdk/Services/JsonUrlFetcherImpl.h
+++ b/sdk/sdk/Services/JsonUrlFetcherImpl.h
@@ -10,13 +10,9 @@
 #import "OBADataSource.h"
 
 @interface JsonUrlFetcherImpl : NSObject<NSURLConnectionDelegate, NSURLConnectionDataDelegate, OBADataSourceConnection>
-@property (strong, nonatomic) NSURLConnection *connection;
-@property (assign, nonatomic) NSStringEncoding responseEncoding;
-@property (strong, nonatomic) NSMutableData *responseData;
-@property (strong, nonatomic) NSHTTPURLResponse *requestResponse;
-@property (assign, nonatomic) NSInteger expectedLength;
 @property (nonatomic, copy) OBADataSourceCompletion completionBlock;
 @property (nonatomic, copy) OBADataSourceProgress progressBlock;
-@property (nonatomic, assign) BOOL uploading;
+
+- (instancetype)initWithCompletionBlock:(OBADataSourceCompletion)completion progressBlock:(OBADataSourceProgress)progress;
 - (void)loadRequest:(NSURLRequest *)request;
 @end

--- a/sdk/sdk/Services/JsonUrlFetcherImpl.m
+++ b/sdk/sdk/Services/JsonUrlFetcherImpl.m
@@ -8,105 +8,46 @@
 
 #import "JsonUrlFetcherImpl.h"
 
-@interface JsonUrlFetcherImpl () 
-
-
+@interface JsonUrlFetcherImpl ()
+@property(nonatomic,strong) NSURLSessionDataTask *task;
 @end
-
 
 @implementation JsonUrlFetcherImpl
 
-- (void)loadRequest:(NSURLRequest *)request {
-    static NSOperationQueue *connectionQueue;
-    static dispatch_once_t onceToken;
+- (instancetype)initWithCompletionBlock:(OBADataSourceCompletion)completion progressBlock:(OBADataSourceProgress)progress {
+    self = [super init];
 
-    dispatch_once(&onceToken, ^{
-        connectionQueue = [[NSOperationQueue alloc] init];
-    });
-
-    self.connection = [[NSURLConnection alloc] initWithRequest:request delegate:self startImmediately:NO];
-    [self.connection setDelegateQueue:connectionQueue];
-    [self.connection start];
-}
-
-- (NSMutableData *)responseData {
-    if (!_responseData) {
-        _responseData = [[NSMutableData alloc] init];
+    if (self) {
+        _completionBlock = completion;
+        _progressBlock = progress;
     }
 
-    return _responseData;
+    return self;
+}
+
+- (void)loadRequest:(NSURLRequest *)request {
+
+    self.task = [[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+        id responseObject = nil;
+
+        if (data.length) {
+            NSError *jsonError = nil;
+            responseObject = [NSJSONSerialization JSONObjectWithData:data options:0 error:&jsonError];
+
+            if (!responseObject && jsonError) {
+                error = jsonError;
+            }
+        }
+        dispatch_async(dispatch_get_main_queue(), ^{
+            self.completionBlock(responseObject, ((NSHTTPURLResponse*)response).statusCode, error);
+        });
+    }];
+    
+    [self.task resume];
 }
 
 - (void)cancel {
-    [self.connection cancel];
-}
-
-#pragma mark NSURLConnection Delegate Methods
-
-- (void)connection:(NSURLConnection *)connection didSendBodyData:(NSInteger)bytesWritten totalBytesWritten:(NSInteger)totalBytesWritten totalBytesExpectedToWrite:(NSInteger)totalBytesExpectedToWrite {
-    if (self.uploading) {
-        float progress = ((float)totalBytesWritten) / totalBytesExpectedToWrite;
-
-        dispatch_async(dispatch_get_main_queue(), ^{
-            if(self.progressBlock) {
-                self.progressBlock(progress);
-            }
-        });
-    }
-}
-
-- (void)connection:(NSURLConnection *)connection didReceiveResponse:(NSURLResponse *)response {
-    self.requestResponse = (NSHTTPURLResponse *)response;
-
-    NSString *textEncodingName = [response textEncodingName];
-
-    if (textEncodingName) {
-        self.responseEncoding = CFStringConvertEncodingToNSStringEncoding(CFStringConvertIANACharSetNameToEncoding((CFStringRef)textEncodingName));
-    }
-    else {
-        self.responseEncoding = NSUTF8StringEncoding;
-    }
-
-    self.expectedLength = (NSInteger)response.expectedContentLength;
-}
-
-- (void)connection:(NSURLConnection *)connection didReceiveData:(NSMutableData *)data {
-    [self.responseData appendData:data];
-
-    if (self.progressBlock) {
-        float progress = [self.responseData length];
-
-        if (self.expectedLength > 0) {
-            progress = ((float)[self.responseData length]) / self.expectedLength;
-        }
-
-        dispatch_async(dispatch_get_main_queue(), ^{
-            if(self.progressBlock) {
-                self.progressBlock(progress);
-            }
-        });
-    }
-}
-
-- (void)connectionDidFinishLoading:(NSURLConnection *)connection {
-    NSError *error = nil;
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wassign-enum"
-    id jsonObject = [NSJSONSerialization JSONObjectWithData:self.responseData options:0 error:&error];
-#pragma clang diagnostic pop
-    dispatch_async(dispatch_get_main_queue(), ^{
-        if (self.completionBlock) {
-            self.completionBlock(jsonObject, self.requestResponse.statusCode, error);
-        }
-    });
-}
-
-- (void)connection:(NSURLConnection *)connection didFailWithError:(NSError *)error {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        if (self.completionBlock) {
-            self.completionBlock(nil, NSUIntegerMax, error);
-        }
-    });
+    [self.task cancel];
 }
 
 @end

--- a/sdk/sdk/Services/OBADataSource.h
+++ b/sdk/sdk/Services/OBADataSource.h
@@ -24,11 +24,4 @@ typedef void (^OBADataSourceProgress)(CGFloat progress);
 - (void) cancel;
 @end
 
-@protocol OBADataSourceDelegate
-- (void)connectionDidFinishLoading:(id<OBADataSourceConnection>)connection withObject:(id)obj context:(id)context;
-- (void)connectionDidFail:(id<OBADataSourceConnection>)connection withError:(NSError *)error context:(id)context;
-@optional
-- (void)connection:(id<OBADataSourceConnection>)connection withProgress:(float)progress;
-@end
-
 NS_ASSUME_NONNULL_END

--- a/sdk/sdk/Services/OBADataSourceConfig.h
+++ b/sdk/sdk/Services/OBADataSourceConfig.h
@@ -19,10 +19,8 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface OBADataSourceConfig : NSObject
-@property(strong,readonly) NSString* url;
-@property(strong,readonly) NSString* args;
-- (id)initWithUrl:(NSString*)url args:(nullable NSString*)args;
-- (NSURL*)constructURL:(NSString*)path withArgs:(nullable NSString*)args includeArgs:(BOOL)includeArgs;
+- (instancetype)initWithURL:(NSURL*)baseURL args:(nullable NSDictionary*)args;
+- (NSURL*)constructURL:(NSString*)path withArgs:(nullable NSDictionary*)args;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/sdk/sdk/Services/OBAJsonDataSource.h
+++ b/sdk/sdk/Services/OBAJsonDataSource.h
@@ -25,26 +25,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (id)initWithConfig:(OBADataSourceConfig*)config;
 
-- (id<OBADataSourceConnection>) requestWithPath:(NSString*)path
-                                completionBlock:(OBADataSourceCompletion) completion;
+- (id<OBADataSourceConnection>)requestWithPath:(NSString*)path
+                                      withArgs:(nullable NSDictionary*)args
+                               completionBlock:(OBADataSourceCompletion) completion
+                                 progressBlock:(nullable OBADataSourceProgress) progress;
 
-- (id<OBADataSourceConnection>) requestWithPath:(NSString*)path
-                                       withArgs:(nullable NSString*)args
-                                completionBlock:(OBADataSourceCompletion) completion
-                                  progressBlock:(nullable OBADataSourceProgress) progress;
-
-- (id<OBADataSourceConnection>) requestWithPath:(NSString*)path
-                                       withArgs:(nullable NSString*)args
-                                 withFileUpload:(NSString*)filePath
-                                completionBlock:(OBADataSourceCompletion) completion
-                                  progressBlock:(nullable OBADataSourceProgress) progress;
-
-- (id<OBADataSourceConnection>) postWithPath:(NSString*)url
-                                    withArgs:(nullable NSDictionary*)args
-                             completionBlock:(OBADataSourceCompletion) completion
-                               progressBlock:(nullable OBADataSourceProgress) progress;
-
-- (void) cancelOpenConnections;
+- (void)cancelOpenConnections;
 
 @end
 

--- a/sdk/sdk/Services/OBAJsonDataSource.m
+++ b/sdk/sdk/Services/OBAJsonDataSource.m
@@ -19,18 +19,16 @@
 #import "JsonUrlFetcherImpl.h"
 
 @interface OBAJsonDataSource ()
-
-@property (strong) OBADataSourceConfig *config;
-@property (strong) NSHashTable *openConnections;
+@property(nonatomic,strong) OBADataSourceConfig *config;
+@property(nonatomic,strong) NSHashTable *openConnections;
 @end
-
 
 @implementation OBAJsonDataSource
 
 - (id)initWithConfig:(OBADataSourceConfig *)config {
     if (self = [super init]) {
-        self.config = config;
-        self.openConnections = [NSHashTable weakObjectsHashTable];
+        _config = config;
+        _openConnections = [NSHashTable weakObjectsHashTable];
     }
 
     return self;
@@ -40,74 +38,15 @@
     [self cancelOpenConnections];
 }
 
-- (id<OBADataSourceConnection>)requestWithPath:(NSString *)path completionBlock:(OBADataSourceCompletion)completion {
-    return [self requestWithPath:path withArgs:nil completionBlock:completion progressBlock:nil];
-}
+- (id<OBADataSourceConnection>)requestWithPath:(NSString *)path withArgs:(NSDictionary *)args completionBlock:(OBADataSourceCompletion)completion progressBlock:(OBADataSourceProgress)progress {
 
-- (id<OBADataSourceConnection>)requestWithPath:(NSString *)path withArgs:(NSString *)args completionBlock:(OBADataSourceCompletion)completion progressBlock:(OBADataSourceProgress)progress {
-    NSURL *feedURL = [self.config constructURL:path withArgs:args includeArgs:YES];
+    NSURL *feedURL = [self.config constructURL:path withArgs:args];
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:feedURL cachePolicy:NSURLRequestUseProtocolCachePolicy timeoutInterval:20];
-
     [request setValue:@"gzip" forHTTPHeaderField:@"Accept-Encoding"];
-    JsonUrlFetcherImpl *fetcher = [[JsonUrlFetcherImpl alloc] init];
-    fetcher.completionBlock = completion;
-    fetcher.progressBlock = progress;
+
+    JsonUrlFetcherImpl *fetcher = [[JsonUrlFetcherImpl alloc] initWithCompletionBlock:completion progressBlock:progress];
     [self.openConnections addObject:fetcher];
     [fetcher loadRequest:request];
-
-    return fetcher;
-}
-
-- (id<OBADataSourceConnection>)postWithPath:(NSString *)url withArgs:(NSDictionary *)args completionBlock:(OBADataSourceCompletion)completion progressBlock:(OBADataSourceProgress)progress {
-    NSURL *targetUrl = [_config constructURL:url withArgs:nil includeArgs:NO];
-    NSMutableURLRequest *postRequest = [NSMutableURLRequest requestWithURL:targetUrl];
-
-    [postRequest setValue:@"gzip" forHTTPHeaderField:@"Accept-Encoding"];
-    [postRequest setHTTPMethod:@"POST"];
-
-    NSString *formBody = [self constructFormBody:args];
-    [postRequest setHTTPBody:[formBody dataUsingEncoding:NSUTF8StringEncoding]];
-
-    JsonUrlFetcherImpl *fetcher = [[JsonUrlFetcherImpl alloc] init];
-    fetcher.progressBlock = progress;
-    fetcher.completionBlock = completion;
-    fetcher.uploading = YES;
-
-    [self.openConnections addObject:fetcher];
-    [fetcher loadRequest:postRequest];
-
-    return fetcher;
-}
-
-- (id<OBADataSourceConnection>)requestWithPath:(NSString *)url withArgs:(NSString *)args withFileUpload:(NSString *)path completionBlock:(OBADataSourceCompletion)completion progressBlock:(OBADataSourceProgress)progress {
-    NSURL *targetUrl = [_config constructURL:url withArgs:args includeArgs:YES];
-    NSMutableURLRequest *postRequest = [NSMutableURLRequest requestWithURL:targetUrl];
-
-    //adding header information:
-    [postRequest setHTTPMethod:@"POST"];
-
-    NSString *stringBoundary = @"0xKhTmLbOuNdArY";
-    NSString *contentType = [NSString stringWithFormat:@"multipart/form-data; boundary=%@", stringBoundary];
-    [postRequest addValue:contentType forHTTPHeaderField:@"Content-Type"];
-
-    //setting up the body:
-    NSMutableData *postBody = [NSMutableData data];
-    [postBody appendData:[[NSString stringWithFormat:@"--%@\r\n", stringBoundary] dataUsingEncoding:NSUTF8StringEncoding]];
-    [postBody appendData:[@"Content-Disposition: form-data; name=\"upload\"; filename=\"upload\"\r\n" dataUsingEncoding : NSUTF8StringEncoding]];
-    [postBody appendData:[@"Content-Type: application/octet-stream\r\n\r\n" dataUsingEncoding : NSUTF8StringEncoding]];
-    NSData *fileData = [NSData dataWithContentsOfFile:path];
-    [postBody appendData:fileData];
-    [postBody appendData:[[NSString stringWithFormat:@"\r\n--%@--\r\n", stringBoundary] dataUsingEncoding:NSUTF8StringEncoding]];
-    [postRequest setHTTPBody:postBody];
-
-    JsonUrlFetcherImpl *fetcher = [[JsonUrlFetcherImpl alloc] init];
-
-    fetcher.progressBlock = progress;
-    fetcher.completionBlock = completion;
-    fetcher.uploading = YES;
-
-    [self.openConnections addObject:fetcher];
-    [fetcher loadRequest:postRequest];
 
     return fetcher;
 }
@@ -118,44 +57,6 @@
     }
 
     [self.openConnections removeAllObjects];
-}
-
-- (NSString *)constructFormBody:(NSDictionary *)args {
-    NSMutableString *body = [NSMutableString string];
-
-    if (_config.args) [body appendString:_config.args];
-
-    for (NSString *paramName in args) {
-        id values = args[paramName];
-
-        if (![values isKindOfClass:[NSArray class]]) values = @[values];
-
-        for (id paramValue in values) {
-            if ([body length] > 0) [body appendString:@"&"];
-
-            [body appendString:paramName];
-            [body appendString:@"="];
-            NSString *stringValue = [self paramValueAsString:paramValue];
-            stringValue = [self escapeParamValue:stringValue];
-            [body appendString:stringValue];
-        }
-    }
-
-    return body;
-}
-
-- (NSString *)paramValueAsString:(id)value {
-    if ([value isKindOfClass:[NSString class]]) return value;
-
-    if ([value isKindOfClass:[NSNumber class]]) return [value stringValue];
-
-    return [value description];
-}
-
-- (NSString *)escapeParamValue:(NSString *)s {
-    NSString *reserved = @";/?:@&=+$,";
-
-    return CFBridgingRelease(CFURLCreateStringByAddingPercentEscapes(kCFAllocatorDefault, (CFStringRef)s, NULL, (CFStringRef)reserved, kCFStringEncodingUTF8));
 }
 
 @end

--- a/sdk/sdk/Services/OBAModelFactory.h
+++ b/sdk/sdk/Services/OBAModelFactory.h
@@ -37,6 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (OBAStopsForRouteV2*) getStopsForRouteV2FromJSON:(NSDictionary*)jsonDictionary error:(NSError**)error;
 - (OBAListWithRangeAndReferencesV2*) getAgenciesWithCoverageV2FromJson:(id)jsonDictionary error:(NSError**)error;
+- (OBAListWithRangeAndReferencesV2*) getRegionsV2FromJson:(id)jsonDictionary error:(NSError**)error;
 - (OBAArrivalsAndDeparturesForStopV2*) getArrivalsAndDeparturesForStopV2FromJSON:(NSDictionary*)jsonDictionary error:(NSError**)error;
 - (OBAEntryWithReferencesV2*) getArrivalAndDepartureForStopV2FromJSON:(NSDictionary*)jsonDictionary error:(NSError**)error;
 - (OBAPlacemarks*) getPlacemarksFromJSONObject:(id)jsonObject error:(NSError**)error;

--- a/sdk/sdk/Services/OBAModelService.h
+++ b/sdk/sdk/Services/OBAModelService.h
@@ -1,6 +1,5 @@
 #import "OBAModelDAO.h"
 #import "OBAModelFactory.h"
-#import "OBADataSourceConfig.h"
 #import "OBAJsonDataSource.h"
 #import "OBALocationManager.h"
 
@@ -22,15 +21,11 @@ NS_ASSUME_NONNULL_BEGIN
  * This protocol mimics the functionality of UIApplication.  It is placed here to get around Extension only API limitation.
  */
 @protocol OBABackgroundTaskExecutor <NSObject>
-
--(UIBackgroundTaskIdentifier) beginBackgroundTaskWithExpirationHandler:(void(^)(void))handler;
--(UIBackgroundTaskIdentifier) endBackgroundTask:(UIBackgroundTaskIdentifier) task;
-
+- (UIBackgroundTaskIdentifier) beginBackgroundTaskWithExpirationHandler:(void(^)(void))handler;
+- (UIBackgroundTaskIdentifier) endBackgroundTask:(UIBackgroundTaskIdentifier) task;
 @end
 
 @interface OBAModelService : NSObject
-
-
 @property (nonatomic, strong) OBAReferencesV2 *references;
 @property (nonatomic, strong) OBAModelDAO *modelDao;
 @property (nonatomic, strong) OBAModelFactory *modelFactory;
@@ -39,8 +34,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) OBAJsonDataSource *googleMapsJsonDataSource;
 @property (nonatomic, strong) OBAJsonDataSource *googlePlacesJsonDataSource;
 @property (nonatomic, strong) OBALocationManager *locationManager;
-
-@property (nonatomic, strong) NSData *deviceToken;
 
 /**
  * Registers a background executor to be used by all services.  This method should not be used by extensions.
@@ -83,16 +76,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (id<OBAModelServiceRequest>)requestStopsForRegion:(MKCoordinateRegion)region
                                     completionBlock:(OBADataSourceCompletion)completion;
-/**
- *  Makes an asynchronous request for a set of stops for a given query
- *
- *  @param stopQuery  A "stopCode" represented by a string
- *  @param completion The block to be called once the request completes, this is always executed on the main thread.
- *
- *  @return The OBAModelServiceRequest object that allows request cancellation
- */
-- (id<OBAModelServiceRequest>)requestStopsForQuery:(NSString *)stopQuery
-                                   completionBlock:(OBADataSourceCompletion)completion;
+
 /**
  *  Makes an asynchronous request to get a set of stops for a given query, bounded by a region
  *
@@ -125,16 +109,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (id<OBAModelServiceRequest>)requestStopsForPlacemark:(OBAPlacemark *)placemark
                                        completionBlock:(OBADataSourceCompletion)completion;
-/**
- *  Makes an asynchronous request to fetch a set of routes
- *
- *  @param routeQuery Query to identify a route
- *  @param completion The block to be called once the request completes, this is always executed on the main thread.
- *
- *  @return The OBAModelServiceRequest object that allows request cancellation
- */
-- (id<OBAModelServiceRequest>)requestRoutesForQuery:(NSString *)routeQuery
-                                    completionBlock:(OBADataSourceCompletion)completion;
+
 /**
  *  Makes an asynchronous request to fetch a set of routes
  *
@@ -157,16 +132,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (id<OBAModelServiceRequest>)placemarksForAddress:(NSString *)address
                                    completionBlock:(OBADataSourceCompletion)completion;
-/**
- *  Makes an asynchronous request to fetch a set of placemarks based on their names
- *
- *  @param name       The name to be used to search for placemarks
- *  @param completion The block to be called once the request completes, this is always executed on the main thread.
- *
- *  @return The OBAModelServiceRequest object that allows request cancellation
- */
-- (id<OBAModelServiceRequest>)placemarksForPlace:(NSString *)name
-                                 completionBlock:(OBADataSourceCompletion)completion;
+
 /**
  *  Makes an asynchronous request to fetch all available OBA regions, including experimental and inactive
  *
@@ -247,16 +213,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (id<OBAModelServiceRequest>)reportProblemWithTrip:(OBAReportProblemWithTripV2 *)problem
                                     completionBlock:(OBADataSourceCompletion)completion;
-/**
- *  Makes an asynchronous request to fetch estimated vehicles times
- *
- *  @param locations  Array of locations for which the data is to be queried
- *  @param completion The block to be called once the request completes, this is always executed on the main thread.
- *
- *  @return The OBAModelServiceRequest object that allows request cancellation
- */
-- (id<OBAModelServiceRequest>)requestCurrentVehicleEstimatesForLocations:(NSArray *)locations
-                                                         completionBlock:(OBADataSourceCompletion)completion;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/sdk/sdk/Services/OBAModelService.m
+++ b/sdk/sdk/Services/OBAModelService.m
@@ -9,83 +9,69 @@ static const CLLocationAccuracy kBigSearchRadius = 15000;
 @implementation OBAModelService
 
 - (id<OBAModelServiceRequest>)requestStopForId:(NSString *)stopId completionBlock:(OBADataSourceCompletion)completion {
-    stopId = [OBAURLHelpers escapeStringForUrl:stopId];
-
-    NSString *url = [NSString stringWithFormat:@"/api/where/stop/%@.json", stopId];
-    NSString *args = @"version=2";
-    SEL selector = @selector(getStopFromJSON:error:);
-
-    return [self request:url args:args selector:selector completionBlock:completion progressBlock:nil];
+    return [self request:self.obaJsonDataSource
+                     url:[NSString stringWithFormat:@"/api/where/stop/%@.json", stopId]
+                    args:nil
+                selector:@selector(getStopFromJSON:error:)
+         completionBlock:completion
+           progressBlock:nil];
 }
 
 - (id<OBAModelServiceRequest>)requestStopWithArrivalsAndDeparturesForId:(NSString *)stopId withMinutesBefore:(NSUInteger)minutesBefore withMinutesAfter:(NSUInteger)minutesAfter completionBlock:(OBADataSourceCompletion)completion progressBlock:(OBADataSourceProgress)progress {
-    stopId = [OBAURLHelpers escapeStringForUrl:stopId];
 
-    NSString *url = [NSString stringWithFormat:@"/api/where/arrivals-and-departures-for-stop/%@.json", stopId];
-    NSString *args = [NSString stringWithFormat:@"version=2&minutesBefore=%lu&minutesAfter=%lu", (unsigned long)minutesBefore, (unsigned long)minutesAfter];
-    SEL selector = @selector(getArrivalsAndDeparturesForStopV2FromJSON:error:);
+    NSDictionary *args = @{ @"minutesBefore": @(minutesBefore),
+                            @"minutesAfter":  @(minutesAfter) };
 
-    return [self request:url args:args selector:selector completionBlock:completion progressBlock:progress];
+    return [self request:self.obaJsonDataSource
+                     url:[NSString stringWithFormat:@"/api/where/arrivals-and-departures-for-stop/%@.json", stopId]
+                    args:args
+                selector:@selector(getArrivalsAndDeparturesForStopV2FromJSON:error:)
+         completionBlock:completion
+           progressBlock:progress];
 }
 
 - (id<OBAModelServiceRequest>)requestStopsForRegion:(MKCoordinateRegion)region completionBlock:(OBADataSourceCompletion)completion; {
-    CLLocationCoordinate2D coord = region.center;
-    MKCoordinateSpan span = region.span;
+    NSDictionary *args = @{ @"lat": @(region.center.latitude),
+                            @"lon": @(region.center.longitude),
+                            @"latSpan": @(region.span.latitudeDelta),
+                            @"lonSpan": @(region.span.longitudeDelta) };
 
-    NSString *url = @"/api/where/stops-for-location.json";
-    NSString *args = [NSString stringWithFormat:@"lat=%f&lon=%f&latSpan=%f&lonSpan=%f&version=2", coord.latitude, coord.longitude, span.latitudeDelta, span.longitudeDelta];
-    SEL selector = @selector(getStopsV2FromJSON:error:);
-
-    return [self request:url args:args selector:selector completionBlock:completion progressBlock:nil];
-}
-
-- (id<OBAModelServiceRequest>)requestStopsForQuery:(NSString *)stopQuery completionBlock:(OBADataSourceCompletion)completion {
-    return [self requestStopsForQuery:stopQuery withRegion:nil completionBlock:completion];
+    return [self request:self.obaJsonDataSource
+                     url:@"/api/where/stops-for-location.json"
+                    args:args
+                selector:@selector(getStopsV2FromJSON:error:)
+         completionBlock:completion
+           progressBlock:nil];
 }
 
 - (id<OBAModelServiceRequest>)requestStopsForQuery:(NSString *)stopQuery withRegion:(CLCircularRegion *)region completionBlock:(OBADataSourceCompletion)completion {
-    CLLocationDistance radius = kBigSearchRadius;
-    CLLocationCoordinate2D coord;
+    CLLocationDistance radius = MAX(region.radius, kBigSearchRadius);
+    CLLocationCoordinate2D coord = region ? region.center : [self currentOrDefaultLocationToSearch].coordinate;
 
-    if (region) {
-        radius = region.radius > kBigSearchRadius ? region.radius : kBigSearchRadius;
-        coord = region.center;
-    }
-    else {
-        CLLocation *location = [self currentOrDefaultLocationToSearch];
-        coord = location.coordinate;
-    }
+    NSDictionary *args = @{@"lat": @(coord.latitude), @"lon": @(coord.longitude), @"query": stopQuery, @"radius": @(radius)};
 
-    stopQuery = [OBAURLHelpers escapeStringForUrl:stopQuery];
-
-    NSString *url = @"/api/where/stops-for-location.json";
-    NSString *args = [NSString stringWithFormat:@"lat=%f&lon=%f&query=%@&version=2&radius=%f", coord.latitude, coord.longitude, stopQuery, radius];
-    SEL selector = @selector(getStopsV2FromJSON:error:);
-
-    return [self request:url args:args selector:selector completionBlock:completion progressBlock:nil];
+    return [self request:self.obaJsonDataSource
+                     url:@"/api/where/stops-for-location.json"
+                    args:args
+                selector:@selector(getStopsV2FromJSON:error:)
+         completionBlock:completion
+           progressBlock:nil];
 }
 
 - (id<OBAModelServiceRequest>)requestStopsForRoute:(NSString *)routeId completionBlock:(OBADataSourceCompletion)completion {
-    routeId = [OBAURLHelpers escapeStringForUrl:routeId];
-
-    NSString *url = [NSString stringWithFormat:@"/api/where/stops-for-route/%@.json", routeId];
-    NSString *args = @"version=2";
-    SEL selector = @selector(getStopsForRouteV2FromJSON:error:);
-
-    return [self request:url args:args selector:selector completionBlock:completion progressBlock:nil];
+    return [self request:self.obaJsonDataSource
+                     url:[NSString stringWithFormat:@"/api/where/stops-for-route/%@.json", routeId]
+                    args:nil
+                selector:@selector(getStopsForRouteV2FromJSON:error:)
+         completionBlock:completion
+           progressBlock:nil];
 }
 
 - (id<OBAModelServiceRequest>)requestStopsForPlacemark:(OBAPlacemark *)placemark completionBlock:(OBADataSourceCompletion)completion {
-    // request search
-    CLLocationCoordinate2D location = placemark.coordinate;
+    MKCoordinateRegion region = [OBASphericalGeometryLibrary createRegionWithCenter:placemark.coordinate latRadius:kSearchRadius lonRadius:kSearchRadius];
 
-    MKCoordinateRegion region = [OBASphericalGeometryLibrary createRegionWithCenter:location latRadius:kSearchRadius lonRadius:kSearchRadius];
-
-    return [self requestStopsForRegion:region completionBlock:completion];
-}
-
-- (id<OBAModelServiceRequest>)requestRoutesForQuery:(NSString *)routeQuery completionBlock:(OBADataSourceCompletion)completion {
-    return [self requestRoutesForQuery:routeQuery withRegion:nil completionBlock:completion];
+    return [self requestStopsForRegion:region
+                       completionBlock:completion];
 }
 
 - (id<OBAModelServiceRequest>)requestRoutesForQuery:(NSString *)routeQuery withRegion:(CLCircularRegion *)region completionBlock:(OBADataSourceCompletion)completion {
@@ -93,7 +79,7 @@ static const CLLocationAccuracy kBigSearchRadius = 15000;
     CLLocationCoordinate2D coord;
 
     if (region) {
-        radius = region.radius > kBigSearchRadius ? region.radius : kBigSearchRadius;
+        radius = MAX(region.radius, kBigSearchRadius);
         coord = region.center;
     }
     else {
@@ -101,149 +87,137 @@ static const CLLocationAccuracy kBigSearchRadius = 15000;
         coord = location.coordinate;
     }
 
-    routeQuery = [OBAURLHelpers escapeStringForUrl:routeQuery];
+    NSDictionary *args = @{@"lat": @(coord.latitude), @"lon": @(coord.longitude), @"query": routeQuery, @"radius": @(radius)};
 
-    NSString *url = @"/api/where/routes-for-location.json";
-    NSString *args = [NSString stringWithFormat:@"lat=%f&lon=%f&query=%@&version=2&radius=%f", coord.latitude, coord.longitude, routeQuery, radius];
-    SEL selector = @selector(getRoutesV2FromJSON:error:);
-
-    return [self request:url args:args selector:selector completionBlock:completion progressBlock:nil];
+    return [self request:self.obaJsonDataSource
+                     url:@"/api/where/routes-for-location.json"
+                    args:args
+                selector:@selector(getRoutesV2FromJSON:error:)
+         completionBlock:completion
+           progressBlock:nil];
 }
 
 - (id<OBAModelServiceRequest>)placemarksForAddress:(NSString *)address completionBlock:(OBADataSourceCompletion)completion {
-    // handle search
-    CLLocation *location = [self currentOrDefaultLocationToSearch];
-    CLLocationCoordinate2D coord = location.coordinate;
+    CLLocationCoordinate2D coord = [self currentOrDefaultLocationToSearch].coordinate;
 
-    address = [OBAURLHelpers escapeStringForUrl:address];
-    address = [address stringByReplacingOccurrencesOfString:@"%20" withString:@"+"];
+    NSDictionary *args = @{
+                           @"bounds": [NSString stringWithFormat:@"%@,%@|%@,%@", @(coord.latitude), @(coord.longitude), @(coord.latitude), @(coord.longitude)],
+                           @"address": address
+                           };
 
-    NSString *url = @"/maps/api/geocode/json";
-
-    NSString *args = [[NSString stringWithFormat:@"bounds=%f,%f|%f,%f&address=%@", coord.latitude, coord.longitude, coord.latitude, coord.longitude, address] stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-
-    SEL selector = @selector(getPlacemarksFromJSONObject:error:);
-
-    return [self request:_googleMapsJsonDataSource url:url args:args selector:selector completionBlock:completion progressBlock:nil];
+    return [self request:_googleMapsJsonDataSource
+                     url:@"/maps/api/geocode/json"
+                    args:args
+                selector:@selector(getPlacemarksFromJSONObject:error:)
+         completionBlock:completion
+           progressBlock:nil];
 }
 
 - (id<OBAModelServiceRequest>)requestRegions:(OBADataSourceCompletion)completion {
-    NSString *url = @"/regions-v3.json";
-    NSString *args = @"";
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wundeclared-selector"
-    SEL selector = @selector(getRegionsV2FromJson:error:);
-#pragma clang diagnostic pop
-
-    return [self request:self.obaRegionJsonDataSource url:url args:args selector:selector completionBlock:completion progressBlock:nil];
-}
-
-- (id<OBAModelServiceRequest>)placemarksForPlace:(NSString *)name completionBlock:(OBADataSourceCompletion)completion {
-    // handle search
-    CLLocation *location = [self currentOrDefaultLocationToSearch];
-    CLLocationCoordinate2D coord = location.coordinate;
-
-    name = [OBAURLHelpers escapeStringForUrl:name];
-
-    CLLocationAccuracy radius = location.horizontalAccuracy;
-
-    if (radius == 0) {
-        radius = kSearchRadius;
-    }
-
-    NSString *url = @"/maps/api/place/search/json";
-    NSString *args = [NSString stringWithFormat:@"location=%f,%f&radius=%ld&name=%@&sensor=true", coord.latitude, coord.longitude, (long)radius, name];
-    SEL selector = @selector(getPlacemarksFromGooglePlacesJSONObject:error:);
-
-    return [self request:_googlePlacesJsonDataSource url:url args:args selector:selector completionBlock:completion progressBlock:nil];
+    return [self request:self.obaRegionJsonDataSource
+                     url:@"/regions-v3.json"
+                    args:nil
+                selector:@selector(getRegionsV2FromJson:error:)
+         completionBlock:completion
+           progressBlock:nil];
 }
 
 - (id<OBAModelServiceRequest>)requestAgenciesWithCoverage:(OBADataSourceCompletion)completion {
-    // update search filter description
-    // self.searchFilterString = [NSString stringWithFormat:@"Transit Agencies"];
-
-    NSString *url = @"/api/where/agencies-with-coverage.json";
-    NSString *args = @"version=2";
-    SEL selector = @selector(getAgenciesWithCoverageV2FromJson:error:);
-
-    return [self request:url args:args selector:selector completionBlock:completion progressBlock:nil];
+    return [self request:self.obaJsonDataSource
+                     url:@"/api/where/agencies-with-coverage.json"
+                    args:nil
+                selector:@selector(getAgenciesWithCoverageV2FromJson:error:)
+         completionBlock:completion
+           progressBlock:nil];
 }
 
 - (id<OBAModelServiceRequest>)requestArrivalAndDepartureForStop:(OBAArrivalAndDepartureInstanceRef *)instance completionBlock:(OBADataSourceCompletion)completion {
-    NSString *stopId = [OBAURLHelpers escapeStringForUrl:instance.stopId];
     OBATripInstanceRef *tripInstance = instance.tripInstance;
-
-    NSString *url = [NSString stringWithFormat:@"/api/where/arrival-and-departure-for-stop/%@.json", stopId];
-    NSMutableString *args = [NSMutableString stringWithString:@"version=2"];
-
-    [args appendFormat:@"&tripId=%@", [OBAURLHelpers escapeStringForUrl:tripInstance.tripId]];
-    [args appendFormat:@"&serviceDate=%lld", tripInstance.serviceDate];
-
-    if (tripInstance.vehicleId) [args appendFormat:@"&vehicleId=%@", [OBAURLHelpers escapeStringForUrl:tripInstance.vehicleId]];
-
-    if (instance.stopSequence >= 0) [args appendFormat:@"&stopSequence=%ld", (long)instance.stopSequence];
-
-    SEL selector = @selector(getArrivalAndDepartureForStopV2FromJSON:error:);
-
-    return [self request:url args:args selector:selector completionBlock:completion progressBlock:nil];
-}
-
-- (id<OBAModelServiceRequest>)requestTripDetailsForTripInstance:(OBATripInstanceRef *)tripInstance completionBlock:(OBADataSourceCompletion)completion progressBlock:(OBADataSourceProgress)progress {
-    NSString *tripId = [OBAURLHelpers escapeStringForUrl:tripInstance.tripId];
-    NSString *url = [NSString stringWithFormat:@"/api/where/trip-details/%@.json", tripId];
-    NSMutableString *args = [NSMutableString stringWithString:@"version=2"];
-
-    if (tripInstance.serviceDate > 0) [args appendFormat:@"&serviceDate=%lld", tripInstance.serviceDate];
-
-    if (tripInstance.vehicleId) [args appendFormat:@"&vehicleId=%@", [OBAURLHelpers escapeStringForUrl:tripInstance.vehicleId]];
-
-    SEL selector = @selector(getTripDetailsV2FromJSON:error:);
-
-    return [self request:url args:args selector:selector completionBlock:completion progressBlock:progress];
-}
-
-- (id<OBAModelServiceRequest>)requestVehicleForId:(NSString *)vehicleId completionBlock:(OBADataSourceCompletion)completion {
-    vehicleId = [OBAURLHelpers escapeStringForUrl:vehicleId];
-
-    NSString *url = [NSString stringWithFormat:@"/api/where/vehicle/%@.json", vehicleId];
-    NSString *args = [NSString stringWithFormat:@"version=2"];
-    SEL selector = @selector(getVehicleStatusV2FromJSON:error:);
-
-    return [self request:url args:args selector:selector completionBlock:completion progressBlock:nil];
-}
-
-- (id<OBAModelServiceRequest>)requestShapeForId:(NSString *)shapeId completionBlock:(OBADataSourceCompletion)completion {
-    shapeId = [OBAURLHelpers escapeStringForUrl:shapeId];
-
-    NSString *url = [NSString stringWithFormat:@"/api/where/shape/%@.json", shapeId];
-    NSString *args = [NSString stringWithFormat:@"version=2"];
-    SEL selector = @selector(getShapeV2FromJSON:error:);
-
-    return [self request:url args:args selector:selector completionBlock:completion progressBlock:nil];
-}
-
-- (id<OBAModelServiceRequest>)reportProblemWithStop:(OBAReportProblemWithStopV2 *)problem completionBlock:(OBADataSourceCompletion)completion {
-    NSString *url = [NSString stringWithFormat:@"/api/where/report-problem-with-stop.json"];
 
     NSMutableDictionary *args = [[NSMutableDictionary alloc] init];
 
-    args[@"version"] = @"2";
+    args[@"tripId"] = tripInstance.tripId;
+    args[@"serviceDate"] = @(tripInstance.serviceDate);
+
+    if (tripInstance.vehicleId) {
+        args[@"vehicleId"] = tripInstance.vehicleId;
+    }
+
+    if (instance.stopSequence >= 0) {
+        args[@"stopSequence"] = @(instance.stopSequence);
+    }
+
+    return [self request:self.obaJsonDataSource
+                     url:[NSString stringWithFormat:@"/api/where/arrival-and-departure-for-stop/%@.json", instance.stopId]
+                    args:args
+                selector:@selector(getArrivalAndDepartureForStopV2FromJSON:error:)
+         completionBlock:completion
+           progressBlock:nil];
+}
+
+- (id<OBAModelServiceRequest>)requestTripDetailsForTripInstance:(OBATripInstanceRef *)tripInstance completionBlock:(OBADataSourceCompletion)completion progressBlock:(OBADataSourceProgress)progress {
+    NSMutableDictionary *args = [[NSMutableDictionary alloc] init];
+
+    if (tripInstance.serviceDate > 0) {
+        args[@"serviceDate"] = @(tripInstance.serviceDate);
+    }
+
+    if (tripInstance.vehicleId) {
+        args[@"vehicleId"] = tripInstance.vehicleId;
+    }
+
+    return [self request:self.obaJsonDataSource
+                     url:[NSString stringWithFormat:@"/api/where/trip-details/%@.json", tripInstance.tripId]
+                    args:args
+                selector:@selector(getTripDetailsV2FromJSON:error:)
+         completionBlock:completion
+           progressBlock:progress];
+}
+
+- (id<OBAModelServiceRequest>)requestVehicleForId:(NSString *)vehicleId completionBlock:(OBADataSourceCompletion)completion {
+    return [self request:self.obaJsonDataSource
+                     url:[NSString stringWithFormat:@"/api/where/vehicle/%@.json", vehicleId]
+                    args:nil
+                selector:@selector(getVehicleStatusV2FromJSON:error:)
+         completionBlock:completion
+           progressBlock:nil];
+}
+
+- (id<OBAModelServiceRequest>)requestShapeForId:(NSString *)shapeId completionBlock:(OBADataSourceCompletion)completion {
+    return [self request:self.obaJsonDataSource
+                     url:[NSString stringWithFormat:@"/api/where/shape/%@.json", shapeId]
+                    args:nil
+                selector:@selector(getShapeV2FromJSON:error:)
+         completionBlock:completion
+           progressBlock:nil];
+}
+
+- (id<OBAModelServiceRequest>)reportProblemWithStop:(OBAReportProblemWithStopV2 *)problem completionBlock:(OBADataSourceCompletion)completion {
+    NSMutableDictionary *args = [[NSMutableDictionary alloc] init];
+
     args[@"stopId"] = problem.stopId;
 
-    if (problem.code) args[@"code"] = problem.code;
+    if (problem.code) {
+        args[@"code"] = problem.code;
+    }
 
-    if (problem.userComment) args[@"userComment"] = problem.userComment;
+    if (problem.userComment) {
+        args[@"userComment"] = problem.userComment;
+    }
 
     if (problem.userLocation) {
         CLLocationCoordinate2D coord = problem.userLocation.coordinate;
-        args[@"userLat"] = [@(coord.latitude)stringValue];
-        args[@"userLon"] = [@(coord.longitude)stringValue];
-        args[@"userLocationAccuracy"] = [@(problem.userLocation.horizontalAccuracy)stringValue];
+        args[@"userLat"] = @(coord.latitude);
+        args[@"userLon"] = @(coord.longitude);
+        args[@"userLocationAccuracy"] = @(problem.userLocation.horizontalAccuracy);
     }
 
-    SEL selector = nil;
-
-    OBAModelServiceRequest *request = [self request:url args:[self argsFromDictionary:args] selector:selector completionBlock:completion progressBlock:nil];
+    OBAModelServiceRequest *request = [self request:self.obaJsonDataSource
+                                                url:@"/api/where/report-problem-with-stop.json"
+                                               args:args
+                                           selector:nil
+                                    completionBlock:completion
+                                      progressBlock:nil];
     request.checkCode = YES;
     return request;
 }
@@ -254,92 +228,53 @@ static const CLLocationAccuracy kBigSearchRadius = 15000;
     NSMutableDictionary *args = [[NSMutableDictionary alloc] init];
     OBATripInstanceRef *tripInstance = problem.tripInstance;
 
-    args[@"version"] = @"2";
     args[@"tripId"] = tripInstance.tripId;
-    args[@"serviceDate"] = [NSString stringWithFormat:@"%lld", tripInstance.serviceDate];
+    args[@"serviceDate"] = @(tripInstance.serviceDate);
 
     if (tripInstance.vehicleId) {
-        NSLog(@"vid=%@", tripInstance.vehicleId);
         args[@"vehicleId"] = tripInstance.vehicleId;
     }
 
-    if (problem.stopId) args[@"stopId"] = problem.stopId;
+    if (problem.stopId) {
+        args[@"stopId"] = problem.stopId;
+    }
 
-    if (problem.code) args[@"code"] = problem.code;
+    if (problem.code) {
+        args[@"code"] = problem.code;
+    }
 
-    if (problem.userComment) args[@"userComment"] = problem.userComment;
+    if (problem.userComment) {
+        args[@"userComment"] = problem.userComment;
+    }
 
     args[@"userOnVehicle"] = (problem.userOnVehicle ? @"true" : @"false");
 
-    if (problem.userVehicleNumber) args[@"userVehicleNumber"] = problem.userVehicleNumber;
+    if (problem.userVehicleNumber) {
+        args[@"userVehicleNumber"] = problem.userVehicleNumber;
+    }
 
     if (problem.userLocation) {
         CLLocationCoordinate2D coord = problem.userLocation.coordinate;
-        args[@"userLat"] = [@(coord.latitude)stringValue];
-        args[@"userLon"] = [@(coord.longitude)stringValue];
-        args[@"userLocationAccuracy"] = [@(problem.userLocation.horizontalAccuracy)stringValue];
+        args[@"userLat"] = @(coord.latitude);
+        args[@"userLon"] = @(coord.longitude);
+        args[@"userLocationAccuracy"] = @(problem.userLocation.horizontalAccuracy);
     }
 
-    SEL selector = nil;
-
-    OBAModelServiceRequest *request = [self request:url args:[self argsFromDictionary:args] selector:selector completionBlock:completion progressBlock:nil];
+    OBAModelServiceRequest *request = [self request:self.obaJsonDataSource
+                                                url:url
+                                               args:args
+                                           selector:nil
+                                    completionBlock:completion
+                                      progressBlock:nil];
     request.checkCode = YES;
     return request;
 }
 
-- (id<OBAModelServiceRequest>)requestCurrentVehicleEstimatesForLocations:(NSArray *)locations completionBlock:(OBADataSourceCompletion)completion {
-    NSString *url = [NSString stringWithFormat:@"/api/where/estimate-current-vehicle.json"];
-
-    NSMutableDictionary *args = [[NSMutableDictionary alloc] init];
-
-    NSMutableString *data = [[NSMutableString alloc] init];
-
-    for (CLLocation *location in locations) {
-        if ([data length] > 0) {
-            [data appendString:@"|"];
-        }
-
-        NSDate *time = location.timestamp;
-        NSTimeInterval interval = [time timeIntervalSince1970];
-        long long t = (long long)(interval * 1000);
-        [data appendFormat:@"%lld", t];
-        [data appendString:@","];
-        [data appendFormat:@"%f", location.coordinate.latitude];
-        [data appendString:@","];
-        [data appendFormat:@"%f", location.coordinate.longitude];
-        [data appendString:@","];
-        [data appendFormat:@"%f", location.horizontalAccuracy];
-    }
-
-    args[@"data"] = data;
-
-    SEL selector = @selector(getCurrentVehicleEstimatesV2FromJSON:error:);
-
-    return [self request:url args:[self argsFromDictionary:args] selector:selector completionBlock:completion progressBlock:nil];
-}
-
-- (OBAModelServiceRequest *)request:(NSString *)url args:(NSString *)args selector:(SEL)selector completionBlock:(OBADataSourceCompletion)completion progressBlock:(OBADataSourceProgress)progress {
-    return [self request:_obaJsonDataSource url:url args:args selector:selector completionBlock:completion progressBlock:nil];
-}
-
-- (OBAModelServiceRequest *)request:(OBAJsonDataSource *)source url:(NSString *)url args:(NSString *)args selector:(SEL)selector completionBlock:(OBADataSourceCompletion)completion progressBlock:(OBADataSourceProgress)progress {
+- (OBAModelServiceRequest *)request:(OBAJsonDataSource *)source url:(NSString *)url args:(NSDictionary *)args selector:(SEL)selector completionBlock:(OBADataSourceCompletion)completion progressBlock:(OBADataSourceProgress)progress {
     OBAModelServiceRequest *request = [self request:source selector:selector];
 
     request.connection = [source requestWithPath:url withArgs:args completionBlock:^(id jsonData, NSUInteger responseCode, NSError *error) {
         [request processData:jsonData withError:error responseCode:responseCode completionBlock:completion];
-    } progressBlock:progress];
-    return request;
-}
-
-- (OBAModelServiceRequest *)post:(NSString *)url args:(NSDictionary *)args selector:(SEL)selector completionBlock:(OBADataSourceCompletion)completion {
-    return [self post:_obaJsonDataSource url:url args:args selector:selector completionBlock:completion progressBlock:nil];
-}
-
-- (OBAModelServiceRequest *)post:(OBAJsonDataSource *)source url:(NSString *)url args:(NSDictionary *)args selector:(SEL)selector completionBlock:(OBADataSourceCompletion)completion progressBlock:(OBADataSourceProgress)progress {
-    OBAModelServiceRequest *request = [self request:source selector:selector];
-
-    request.connection = [source postWithPath:url withArgs:args completionBlock:^(id responseData, NSUInteger responseCode, NSError *error) {
-        [request processData:responseData withError:error responseCode:responseCode completionBlock:completion];
     } progressBlock:progress];
     return request;
 }
@@ -350,11 +285,13 @@ static const CLLocationAccuracy kBigSearchRadius = 15000;
     request.modelFactory = _modelFactory;
     request.modelFactorySelector = selector;
 
-    if (source != _obaJsonDataSource) request.checkCode = NO;
+    if (source != _obaJsonDataSource) {
+        request.checkCode = NO;
+    }
 
-    NSObject<OBABackgroundTaskExecutor> * executor = [[self class] sharedBackgroundExecutor];
+    NSObject<OBABackgroundTaskExecutor> *executor = [[self class] sharedBackgroundExecutor];
     
-    if(executor) {
+    if (executor) {
         request.bgTask = [executor beginBackgroundTaskWithExpirationHandler:^{
             if(request.cleanupBlock) {
                 request.cleanupBlock(request.bgTask);
@@ -372,36 +309,22 @@ static const CLLocationAccuracy kBigSearchRadius = 15000;
 - (CLLocation *)currentOrDefaultLocationToSearch {
     CLLocation *location = _locationManager.currentLocation;
 
-    if (!location) location = _modelDao.mostRecentLocation;
-
-    if (!location) location = [[CLLocation alloc] initWithLatitude:47.61229680032385  longitude:-122.3386001586914];
-
-    return location;
-}
-
-- (NSString *)argsFromDictionary:(NSDictionary *)args {
-    NSMutableString *s = [NSMutableString string];
-
-    for (NSString *key in args) {
-        if ([s length] > 0) [s appendString:@"&"];
-
-        [s appendString:[OBAURLHelpers escapeStringForUrl:key]];
-        [s appendString:@"="];
-        [s appendString:[OBAURLHelpers escapeStringForUrl:args[key]]];
+    if (!location) {
+        location = _modelDao.mostRecentLocation ?: [[CLLocation alloc] initWithLatitude:47.61229680032385 longitude:-122.3386001586914];
     }
 
-    return s;
+    return location;
 }
 
 #pragma mark - OBABackgroundTaskExecutor
 
 static NSObject<OBABackgroundTaskExecutor>* executor;
 
-+(NSObject<OBABackgroundTaskExecutor>*) sharedBackgroundExecutor {
++ (NSObject<OBABackgroundTaskExecutor>*)sharedBackgroundExecutor {
     return executor;
 }
 
-+(void) addBackgroundExecutor:(NSObject<OBABackgroundTaskExecutor>*) exc {
++ (void)addBackgroundExecutor:(NSObject<OBABackgroundTaskExecutor>*)exc {
     executor = exc;
 }
 


### PR DESCRIPTION
Fixes #506

* Switch over to frameworks for Pods
* Tear out a bunch of unused code from the data loader stack
* Simplify JsonUrlFetcherImpl initialization and usage
* Simplify the data loader APIs
* OBADataSourceConfig now takes an NSURL in its -init method, not a string.
* Add tests for OBADataSourceConfig
* Fix a bug in how we talk to Google's APIs that was exposed from writing OBADataSourceConfig tests
* Replace all URL construction string arguments with dictionaries that get turned into NSURLQueryItems
* Delete dead code
* Normalize style of URL loading in OBAModelService