### PR TITLE
Simplify the travis.yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,11 @@
-osx_image: xcode7.1
+osx_image: xcode7.2
 language: objective-c
-before_install:
-  - brew update
-  - brew outdated xctool || brew upgrade xctool
-  - gem install cocoapods
-  - pod install
 xcode_workspace: org.onebusaway.iphone.xcworkspace
-xcode_sdk:
-    - iphonesimulator
 xcode_scheme:
     - Debug
 notifications:
   slack:
-    rooms: 
+    rooms:
       - onebusaway:kcIbPpOOuJEhNgpzWMd8gkqj
     on_success: change
     on_failure: always


### PR DESCRIPTION
I'm pretty sure we can get away with not having a bunch of the stuff that was in our travis.yml file in our travis.yml file.