### PR TITLE
Clean up a bunch of things that needed cleaning

### DIFF
--- a/OBAKit/Helpers/OBACommonV1.h
+++ b/OBAKit/Helpers/OBACommonV1.h
@@ -13,9 +13,3 @@ typedef NS_ENUM(NSInteger, OBANavigationTargetType) {
     OBANavigationTargetTypeContactUs,
     OBANavigationTargetTypeAgencies,
 };
-
-typedef NS_ENUM(NSInteger, OBASearchViewType) {
-    OBASearchViewTypeByStop = 0,
-    OBASearchViewTypeByRoute,
-    OBASearchViewTypeByAddress,
-};

--- a/OBAKit/Helpers/OBAImageHelpers.h
+++ b/OBAKit/Helpers/OBAImageHelpers.h
@@ -1,0 +1,34 @@
+//
+//  OBAImageHelpers.h
+//  org.onebusaway.iphone
+//
+//  Created by Aaron Brethorst on 2/28/16.
+//  Copyright © 2016 OneBusAway. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface OBAImageHelpers : NSObject
+
+/**
+ Overlays the image parameter with the specified color using the multiply blend mode.
+
+ @param image The image object that will have a color overlay applied to it.
+ @param color The color that will be overlayed on top of the image.
+
+ @return A new image object with the specified color applied on top of it.
+ */
++ (UIImage*)colorizeImage:(UIImage *)image withColor:(UIColor *)color;
+
+/**
+ Draws one image on top of another at the specified location.
+
+ @param image     The image that is drawn on top of the baseImage.
+ @param baseImage The image upon which new content is drawn.
+ @param point     The point in the base image that the image is drawn at.
+
+ @return The new composite image.
+ */
++ (UIImage*)draw:(UIImage*)image onto:(UIImage*)baseImage atPoint:(CGPoint)point;
+
+@end

--- a/OBAKit/Helpers/OBAImageHelpers.m
+++ b/OBAKit/Helpers/OBAImageHelpers.m
@@ -1,0 +1,52 @@
+//
+//  OBAImageHelpers.m
+//  org.onebusaway.iphone
+//
+//  Created by Aaron Brethorst on 2/28/16.
+//  Copyright © 2016 OneBusAway. All rights reserved.
+//
+
+#import "OBAImageHelpers.h"
+
+@implementation OBAImageHelpers
+
++ (UIImage *)colorizeImage:(UIImage *)image withColor:(UIColor *)color {
+    UIGraphicsBeginImageContextWithOptions(image.size, NO, image.scale);
+
+    CGContextRef context = UIGraphicsGetCurrentContext();
+    CGRect area = CGRectMake(0, 0, image.size.width, image.size.height);
+
+    CGContextScaleCTM(context, 1, -1);
+    CGContextTranslateCTM(context, 0, -area.size.height);
+
+    CGContextSaveGState(context);
+    CGContextClipToMask(context, area, image.CGImage);
+
+    [color set];
+    CGContextFillRect(context, area);
+
+    CGContextRestoreGState(context);
+
+    CGContextSetBlendMode(context, kCGBlendModeMultiply);
+
+    CGContextDrawImage(context, area, image.CGImage);
+
+    UIImage *colorizedImage = UIGraphicsGetImageFromCurrentImageContext();
+
+    UIGraphicsEndImageContext();
+
+    return colorizedImage;
+}
+
++ (UIImage*)draw:(UIImage*)image onto:(UIImage*)baseImage atPoint:(CGPoint)point {
+    UIGraphicsBeginImageContextWithOptions(baseImage.size, YES, baseImage.scale);
+
+    [baseImage drawAtPoint:CGPointZero];
+    [image drawAtPoint:point];
+
+    UIImage *compositeImage = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+
+    return compositeImage;
+}
+@end

--- a/OBAKit/Helpers/OBAMacros.h
+++ b/OBAKit/Helpers/OBAMacros.h
@@ -24,7 +24,10 @@
 #define SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(v)  ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedAscending)
 
 #define OBAGuard(CONDITION) \
-if (!CONDITION) { NSParameterAssert(CONDITION); } \
-if (CONDITION) {}
+    if (!CONDITION) { NSParameterAssert(CONDITION); } \
+    if (CONDITION) {}
+
+#define OBAGuardClass(object, typeName) \
+    OBAGuard([object isKindOfClass:[typeName class]])
 
 #endif /* OBAMacros_h */

--- a/OBAKit/Helpers/OBAMapHelpers.h
+++ b/OBAKit/Helpers/OBAMapHelpers.h
@@ -1,0 +1,22 @@
+//
+//  OBAMapHelpers.h
+//  org.onebusaway.iphone
+//
+//  Created by Aaron Brethorst on 2/27/16.
+//  Copyright © 2016 OneBusAway. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <MapKit/MapKit.h>
+
+@interface OBAMapHelpers : NSObject
+
++ (double)longitudeToPixelSpaceX:(double)longitude;
++ (double)latitudeToPixelSpaceY:(double)latitude;
++ (double)pixelSpaceXToLongitude:(double)pixelX;
++ (double)pixelSpaceYToLatitude:(double)pixelY;
++ (MKCoordinateSpan)coordinateSpanWithCenterCoordinate:(CLLocationCoordinate2D)centerCoordinate zoomLevel:(NSUInteger)zoomLevel viewSize:(CGSize)size;
++ (MKCoordinateRegion)coordinateRegionWithCenterCoordinate:(CLLocationCoordinate2D)centerCoordinate zoomLevel:(NSUInteger)zoomLevel viewSize:(CGSize)size;
+
++ (NSString*)stringFromDistance:(CLLocationDistance)distance;
+@end

