### PR TITLE
Rebuild the Bookmarks View Controller

### DIFF
--- a/OBAApplicationDelegate.m
+++ b/OBAApplicationDelegate.m
@@ -23,6 +23,7 @@
 #import "OBASearchResultsMapViewController.h"
 #import "OBARecentStopsViewController.h"
 #import "OBABookmarksViewController.h"
+#import "OBABookmarksViewController2.h"
 #import "OBAInfoViewController.h"
 
 #import "OBASearchController.h"
@@ -122,7 +123,7 @@ static NSString *const kApplicationShortcutBookmarks = @"org.onebusaway.iphone.s
     self.recentsViewController = [[OBARecentStopsViewController alloc] init];
     self.recentsNavigationController = [[UINavigationController alloc] initWithRootViewController:self.recentsViewController];
 
-    self.bookmarksViewController = [[OBABookmarksViewController alloc] init];
+    self.bookmarksViewController = [[OBABookmarksViewController2 alloc] init];
     self.bookmarksNavigationController = [[UINavigationController alloc] initWithRootViewController:self.bookmarksViewController];
 
     self.infoViewController = [[OBAInfoViewController alloc] init];
@@ -257,11 +258,13 @@ static NSString *const kApplicationShortcutBookmarks = @"org.onebusaway.iphone.s
 
         [self.mapNavigationController popToRootViewControllerAnimated:NO];
         [self.mapViewController onCrossHairsButton:self];
-    } else if ([shortcutIdentifier isEqualToString:kApplicationShortcutBookmarks]) {
+    }
+    else if ([shortcutIdentifier isEqualToString:kApplicationShortcutBookmarks]) {
         [self.tabBarController setSelectedViewController:self.bookmarksNavigationController];
 
         [self.bookmarksNavigationController popToRootViewControllerAnimated:NO];
-    } else if ([shortcutIdentifier isEqualToString:kApplicationShortcutRecents]) {
+    }
+    else if ([shortcutIdentifier isEqualToString:kApplicationShortcutRecents]) {
         [self.tabBarController setSelectedViewController:self.recentsNavigationController];
 
         NSArray *stopIds = (NSArray *)shortcutItem.userInfo[@"stopIds"];

--- a/OBAKit/Models/dao/OBAModelDAO.h
+++ b/OBAKit/Models/dao/OBAModelDAO.h
@@ -57,8 +57,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void) moveBookmark:(OBABookmarkV2*)bookmark toGroup:(OBABookmarkGroup*)group;
 - (void) moveBookmark:(NSInteger)startIndex to:(NSInteger)endIndex inGroup:(OBABookmarkGroup*)group;
 
-- (void) addStopAccessEvent:(OBAStopAccessEventV2*)event;
-
 - (OBAStopPreferencesV2*) stopPreferencesForStopWithId:(NSString*)stopId;
 - (void) setStopPreferences:(OBAStopPreferencesV2*)preferences forStopWithId:(NSString*)stopId;
 

--- a/OBAKit/Models/dao/OBAModelDAO.m
+++ b/OBAKit/Models/dao/OBAModelDAO.m
@@ -240,13 +240,22 @@ const NSInteger kMaxEntriesInMostRecentList = 10;
     [_preferencesDao writeBookmarks:_bookmarks];
 }
 
