### PR TITLE
Fixes #516. Removes duplicate stop header when filtering.

### DIFF
--- a/ui/stop_details/OBAGenericStopViewController.m
+++ b/ui/stop_details/OBAGenericStopViewController.m
@@ -475,7 +475,12 @@ static NSString *kOBANoStopInformationURL = @"http://stopinfo.pugetsound.onebusa
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section {
-    return kSectionHeaderHeight;
+    if (_filteredArrivals.count != _allArrivals.count && section == OBAStopSectionTypeArrivals) {
+        return 0.0f;
+    }
+    else {
+        return kSectionHeaderHeight;
+    }
 }
 
 - (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section {


### PR DESCRIPTION
The logic for sections/headers/rows of OBAGenericStopViewController is quite convoluted. This should serve as a stop-gap for now, but should definitely be cleaned up at some point in the near future. That would also address #514.