--- a/OBAKit/Helpers/OBAMapHelpers.m
+++ b/OBAKit/Helpers/OBAMapHelpers.m
@@ -1,0 +1,89 @@
+//
+//  OBAMapHelpers.m
+//  org.onebusaway.iphone
+//
+//  Created by Aaron Brethorst on 2/27/16.
+//  Copyright © 2016 OneBusAway. All rights reserved.
+//
+
+#import "OBAMapHelpers.h"
+
+#define MERCATOR_OFFSET 268435456
+#define MERCATOR_RADIUS 85445659.44705395
+
+@implementation OBAMapHelpers
+
+#pragma mark - Map conversion methods
+
++ (double)longitudeToPixelSpaceX:(double)longitude
+{
+    return round(MERCATOR_OFFSET + MERCATOR_RADIUS * longitude * M_PI / 180.0);
+}
+
++ (double)latitudeToPixelSpaceY:(double)latitude
+{
+    return round(MERCATOR_OFFSET - MERCATOR_RADIUS * log((1 + sin(latitude * M_PI / 180.0)) / (1 - sin(latitude * M_PI / 180.0))) / 2.0);
+}
+
++ (double)pixelSpaceXToLongitude:(double)pixelX
+{
+    return ((round(pixelX) - MERCATOR_OFFSET) / MERCATOR_RADIUS) * 180.0 / M_PI;
+}
+
++ (double)pixelSpaceYToLatitude:(double)pixelY
+{
+    return (M_PI / 2.0 - 2.0 * atan(exp((round(pixelY) - MERCATOR_OFFSET) / MERCATOR_RADIUS))) * 180.0 / M_PI;
+}
+
+#pragma mark - Helper methods
+
++ (MKCoordinateSpan)coordinateSpanWithCenterCoordinate:(CLLocationCoordinate2D)centerCoordinate zoomLevel:(NSUInteger)zoomLevel viewSize:(CGSize)size
+{
+    // convert center coordiate to pixel space
+    double centerPixelX = [self longitudeToPixelSpaceX:centerCoordinate.longitude];
+    double centerPixelY = [self latitudeToPixelSpaceY:centerCoordinate.latitude];
+
+    // determine the scale value from the zoom level
+    NSInteger zoomExponent = 20 - zoomLevel;
+    double zoomScale = pow(2, zoomExponent);
+
+    // scale the map’s size in pixel space
+    CGSize mapSizeInPixels = size;
+    double scaledMapWidth = mapSizeInPixels.width * zoomScale;
+    double scaledMapHeight = mapSizeInPixels.height * zoomScale;
+
+    // figure out the position of the top-left pixel
+    double topLeftPixelX = centerPixelX - (scaledMapWidth / 2);
+    double topLeftPixelY = centerPixelY - (scaledMapHeight / 2);
+
+    // find delta between left and right longitudes
+    CLLocationDegrees minLng = [self.class pixelSpaceXToLongitude:topLeftPixelX];
+    CLLocationDegrees maxLng = [self.class pixelSpaceXToLongitude:topLeftPixelX + scaledMapWidth];
+    CLLocationDegrees longitudeDelta = maxLng - minLng;
+
+    // find delta between top and bottom latitudes
+    CLLocationDegrees minLat = [self.class pixelSpaceYToLatitude:topLeftPixelY];
+    CLLocationDegrees maxLat = [self.class pixelSpaceYToLatitude:topLeftPixelY + scaledMapHeight];
+    CLLocationDegrees latitudeDelta = -1 * (maxLat - minLat);
+
+    // create and return the lat/lng span
+    MKCoordinateSpan span = MKCoordinateSpanMake(latitudeDelta, longitudeDelta);
+    return span;
+}
+
++ (MKCoordinateRegion)coordinateRegionWithCenterCoordinate:(CLLocationCoordinate2D)centerCoordinate zoomLevel:(NSUInteger)zoomLevel viewSize:(CGSize)size
+{
+    return MKCoordinateRegionMake(centerCoordinate, [self coordinateSpanWithCenterCoordinate:centerCoordinate zoomLevel:zoomLevel viewSize:size]);
+}
+
++ (NSString*)stringFromDistance:(CLLocationDistance)distance {
+    static MKDistanceFormatter *formatter = nil;
+
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        formatter = [[MKDistanceFormatter alloc] init];
+    });
+
+    return [formatter stringFromDistance:distance];
+}
+@end