-- (void) removeBookmark:(OBABookmarkV2*)bookmark {
-    if (!bookmark.group) {
+- (void)removeBookmark:(OBABookmarkV2*)bookmark {
+    if (bookmark.group) {
+        OBABookmarkGroup *group = bookmark.group;
+
+        [group.bookmarks removeObject:bookmark];
+
+        // The group is empty. Delete it.
+        if (group.bookmarks.count == 0) {
+            [_bookmarkGroups removeObject:group];
+        }
+
+        [_preferencesDao writeBookmarkGroups:_bookmarkGroups];
+    }
+    else {
         [_bookmarks removeObject:bookmark];
         [_preferencesDao writeBookmarks:_bookmarks];
-    } else {
-        [bookmark.group.bookmarks removeObject:bookmark];
-        [_preferencesDao writeBookmarkGroups:_bookmarkGroups];
     }
 }
 

--- a/org.onebusaway.iphone.xcodeproj/project.pbxproj
+++ b/org.onebusaway.iphone.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		932076451C90C635005F7D4A /* bookmark_with_stopids_array.plist in Resources */ = {isa = PBXBuildFile; fileRef = 932076441C90C635005F7D4A /* bookmark_with_stopids_array.plist */; };
 		932076471C90CE12005F7D4A /* bookmark_without_region_identifier.plist in Resources */ = {isa = PBXBuildFile; fileRef = 932076461C90CE12005F7D4A /* bookmark_without_region_identifier.plist */; };
 		932076491C90CF73005F7D4A /* bookmark_with_region_identifier.plist in Resources */ = {isa = PBXBuildFile; fileRef = 932076481C90CF73005F7D4A /* bookmark_with_region_identifier.plist */; };
+		9320764C1C915441005F7D4A /* OBABookmarksViewController2.m in Sources */ = {isa = PBXBuildFile; fileRef = 9320764B1C915441005F7D4A /* OBABookmarksViewController2.m */; };
 		932BE49D1AB66D320011F2FB /* OBAAgenciesListViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 932BE4931AB66D320011F2FB /* OBAAgenciesListViewController.m */; };
 		932BE49E1AB66D320011F2FB /* OBAContactUsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 932BE4951AB66D320011F2FB /* OBAContactUsViewController.m */; };
 		932BE49F1AB66D320011F2FB /* OBAInfoViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 932BE4971AB66D320011F2FB /* OBAInfoViewController.m */; };
@@ -320,6 +321,8 @@
 		932076441C90C635005F7D4A /* bookmark_with_stopids_array.plist */ = {isa = PBXFileReference; lastKnownFileType = file.bplist; path = bookmark_with_stopids_array.plist; sourceTree = "<group>"; };
 		932076461C90CE12005F7D4A /* bookmark_without_region_identifier.plist */ = {isa = PBXFileReference; lastKnownFileType = file.bplist; path = bookmark_without_region_identifier.plist; sourceTree = "<group>"; };
 		932076481C90CF73005F7D4A /* bookmark_with_region_identifier.plist */ = {isa = PBXFileReference; lastKnownFileType = file.bplist; path = bookmark_with_region_identifier.plist; sourceTree = "<group>"; };
+		9320764A1C915441005F7D4A /* OBABookmarksViewController2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBABookmarksViewController2.h; sourceTree = "<group>"; };
+		9320764B1C915441005F7D4A /* OBABookmarksViewController2.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBABookmarksViewController2.m; sourceTree = "<group>"; };
 		932BE4921AB66D320011F2FB /* OBAAgenciesListViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAAgenciesListViewController.h; sourceTree = "<group>"; };
 		932BE4931AB66D320011F2FB /* OBAAgenciesListViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAAgenciesListViewController.m; sourceTree = "<group>"; };
 		932BE4941AB66D320011F2FB /* OBAContactUsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAContactUsViewController.h; sourceTree = "<group>"; };
@@ -923,6 +926,8 @@
 				932BE4E61AB66E3C0011F2FB /* OBAEditStopBookmarkGroupViewController.m */,
 				932BE4E71AB66E3C0011F2FB /* OBAEditStopBookmarkViewController.h */,
 				932BE4E81AB66E3C0011F2FB /* OBAEditStopBookmarkViewController.m */,
+				9320764A1C915441005F7D4A /* OBABookmarksViewController2.h */,
+				9320764B1C915441005F7D4A /* OBABookmarksViewController2.m */,
 			);
 			path = bookmarks;
 			sourceTree = "<group>";
