### PR TITLE
Further improve the rendering of the classic stop UI

### DIFF
--- a/OBAKit/Helpers/OBAMapHelpers.m
+++ b/OBAKit/Helpers/OBAMapHelpers.m
@@ -16,7 +16,8 @@
 
 const double OBADefaultMapRadiusInMeters = 100;
 const double OBAMinMapRadiusInMeters = 150;
-const double OBAMaxLatitudeDeltaToShowStops = 0.008;
+//const double OBAMaxLatitudeDeltaToShowStops = 0.008;
+const double OBAMaxLatitudeDeltaToShowStops = 0.01;
 const double OBARegionScaleFactor = 1.5;
 const double OBAMaxMapDistanceFromCurrentLocationForNearby = 800;
 const double OBAPaddingScaleFactor = 1.075;

--- a/ui/stops/OBAClassicDepartureCell.m
+++ b/ui/stops/OBAClassicDepartureCell.m
@@ -102,7 +102,7 @@
             sv.axis = UILayoutConstraintAxisVertical;
             sv.distribution = UIStackViewDistributionFillProportionally;
             sv.layoutMarginsRelativeArrangement = YES;
-            sv.layoutMargins = UIEdgeInsetsMake(0, [OBATheme defaultPadding] / 2.f, 0, [OBATheme defaultPadding] / 2.f);
+            sv.layoutMargins = UIEdgeInsetsMake(0, [OBATheme halfDefaultPadding], 0, [OBATheme halfDefaultPadding]);
             sv.distribution = UIStackViewDistributionEqualSpacing;
             sv;
         });
@@ -112,7 +112,7 @@
             stack.axis = UILayoutConstraintAxisHorizontal;
             stack.distribution = UIStackViewDistributionEqualSpacing;
             stack.layoutMarginsRelativeArrangement = YES;
-            stack.layoutMargins = self.layoutMargins; //UIEdgeInsetsMake(0, self.layoutMargins.left, 0, self.layoutMargins.right);
+            stack.layoutMargins = UIEdgeInsetsMake([OBATheme halfDefaultPadding], self.layoutMargins.left, [OBATheme halfDefaultPadding], 0);
             stack;
         });
         [self.contentView addSubview:horizontalStack];

--- a/ui/stops/OBAParallaxTableHeaderView.m
+++ b/ui/stops/OBAParallaxTableHeaderView.m
@@ -147,7 +147,9 @@
         return [directions calculateETA];
     }).then(^(MKETAResponse* ETA) {
         UILabel *label = [[UILabel alloc] initWithFrame:CGRectZero];
-        label.numberOfLines = 0;
+        label.numberOfLines = 1;
+        label.adjustsFontSizeToFitWidth = YES;
+        label.minimumScaleFactor = 0.8f;
         [OBAParallaxTableHeaderView applyHeaderStylingToLabel:label];
 
         label.text = [NSString stringWithFormat:@"Walk to stop: %@: %.0f min, arriving at %@.", [OBAMapHelpers stringFromDistance:ETA.distance],

--- a/ui/themes/OBATheme.h
+++ b/ui/themes/OBATheme.h
@@ -97,6 +97,11 @@
 // Pixels (err, points)
 
 /**
+ Half of the default padding. Used in situations where a tighter fit is necessary.
+ */
++ (CGFloat)halfDefaultPadding;
+
+/**
  * The default vertical and horizontal padding in px.
  */
 + (CGFloat)defaultPadding;

--- a/ui/themes/OBATheme.m
+++ b/ui/themes/OBATheme.m
@@ -106,6 +106,10 @@ static UIFont *_boldFootnoteFont = nil;
 
 #pragma mark - Pixels, err points
 
++ (CGFloat)halfDefaultPadding {
+    return self.defaultPadding / 2.f;
+}
+
 + (CGFloat)defaultPadding {
     return 8.f;
 }


### PR DESCRIPTION
Fixes #62 - Show stop icons at a higher (i.e., more zoomed out) zoom level
* Ensure that the walk time header text always fits.
* Just for fun, let's ratchet up the maximum latitude delta at which to show stops.