--- a/OBAKit/Helpers/OBAStopIconFactory.h
+++ b/OBAKit/Helpers/OBAStopIconFactory.h
@@ -1,19 +1,26 @@
+/**
+* Copyright (C) 2009 bdferris <bdferris@onebusaway.org>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*         http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
 #import "OBAStopV2.h"
 #import "OBARouteV2.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface OBAStopIconFactory : NSObject
-
-+ (UIImage*) getIconForStop:(OBAStopV2*)stop;
-+ (UIImage*) getIconForStop:(OBAStopV2*)stop includeDirection:(BOOL)includeDirection;
-
-+ (UIImage*) getModeIconForRoute:(OBARouteV2*)route;
-+ (UIImage*) getModeIconForRoute:(OBARouteV2*)route selected:(BOOL)selected;
-+ (UIImage*) getModeIconForRouteIconType:(NSString*)routeType selected:(BOOL)selected;
-
-+ (NSString*) getRouteIconTypeForRoutes:(NSArray*)routes;
-
++ (UIImage*)getIconForStop:(OBAStopV2*)stop;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/OBAKit/Helpers/OBAStopIconFactory.m
+++ b/OBAKit/Helpers/OBAStopIconFactory.m
@@ -1,51 +1,35 @@
+/**
+ * Copyright (C) 2009 bdferris <bdferris@onebusaway.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #import "OBAStopIconFactory.h"
 #import "OBARouteV2.h"
 
 @implementation OBAStopIconFactory
 
 + (UIImage *)getIconForStop:(OBAStopV2 *)stop {
-    return [self getIconForStop:stop includeDirection:YES];
-}
-
-+ (UIImage *)getIconForStop:(OBAStopV2 *)stop includeDirection:(BOOL)includeDirection {
     NSString *routeIconType = [self getRouteIconTypeForStop:stop];
     NSString *direction = @"";
 
-    if (includeDirection && stop.direction) {
+    if (stop.direction) {
         direction = stop.direction;
     }
 
     NSString *key = [NSString stringWithFormat:@"%@StopIcon%@", routeIconType, direction];
 
     return [UIImage imageNamed:key];
-}
-
-+ (UIImage *)getModeIconForRoute:(OBARouteV2 *)route {
-    return [self getModeIconForRoute:route selected:NO];
-}
-
-+ (UIImage *)getModeIconForRoute:(OBARouteV2 *)route selected:(BOOL)selected {
-    NSString *type = [self getRouteIconTypeForRoute:route];
-
-    return [self getModeIconForRouteIconType:type selected:selected];
-}
-
-+ (UIImage *)getModeIconForRouteIconType:(NSString *)routeType selected:(BOOL)selected {
-    NSString *format = selected ? @"Mode-%@-Selected" : @"Mode-%@";
-
-    return [UIImage imageNamed:[NSString stringWithFormat:format, routeType]];
-}
-
-+ (NSString *)getRouteIconTypeForRoutes:(NSArray *)routes {
-    NSMutableSet *routeTypes = [NSMutableSet set];
-
-    for (OBARouteV2 *route in routes) {
-        if (route.routeType) {
-            [routeTypes addObject:route.routeType];
-        }
-    }
-
-    return [self getRouteIconTypeForRouteTypes:routeTypes];
 }
 
 #pragma mark - Private
@@ -62,35 +46,19 @@
     return [self getRouteIconTypeForRouteTypes:routeTypes];
 }
 
+// TODO: what about "metro"?
 + (NSString *)getRouteIconTypeForRouteTypes:(NSSet *)routeTypes {
-    // Heay rail dominations
-    if ([routeTypes containsObject:@4]) {
+    if ([routeTypes containsObject:@(OBARouteTypeFerry)]) {
         return @"Ferry";
     }
-    else if ([routeTypes containsObject:@2]) {
+    else if ([routeTypes containsObject:@(OBARouteTypeTrain)]) {
         return @"Rail";
     }
-    else if ([routeTypes containsObject:@0]) {
+    else if ([routeTypes containsObject:@(OBARouteTypeLightRail)]) {
         return @"LightRail";
     }
     else {
         return @"Bus";
-    }
-}
-
-+ (NSString *)getRouteIconTypeForRoute:(OBARouteV2 *)route {
-    switch (route.routeType.integerValue) {
-        case 4:
-            return @"Ferry";
-
-        case 2:
-            return @"Rail";
-
-        case 0:
-            return @"LightRail";
-
-        default:
-            return @"Bus";
     }
 }
 

--- a/OBAKit/Models/unmanaged/OBAArrivalAndDepartureV2.h
+++ b/OBAKit/Models/unmanaged/OBAArrivalAndDepartureV2.h
@@ -6,12 +6,11 @@
 #import "OBATripStatusV2.h"
 #import "OBATripInstanceRef.h"
 #import "OBAArrivalAndDepartureInstanceRef.h"
+#import "OBADepartureStatus.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface OBAArrivalAndDepartureV2 : OBAHasReferencesV2 {
-    NSMutableArray * _situationIds;
-}
+@interface OBAArrivalAndDepartureV2 : OBAHasReferencesV2
 
 @property (nonatomic,strong) NSString * routeId;
 @property (weak, nonatomic,readonly) OBARouteV2 * route;
@@ -45,12 +44,28 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)hasRealTimeData;
 
 @property (nonatomic) double distanceFromStop;
+@property (nonatomic) NSInteger numberOfStopsAway;
 
-@property (nonatomic,readonly) NSArray * situationIds;
 @property (weak, nonatomic,readonly) NSArray * situations;
 
 - (void) addSituationId:(NSString*)situationId;
 
+- (OBADepartureStatus)departureStatus;
+- (NSString*)statusText;
+
+/**
+ How far off is this vehicle from its predicted, scheduled time?
+
+ @return `NaN` when real time data is unavailable. Negative is early, positive is delayed.
+ */
+- (double)predictedDepatureTimeDeviationFromScheduleInMinutes;
+
+/**
+ How far away are we right now from the best departure time available to us? Uses real time data when available, and scheduled data otherwise.
+
+ @return The number of minutes until departure, suitable to display to a user.
+ */
+- (NSInteger)minutesUntilBestDeparture;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/OBAKit/Models/unmanaged/OBAArrivalsAndDeparturesForStopV2.h
+++ b/OBAKit/Models/unmanaged/OBAArrivalsAndDeparturesForStopV2.h
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic,strong) NSString * stopId;
 @property (weak, nonatomic,readonly) OBAStopV2 * stop;