@@ -1813,6 +1818,7 @@
 				932BE4D91AB66D890011F2FB /* OBADiversionViewController.m in Sources */,
 				932BE4F61AB66E990011F2FB /* OBASearchController.m in Sources */,
 				934446D01AB12B29005B3333 /* OBATextEditViewController.m in Sources */,
+				9320764C1C915441005F7D4A /* OBABookmarksViewController2.m in Sources */,
 				93F05A631C8E080000BF36B1 /* OBAAnimation.m in Sources */,
 				932BE4F71AB66E990011F2FB /* OBASearchResultsListViewController.m in Sources */,
 				936D2EF31C7A68260060B7E1 /* OBATableRow.m in Sources */,

--- a/ui/bookmarks/OBABookmarksViewController2.h
+++ b/ui/bookmarks/OBABookmarksViewController2.h
@@ -1,0 +1,13 @@
+//
+//  OBABookmarksViewController2.h
+//  org.onebusaway.iphone
+//
+//  Created by Aaron Brethorst on 3/9/16.
+//  Copyright © 2016 OneBusAway. All rights reserved.
+//
+
+#import "OBAStaticTableViewController.h"
+
+@interface OBABookmarksViewController2 : OBAStaticTableViewController
+
+@end

--- a/ui/bookmarks/OBABookmarksViewController2.m
+++ b/ui/bookmarks/OBABookmarksViewController2.m
@@ -1,0 +1,135 @@
+//
+//  OBABookmarksViewController2.m
+//  org.onebusaway.iphone
+//
+//  Created by Aaron Brethorst on 3/9/16.
+//  Copyright © 2016 OneBusAway. All rights reserved.
+//
+
+#import "OBABookmarksViewController2.h"
+#import "OBAApplication.h"
+#import "OBABookmarkGroup.h"
+#import "OBAStopViewController.h"
+#import "OBAEditStopBookmarkViewController.h"
+
+@interface OBABookmarksViewController2 ()
+
+@end
+
+@implementation OBABookmarksViewController2
+
+- (instancetype)init {
+    self = [super init];
+
+    if (self) {
+        self.tabBarItem.title = NSLocalizedString(@"Bookmarks", @"Bookmarks tab title");
+        self.tabBarItem.image = [UIImage imageNamed:@"Bookmarks"];
+    }
+    return self;
+}
+
+#pragma mark - UIViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+    self.tableView.allowsSelectionDuringEditing = YES;
+    self.navigationItem.leftBarButtonItem = self.editButtonItem;
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+
+    NSString *title = nil;
+    if (self.currentRegion) {
+        title = [NSString stringWithFormat:NSLocalizedString(@"Bookmarks - %@", @""), self.currentRegion.regionName];
+    }
+    else {
+        title = NSLocalizedString(@"Bookmarks", @"");
+    }
+    self.navigationItem.title = title;
+
+    [self loadData];
+}
+
+#pragma mark - Data Loading
+
+- (void)loadData {
+    OBAModelDAO *modelDAO = [OBAApplication sharedApplication].modelDao;
+
+    NSMutableArray *sections = [[NSMutableArray alloc] init];
+
+    for (OBABookmarkGroup *group in modelDAO.bookmarkGroups) {
+        NSArray *rows = [self tableRowsFromBookmarks:group.bookmarks];
+        OBATableSection *section = [[OBATableSection alloc] initWithTitle:group.name rows:rows];
+        [sections addObject:section];
+    }
+
+    OBATableSection *looseBookmarks = [[OBATableSection alloc] initWithTitle:nil rows:[self tableRowsFromBookmarks:modelDAO.bookmarks]];
+    [sections addObject:looseBookmarks];
+
+    self.sections = sections;
+    [self.tableView reloadData];
+}
+
+#pragma mark - UITableView
+
+- (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath {
+    return YES;
+}
+
+// Disabled for now. This requires more time and attention than I can give it at the moment.
+// I'd love to re-enable this feature, and soon, though.
+- (BOOL)tableView:(UITableView*)tableView canMoveRowAtIndexPath:(NSIndexPath *)indexPath {
+    return NO;
+}
+
+// After a row has the minus or plus button invoked (based on the UITableViewCellEditingStyle for the cell), the dataSource must commit the change
+// Not called for edit actions using UITableViewRowAction - the action's handler will be invoked instead
+- (void)tableView:(UITableView *)tableView commitEditingStyle:(UITableViewCellEditingStyle)editingStyle forRowAtIndexPath:(NSIndexPath *)indexPath {
+
+    OBATableSection *tableSection = self.sections[indexPath.section];
+    OBATableRow *tableRow = tableSection.rows[indexPath.row];
+
+    NSMutableArray *rows = [NSMutableArray arrayWithArray:tableSection.rows];
+    [rows removeObjectAtIndex:indexPath.row];
+    tableSection.rows = rows;
+
+    if (tableRow.deleteModel) {
+        tableRow.deleteModel();
+    }
+
+    [tableView deleteRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
+}
+
+#pragma mark - Accessors
+
+- (OBARegionV2*)currentRegion {
+    return [OBAApplication sharedApplication].modelDao.region;
+}
+
+#pragma mark - Private
+
+- (NSArray<OBATableRow*>*)tableRowsFromBookmarks:(NSArray<OBABookmarkV2*>*)bookmarks {
+    NSMutableArray *rows = [NSMutableArray array];
+
+    for (OBABookmarkV2 *bm in bookmarks) {
+        OBATableRow *row = [[OBATableRow alloc] initWithTitle:bm.name action:^{
+            OBAStopViewController *controller = [[OBAStopViewController alloc] initWithStopID:bm.stopID];
+            [self.navigationController pushViewController:controller animated:YES];
+        }];
+        [row setEditAction:^{
+            OBAEditStopBookmarkViewController *editor = [[OBAEditStopBookmarkViewController alloc] initWithBookmark:bm editType:OBABookmarkEditExisting];
+            UINavigationController *nav = [[UINavigationController alloc] initWithRootViewController:editor];
+            [self presentViewController:nav animated:YES completion:nil];
+        }];
+        [row setDeleteModel:^{
+            [[OBAApplication sharedApplication].modelDao removeBookmark:bm];
+        }];
+        [rows addObject:row];
+    }
+
+    return rows;
+}
+
+@end

--- a/ui/static_table/OBAStaticTableViewController.h
+++ b/ui/static_table/OBAStaticTableViewController.h
@@ -16,6 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic,strong,readonly) UITableView *tableView;
 @property(nonatomic,strong) NSArray<OBATableSection*> *sections;
 
+- (OBABaseRow*)rowAtIndexPath:(NSIndexPath*)indexPath;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ui/static_table/cells/OBATableCell.h
+++ b/ui/static_table/cells/OBATableCell.h
@@ -7,8 +7,8 @@
 //
 
 #import <UIKit/UIKit.h>
-#import "OBATableRow.h"
+#import "OBABaseRow.h"
 
 @protocol OBATableCell <NSObject>
-@property(nonatomic,copy) OBATableRow *tableRow;
+@property(nonatomic,copy) OBABaseRow *tableRow;
 @end

--- a/ui/static_table/cells/OBATableViewCell.m
+++ b/ui/static_table/cells/OBATableViewCell.m
@@ -7,6 +7,7 @@
 //
 
 #import "OBATableViewCell.h"
+#import "OBATableRow.h"
 
 @implementation OBATableViewCell
 @synthesize tableRow = _tableRow;
@@ -28,10 +29,14 @@
 
     _tableRow = [tableRow copy];
 
-    self.textLabel.text = _tableRow.title;
-    self.textLabel.textAlignment = _tableRow.textAlignment;
-    self.detailTextLabel.text = _tableRow.subtitle;
-    self.accessoryType = _tableRow.accessoryType;
-    self.imageView.image = _tableRow.image;
+    self.textLabel.text = [self tableDataRow].title;
+    self.textLabel.textAlignment = [self tableDataRow].textAlignment;
+    self.detailTextLabel.text = [self tableDataRow].subtitle;
+    self.accessoryType = [self tableDataRow].accessoryType;
+    self.imageView.image = [self tableDataRow].image;
+}
+
+- (OBATableRow*)tableDataRow {
+    return (OBATableRow*)self.tableRow;
 }
 @end