-@property (nonatomic,readonly) NSArray * arrivalsAndDepartures;
+@property (nonatomic,readonly) NSArray<OBAArrivalAndDepartureV2*> * arrivalsAndDepartures;
 @property (nonatomic,readonly) NSArray * situationIds;
 @property (weak, nonatomic,readonly) NSArray * situations;
 

--- a/OBAKit/Models/unmanaged/OBADepartureStatus.h
+++ b/OBAKit/Models/unmanaged/OBADepartureStatus.h
@@ -1,0 +1,16 @@
+//
+//  OBADepartureStatus.h
+//  org.onebusaway.iphone
+//
+//  Created by Aaron Brethorst on 2/25/16.
+//  Copyright © 2016 OneBusAway. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+typedef NS_ENUM(NSUInteger, OBADepartureStatus) {
+    OBADepartureStatusUnknown = 0,
+    OBADepartureStatusEarly,
+    OBADepartureStatusOnTime,
+    OBADepartureStatusDelayed
+};

--- a/OBAKit/Models/unmanaged/OBARouteV2.h
+++ b/OBAKit/Models/unmanaged/OBARouteV2.h
@@ -3,6 +3,15 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef NS_ENUM(NSUInteger, OBARouteType) {
+    OBARouteTypeLightRail = 0,
+    OBARouteTypeMetro = 1,
+    OBARouteTypeTrain = 2,
+    OBARouteTypeBus = 3,
+    OBARouteTypeFerry = 4,
+    OBARouteTypeUnknown = 999
+};
+
 @interface OBARouteV2 : OBAHasReferencesV2
 
 @property (nonatomic, strong) NSString * routeId;

--- a/OBAKit/OBAKit.h
+++ b/OBAKit/OBAKit.h
@@ -92,3 +92,4 @@ FOUNDATION_EXPORT const unsigned char OBAKitVersionString[];
 #import <OBAKit/OBAModelFactory.h>
 #import <OBAKit/OBAModelService.h>
 #import <OBAKit/OBAModelServiceRequest.h>
+#import <OBAKit/OBAImageHelpers.h>

--- a/OBAKit/Services/OBAModelFactory.m
+++ b/OBAKit/Services/OBAModelFactory.m
@@ -482,7 +482,8 @@ static NSString * const kReferences = @"references";
     [self addSetPropertyRule:@"predictedDepartureTime" forPrefix:[self extendPrefix:prefix withValue:@"predictedDepartureTime"]];
     
     [self addSetPropertyRule:@"distanceFromStop" forPrefix:[self extendPrefix:prefix withValue:@"distanceFromStop"]];
-    
+    [self addSetPropertyRule:@"numberOfStopsAway" forPrefix:[self extendPrefix:prefix withValue:@"numberOfStopsAway"]];
+
     NSString * frequencyPrefix = [self extendPrefix:prefix withValue:@"frequency"];
     [self addFrequencyV2RulesWithPrefix:frequencyPrefix];
     [self addSetNext:@selector(setFrequency:) forPrefix:frequencyPrefix];

--- a/OBAKit/Services/OBAModelService.m
+++ b/OBAKit/Services/OBAModelService.m
@@ -2,6 +2,7 @@
 #import "OBAModelServiceRequest.h"
 #import "OBASphericalGeometryLibrary.h"
 #import "OBAURLHelpers.h"
+#import "OBAMacros.h"
 
 static const CLLocationAccuracy kSearchRadius = 400;
 static const CLLocationAccuracy kBigSearchRadius = 15000;
@@ -9,7 +10,11 @@ static const CLLocationAccuracy kBigSearchRadius = 15000;
 @implementation OBAModelService
 
 - (AnyPromise*)requestStopForID:(NSString*)stopID {
-    
+
+    OBAGuard(stopID) else {
+        return nil;
+    }
+
     NSDictionary *args = @{ @"minutesBefore": @(5),
                             @"minutesAfter":  @(35) };
     

--- a/Podfile
+++ b/Podfile
@@ -9,7 +9,14 @@ pod 'TWSReleaseNotesView', '1.2.0'
 pod 'GoogleAnalytics-iOS-SDK', '3.11'
 pod 'libextobjc', '0.4.1'
 pod 'SVProgressHUD', '2.0-beta'
-pod 'PromiseKit', '3.0.2'
+#pod 'Masonry', '0.6.4'
+#pod 'DateTools', '1.7.0'
+
+# pod 'PromiseKit', '3.0.2'
+pod 'PromiseKit/CorePromise', '3.0.2'
+pod 'PromiseKit/CoreLocation', '3.0.2'
+pod 'PromiseKit/Foundation', '3.0.2'
+pod "PromiseKit/MapKit", '3.0.2'
 
 post_install do |installer_representation|
   installer_representation.pods_project.targets.each do |target|

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -44,17 +44,13 @@ PODS:
     - OMGHTTPURLRQ/FormURLEncode
     - OMGHTTPURLRQ/UserAgent
   - OMGHTTPURLRQ/UserAgent (3.1.1)
-  - PromiseKit (3.0.2):
-    - PromiseKit/Foundation (= 3.0.2)
-    - PromiseKit/QuartzCore (= 3.0.2)
-    - PromiseKit/UIKit (= 3.0.2)
+  - PromiseKit/CoreLocation (3.0.2):
+    - PromiseKit/CorePromise
   - PromiseKit/CorePromise (3.0.2)
   - PromiseKit/Foundation (3.0.2):
     - OMGHTTPURLRQ (~> 3.1.0)
     - PromiseKit/CorePromise
-  - PromiseKit/QuartzCore (3.0.2):
-    - PromiseKit/CorePromise
-  - PromiseKit/UIKit (3.0.2):
+  - PromiseKit/MapKit (3.0.2):
     - PromiseKit/CorePromise
   - SVProgressHUD (2.0-beta)
   - TWSReleaseNotesView (1.2.0)
@@ -62,7 +58,10 @@ PODS:
 DEPENDENCIES:
   - GoogleAnalytics-iOS-SDK (= 3.11)
   - libextobjc (= 0.4.1)
-  - PromiseKit (= 3.0.2)
+  - PromiseKit/CoreLocation (= 3.0.2)
+  - PromiseKit/CorePromise (= 3.0.2)
+  - PromiseKit/Foundation (= 3.0.2)
+  - PromiseKit/MapKit (= 3.0.2)
   - SVProgressHUD (= 2.0-beta)
   - TWSReleaseNotesView (= 1.2.0)
 

--- a/categories/MKMapView+oba_Additions.m
+++ b/categories/MKMapView+oba_Additions.m
@@ -7,74 +7,14 @@
 //
 
 #import "MKMapView+oba_Additions.h"
-
-#define MERCATOR_OFFSET 268435456
-#define MERCATOR_RADIUS 85445659.44705395
+#import <OBAKit/OBAMapHelpers.h>
 
 @implementation MKMapView (oba_Additions)
 
-#pragma mark -
-#pragma mark Map conversion methods
-
-- (double)longitudeToPixelSpaceX:(double)longitude
-{
-    return round(MERCATOR_OFFSET + MERCATOR_RADIUS * longitude * M_PI / 180.0);
-}
-
-- (double)latitudeToPixelSpaceY:(double)latitude
-{
-    return round(MERCATOR_OFFSET - MERCATOR_RADIUS * log((1 + sin(latitude * M_PI / 180.0)) / (1 - sin(latitude * M_PI / 180.0))) / 2.0);
-}
-
-- (double)pixelSpaceXToLongitude:(double)pixelX
-{
-    return ((round(pixelX) - MERCATOR_OFFSET) / MERCATOR_RADIUS) * 180.0 / M_PI;
-}
-
-- (double)pixelSpaceYToLatitude:(double)pixelY
-{
-    return (M_PI / 2.0 - 2.0 * atan(exp((round(pixelY) - MERCATOR_OFFSET) / MERCATOR_RADIUS))) * 180.0 / M_PI;
-}
-
-#pragma mark -
-#pragma mark Helper methods
-
 - (MKCoordinateSpan)oba_coordinateSpanWithCenterCoordinate:(CLLocationCoordinate2D)centerCoordinate zoomLevel:(NSUInteger)zoomLevel
 {
-    // convert center coordiate to pixel space
-    double centerPixelX = [self longitudeToPixelSpaceX:centerCoordinate.longitude];
-    double centerPixelY = [self latitudeToPixelSpaceY:centerCoordinate.latitude];
-    
-    // determine the scale value from the zoom level
-    NSInteger zoomExponent = 20 - zoomLevel;
-    double zoomScale = pow(2, zoomExponent);
-    
-    // scale the map’s size in pixel space
-    CGSize mapSizeInPixels = self.bounds.size;
-    double scaledMapWidth = mapSizeInPixels.width * zoomScale;
-    double scaledMapHeight = mapSizeInPixels.height * zoomScale;
-    
-    // figure out the position of the top-left pixel
-    double topLeftPixelX = centerPixelX - (scaledMapWidth / 2);
-    double topLeftPixelY = centerPixelY - (scaledMapHeight / 2);
-    
-    // find delta between left and right longitudes
-    CLLocationDegrees minLng = [self pixelSpaceXToLongitude:topLeftPixelX];
-    CLLocationDegrees maxLng = [self pixelSpaceXToLongitude:topLeftPixelX + scaledMapWidth];
-    CLLocationDegrees longitudeDelta = maxLng - minLng;
-    
-    // find delta between top and bottom latitudes
-    CLLocationDegrees minLat = [self pixelSpaceYToLatitude:topLeftPixelY];
-    CLLocationDegrees maxLat = [self pixelSpaceYToLatitude:topLeftPixelY + scaledMapHeight];
-    CLLocationDegrees latitudeDelta = -1 * (maxLat - minLat);
-    
-    // create and return the lat/lng span
-    MKCoordinateSpan span = MKCoordinateSpanMake(latitudeDelta, longitudeDelta);
-    return span;
+    return [OBAMapHelpers coordinateSpanWithCenterCoordinate:centerCoordinate zoomLevel:zoomLevel viewSize:self.bounds.size];
 }
-
-#pragma mark -
-#pragma mark Public methods
 
 - (void)oba_setCenterCoordinate:(CLLocationCoordinate2D)centerCoordinate zoomLevel:(NSUInteger)zoomLevel animated:(BOOL)animated
 {

--- a/org.onebusaway.iphone.xcodeproj/project.pbxproj
+++ b/org.onebusaway.iphone.xcodeproj/project.pbxproj
@@ -212,6 +212,11 @@
 		934EA5F01C84CD9200B60F06 /* OBAModelService.m in Sources */ = {isa = PBXBuildFile; fileRef = 934EA55E1C84CD9200B60F06 /* OBAModelService.m */; };
 		934EA5F11C84CD9200B60F06 /* OBAModelServiceRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 934EA55F1C84CD9200B60F06 /* OBAModelServiceRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		934EA5F21C84CD9200B60F06 /* OBAModelServiceRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 934EA5601C84CD9200B60F06 /* OBAModelServiceRequest.m */; };
+		934EA5F51C84D65600B60F06 /* OBAImageHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 934EA5F31C84D65600B60F06 /* OBAImageHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		934EA5F61C84D65600B60F06 /* OBAImageHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 934EA5F41C84D65600B60F06 /* OBAImageHelpers.m */; };
+		934EA5F91C84D6BB00B60F06 /* OBAMapHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 934EA5F71C84D6BB00B60F06 /* OBAMapHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		934EA5FA1C84D6BB00B60F06 /* OBAMapHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 934EA5F81C84D6BB00B60F06 /* OBAMapHelpers.m */; };
+		934EA5FC1C84D7DF00B60F06 /* OBADepartureStatus.h in Headers */ = {isa = PBXBuildFile; fileRef = 934EA5FB1C84D7CE00B60F06 /* OBADepartureStatus.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		93631E4C1604F96800CB7209 /* OBAApplicationDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 93631E4B1604F96800CB7209 /* OBAApplicationDelegate.m */; };
 		936D2EDB1C78D7140060B7E1 /* OBADataSourceConfig_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 936D2EDA1C78D7140060B7E1 /* OBADataSourceConfig_Tests.m */; };
 		936D2EDD1C78D7300060B7E1 /* OBAURLHelpers_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 936D2EDC1C78D7300060B7E1 /* OBAURLHelpers_Tests.m */; };