--- a/ui/static_table/viewmodels/OBABaseRow.h
+++ b/ui/static_table/viewmodels/OBABaseRow.h
@@ -9,7 +9,25 @@
 #import <Foundation/Foundation.h>
 
 @interface OBABaseRow : NSObject<NSCopying>
+
+/**
+ The action taken (pushing a view controller, etc.) when the row is tapped.
+ */
 @property(nonatomic,copy) void (^action)();
+
+/**
+ The action taken (editing the underlying model, etc.) when the row is tapped while the table is in edit mode.
+ */
+@property(nonatomic,copy) void (^editAction)();
+
+/**
+ This block is provided as a convenience for table views where you can delete models. Since it may be difficult
+ to associate your row with a model (due to sorting differences or whatever), this block provides an easy way
+ to get back to—and delete—the underlying data.
+ */
+@property(nonatomic,copy) void (^deleteModel)();
+
+@property(nonatomic,assign) NSUInteger indentationLevel;
 
 - (instancetype)initWithAction:(void (^)())action NS_DESIGNATED_INITIALIZER;
 

--- a/ui/static_table/viewmodels/OBABaseRow.m
+++ b/ui/static_table/viewmodels/OBABaseRow.m
@@ -31,6 +31,9 @@
 - (id)copyWithZone:(NSZone *)zone {
     OBABaseRow *newRow = [[self.class allocWithZone:zone] init];
     newRow->_action = [_action copyWithZone:zone];
+    newRow->_editAction = [_editAction copyWithZone:zone];
+    newRow->_deleteModel = [_deleteModel copyWithZone:zone];
+    newRow->_indentationLevel = _indentationLevel;
     
     return newRow;
 }