@@ -529,6 +534,11 @@
 		934EA55E1C84CD9200B60F06 /* OBAModelService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAModelService.m; sourceTree = "<group>"; };
 		934EA55F1C84CD9200B60F06 /* OBAModelServiceRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAModelServiceRequest.h; sourceTree = "<group>"; };
 		934EA5601C84CD9200B60F06 /* OBAModelServiceRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAModelServiceRequest.m; sourceTree = "<group>"; };
+		934EA5F31C84D65600B60F06 /* OBAImageHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAImageHelpers.h; sourceTree = "<group>"; };
+		934EA5F41C84D65600B60F06 /* OBAImageHelpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAImageHelpers.m; sourceTree = "<group>"; };
+		934EA5F71C84D6BB00B60F06 /* OBAMapHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAMapHelpers.h; sourceTree = "<group>"; };
+		934EA5F81C84D6BB00B60F06 /* OBAMapHelpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAMapHelpers.m; sourceTree = "<group>"; };
+		934EA5FB1C84D7CE00B60F06 /* OBADepartureStatus.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OBADepartureStatus.h; sourceTree = "<group>"; };
 		93631E4A1604F96800CB7209 /* OBAApplicationDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAApplicationDelegate.h; sourceTree = "<group>"; };
 		93631E4B1604F96800CB7209 /* OBAApplicationDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = OBAApplicationDelegate.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		936D2EDA1C78D7140060B7E1 /* OBADataSourceConfig_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBADataSourceConfig_Tests.m; sourceTree = "<group>"; };
@@ -635,6 +645,7 @@
 		29B97314FDCFA39411CA2CEA /* org.onebusaway.iphone */ = {
 			isa = PBXGroup;
 			children = (
+				936F44FE1C780E7600C61656 /* OBAKit */,
 				932BE4901AB66D320011F2FB /* ui */,
 				934446791AB10B1D005B3333 /* location */,
 				934445F71AB105FB005B3333 /* gpx_files */,
@@ -646,7 +657,6 @@
 				669B2F711AEBF92E00CF2367 /* utilities */,
 				29B97315FDCFA39411CA2CEA /* Other Sources */,
 				29B97317FDCFA39411CA2CEA /* Resources */,
-				936F44FE1C780E7600C61656 /* OBAKit */,
 				936F45DA1C78D06600C61656 /* OneBusAwayTests */,
 				29B97323FDCFA39411CA2CEA /* Frameworks */,
 				19C28FACFE9D520D11CA2CBB /* Products */,
@@ -914,6 +924,10 @@
 				934EA4D31C84CD9200B60F06 /* OBAStopIconFactory.m */,
 				934EA4D41C84CD9200B60F06 /* OBAURLHelpers.h */,
 				934EA4D51C84CD9200B60F06 /* OBAURLHelpers.m */,
+				934EA5F31C84D65600B60F06 /* OBAImageHelpers.h */,
+				934EA5F41C84D65600B60F06 /* OBAImageHelpers.m */,
+				934EA5F71C84D6BB00B60F06 /* OBAMapHelpers.h */,
+				934EA5F81C84D6BB00B60F06 /* OBAMapHelpers.m */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -1077,6 +1091,7 @@
 				934EA54E1C84CD9200B60F06 /* OBATripV2.m */,
 				934EA54F1C84CD9200B60F06 /* OBAVehicleStatusV2.h */,
 				934EA5501C84CD9200B60F06 /* OBAVehicleStatusV2.m */,
+				934EA5FB1C84D7CE00B60F06 /* OBADepartureStatus.h */,
 			);
 			path = unmanaged;
 			sourceTree = "<group>";
@@ -1303,7 +1318,10 @@
 				934EA5891C84CD9200B60F06 /* OBAJsonDigester.h in Headers */,
 				934EA5E81C84CD9200B60F06 /* OBADataSource.h in Headers */,
 				934EA57F1C84CD9200B60F06 /* OBAVehicleMapAnnotation.h in Headers */,
+				934EA5FC1C84D7DF00B60F06 /* OBADepartureStatus.h in Headers */,
 				934EA5CC1C84CD9200B60F06 /* OBASituationV2.h in Headers */,
+				934EA5F51C84D65600B60F06 /* OBAImageHelpers.h in Headers */,
+				934EA5F91C84D6BB00B60F06 /* OBAMapHelpers.h in Headers */,
 				936F45001C780E7600C61656 /* OBAKit.h in Headers */,
 				934EA5B01C84CD9200B60F06 /* OBAListWithRangeAndReferencesV2.h in Headers */,
 			);
@@ -1630,6 +1648,7 @@
 				934EA56C1C84CD9200B60F06 /* OBAStopIconFactory.m in Sources */,
 				934EA5841C84CD9200B60F06 /* OBAModelDAOUserPreferencesImpl.m in Sources */,
 				934EA5A31C84CD9200B60F06 /* OBABookmarkGroup.m in Sources */,
+				934EA5F61C84D65600B60F06 /* OBAImageHelpers.m in Sources */,
 				934EA5D71C84CD9200B60F06 /* OBATripDetailsV2.m in Sources */,
 				934EA5651C84CD9200B60F06 /* OBADateHelpers.m in Sources */,
 				934EA58E1C84CD9200B60F06 /* OBASetCoordinatePropertyJsonDigesterRule.m in Sources */,
@@ -1661,6 +1680,7 @@
 				934EA5EE1C84CD9200B60F06 /* OBAModelFactory.m in Sources */,
 				934EA5621C84CD9200B60F06 /* OBACommon.m in Sources */,
 				934EA5701C84CD9200B60F06 /* OBALocationManager.m in Sources */,
+				934EA5FA1C84D6BB00B60F06 /* OBAMapHelpers.m in Sources */,
 				934EA56A1C84CD9200B60F06 /* OBAPresentation.m in Sources */,
 				934EA5C71C84CD9200B60F06 /* OBASearchResult.m in Sources */,
 				934EA5801C84CD9200B60F06 /* OBAVehicleMapAnnotation.m in Sources */,

--- a/ui/stop_details/OBAGenericStopViewController.m
+++ b/ui/stop_details/OBAGenericStopViewController.m
@@ -935,7 +935,7 @@ NSComparisonResult predictedArrivalSortByRoute(id o1, id o2, void *context) {
     self.stopInformationLabel.shadowColor = [UIColor colorWithWhite:0.f alpha:0.5f];
     self.stopInformationLabel.shadowOffset = CGSizeMake(0, 1);
     self.stopInformationLabel.numberOfLines = 0;
-    self.stopInformationLabel.font = [OBATheme headlineFont];
+    self.stopInformationLabel.font = [OBATheme bodyFont];
     self.stopInformationLabel.autoresizingMask = UIViewAutoresizingFlexibleHeight|UIViewAutoresizingFlexibleWidth;
     [coverView addSubview:self.stopInformationLabel];
     

--- a/ui/themes/OBATheme.h
+++ b/ui/themes/OBATheme.h
@@ -43,11 +43,36 @@
 + (UIFont*)boldBodyFont;
 
 /**
- * Big, freeform title text. A 'headline,' if you will.
+ * The largest title font.
  */
-+ (UIFont*)headlineFont;
++ (UIFont*)titleFont;
+
+/**
+ * A smaller title font.
+ */
++ (UIFont*)subtitleFont;
+
 
 // Colors
+
+/**
+ Creates a UIColor with color values expressed in more typical 0-255 fashion.
+
+ @param red   Red component: 0-255.
+ @param green Green component: 0-255.
+ @param blue  Blue component: 0-255.
+ @param alpha Alpha component: 0-1.
+
+ @return A UIColor
+ */
++ (UIColor*)colorWithRed:(NSUInteger)red green:(NSUInteger)green blue:(NSUInteger)blue alpha:(CGFloat)alpha;
+
+/**
+ The standard highlight color with a less-than-100% opacity. By default, this is a dark green color.
+
+ @return A UIColor.
+ */
++ (UIColor*)nonOpaquePrimaryColor;
 
 /**
  * The default background color for non-white pages. By default, this is a dark green color.
@@ -59,10 +84,25 @@
  */
 + (UIColor*)onTimeDepartureColor;
 
+/**
+ The text color used to indicate that the bus will depart early. Usually red.
+ */
++ (UIColor*)earlyDepartureColor;
+
+/**
+ The text color used to indicate that the bus will depart late. Usually blue.
+ */
++ (UIColor*)delayedDepartureColor;
+
 // Pixels (err, points)
 
 /**
  * The default vertical and horizontal padding in px.
  */
 + (CGFloat)defaultPadding;
+
+/**
+ The value of +[OBATheme defaultPadding] in the form of UIEdgeInsets.
+ */
++ (UIEdgeInsets)defaultEdgeInsets;
 @end

--- a/ui/themes/OBATheme.m
+++ b/ui/themes/OBATheme.m
@@ -10,7 +10,8 @@
 
 static UIFont *_bodyFont = nil;
 static UIFont *_boldBodyFont = nil;
-static UIFont *_headlineFont = nil;
+static UIFont *_titleFont = nil;
+static UIFont *_subtitleFont = nil;
 static UIFont *_footnoteFont = nil;
 static UIFont *_boldFootnoteFont = nil;
 
@@ -21,7 +22,8 @@ static UIFont *_boldFootnoteFont = nil;
 + (void)resetTheme {
     _bodyFont = nil;
     _boldBodyFont = nil;
-    _headlineFont = nil;
+    _titleFont = nil;
+    _subtitleFont = nil;
     _footnoteFont = nil;
     _boldFootnoteFont = nil;
 }
@@ -44,11 +46,18 @@ static UIFont *_boldFootnoteFont = nil;
     return _boldBodyFont;
 }
 