--- a/ui/stops/OBAClassicDepartureCell.m
+++ b/ui/stops/OBAClassicDepartureCell.m
@@ -137,7 +137,7 @@
 
 #pragma mark - OBATableCell
 
-- (void)setTableRow:(OBATableRow *)tableRow {
+- (void)setTableRow:(OBABaseRow *)tableRow {
 
     OBAGuardClass(tableRow, OBAClassicDepartureRow) else {
         return;

--- a/ui/stops/OBADepartureCell.m
+++ b/ui/stops/OBADepartureCell.m
@@ -134,7 +134,7 @@
 
 #pragma mark - OBATableCell
 
-- (void)setTableRow:(OBATableRow *)tableRow {
+- (void)setTableRow:(OBABaseRow *)tableRow {
     
     OBAGuardClass(tableRow, OBADepartureRow) else {
         return;


### PR DESCRIPTION
This is part of the continuing work to enable support for region-scoping bookmarks, and for displaying bookmarks on the map.

Fix Bugs I Introduced Recently:

* Fix a dumb bug I previously introduced in initializing the static table

New Bookmarks Controller

* Create a new class: OBABookmarksViewController2. This will replace OBABookmarksViewController soon, but—for now—I want to keep both of them around.
* Add -rowAtIndexPath: to OBAStaticTableViewController to be able to extract specific rows. Use this to DRY up some base code in the static controller.
* Fix some BaseRow/TableRow type issues
* Add indentationLevel to OBABaseRow's properties and consume it where appropriate.
* Deleting the last bookmark in a group deletes the group