-+ (UIFont*)headlineFont {
-    if (!_headlineFont) {
-        _headlineFont = [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline];
++ (UIFont*)titleFont {
+    if (!_titleFont) {
+        _titleFont = [UIFont preferredFontForTextStyle:UIFontTextStyleTitle1];
     }
-    return _headlineFont;
+    return _titleFont;
+}
+
++ (UIFont*)subtitleFont {
+    if (!_subtitleFont) {
+        _subtitleFont = [UIFont preferredFontForTextStyle:UIFontTextStyleTitle2];
+    }
+    return _subtitleFont;
 }
 
 + (UIFont*)footnoteFont {
@@ -69,18 +78,40 @@ static UIFont *_boldFootnoteFont = nil;
 
 #pragma mark - UIColor
 
-+ (UIColor*)backgroundColor {
-    return [UIColor colorWithRed:0.92f green:0.95f blue:0.88f alpha:0.67f];
++ (UIColor*)colorWithRed:(NSUInteger)red green:(NSUInteger)green blue:(NSUInteger)blue alpha:(CGFloat)alpha {
+    return [UIColor colorWithRed:((CGFloat)red / 255.f) green:((CGFloat)green / 255.f) blue:((CGFloat)blue / 255.f) alpha:alpha];
 }
+
++ (UIColor*)nonOpaquePrimaryColor {
+    return [self colorWithRed:152 green:216 blue:69 alpha:0.8f];
+}
+
++ (UIColor*)backgroundColor {
+    return [self colorWithRed:235 green:242 blue:224 alpha:1.f];
+}
+
+#pragma mark - Named Colors
 
 + (UIColor*)onTimeDepartureColor {
     return [UIColor colorWithRed:0.f green:0.478f blue:0.f alpha:1.f];
+}
+
++ (UIColor*)earlyDepartureColor {
+    return [UIColor redColor];
+}
+
++ (UIColor*)delayedDepartureColor {
+    return [UIColor blueColor];
 }
 
 #pragma mark - Pixels, err points
 
 + (CGFloat)defaultPadding {
     return 8.f;
+}
+
++ (UIEdgeInsets)defaultEdgeInsets {
+    return UIEdgeInsetsMake([self defaultPadding], [self defaultPadding], [self defaultPadding], [self defaultPadding]);
 }
 
 @end

--- a/ui/trip_details/OBAReportProblemWithTripViewController.m
+++ b/ui/trip_details/OBAReportProblemWithTripViewController.m
@@ -222,7 +222,7 @@ typedef NS_ENUM (NSInteger, OBASectionType) {
             vc.delegate = self;
             vc.text = _comment;
             vc.title = NSLocalizedString(@"Comment", @"withTitle");
-            
+
             UINavigationController *nav = [[UINavigationController alloc] initWithRootViewController:vc];
             [self presentViewController:nav animated:YES completion:nil];
 
@@ -373,19 +373,20 @@ typedef NS_ENUM (NSInteger, OBASectionType) {
 
 - (NSString *)getVehicleTypeLabeForTrip:(OBATripV2 *)trip {
     OBARouteV2 *route = trip.route;
-
-    switch ([route.routeType intValue]) {
-        case 0:
-        case 1:
+    // TODO: The value for light rail seems totally wrong.
+    // And what does "metro" even mean?
+    switch (route.routeType.unsignedIntegerValue) {
+        case OBARouteTypeLightRail:
+        case OBARouteTypeMetro:
             return NSLocalizedString(@"metro", @"routeType 1");
 
-        case 2:
+        case OBARouteTypeTrain:
             return NSLocalizedString(@"train", @"routeType 2");
 
-        case 3:
+        case OBARouteTypeBus:
             return NSLocalizedString(@"bus", @"routeType 3");
 
-        case 4:
+        case OBARouteTypeFerry:
             return NSLocalizedString(@"ferry", @"routeType 4");
 
         default:


### PR DESCRIPTION
Hygiene:

* Be more selective about the parts of PromiseKit we use
* Add a new macro for ensuring that objects are of a specific type
* Rip out a bunch of unused code from OBAStopIconFactory

Helpers:

* Add image helper methods to colorize images and composite images together
* Move most of the code in our MKMapView category out into a new file where it can be used by anyone—including objects that aren't MKMapViews.
* New fonts and colors in OBATheme

Models:

* Expose a few new helper methods in OBAArrivalAndDepartureV2
* Add numberOfStopsAway property to OBAArrivalAndDepartureV2
* Add a new enum to represent route types - previously the app had been passing around magic numbers. This simply codifies their meaning.