### PR TITLE
Make it easier to input a custom API server

### DIFF
--- a/OBAKit/Helpers/OBAURLHelpers.h
+++ b/OBAKit/Helpers/OBAURLHelpers.h
@@ -11,7 +11,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface OBAURLHelpers : NSObject
-+ (NSURL*)normalizeURLPath:(NSString*)path relativeToBaseURL:(NSString*)baseURLString parameters:(NSDictionary*)params;
++ (NSURL*)normalizeURLPath:(NSString*)path relativeToBaseURL:(NSString*)baseURLString parameters:(NSDictionary* _Nullable)params;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/OBAKit/Helpers/OBAURLHelpers.m
+++ b/OBAKit/Helpers/OBAURLHelpers.m
@@ -18,6 +18,13 @@
 
     NSURLComponents *components = [[NSURLComponents alloc] initWithString:baseURLString];
 
+    if (components.path.length == 0) {
+        components.path = @"/api";
+    }
+    else if (![components.path hasSuffix:@"api"] && ![components.path hasSuffix:@"api/"]) {
+        components.path = [components.path stringByAppendingPathComponent:@"api"];
+    }
+
     components.path = [(components.path ?: @"") stringByAppendingPathComponent:path];
 
     if (params.count > 0) {

--- a/OneBusAwayTests/OBAURLHelpers_Tests.m
+++ b/OneBusAwayTests/OBAURLHelpers_Tests.m
@@ -8,7 +8,6 @@
 
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
-//#import "OBAURLHelpers.h"
 #import <OBAKit/OBAURLHelpers.h>
 
 @interface OBAURLHelpers_Tests : XCTestCase
@@ -17,50 +16,90 @@
 
 @implementation OBAURLHelpers_Tests
 
++ (NSURL*)yorkResultURL {
+    return [NSURL URLWithString:@"http://oba.yrt.ca/api/where/current-time.json?key=org.onebusaway.iphone"];
+}
+
++ (NSURL*)tampaResultURL {
+    return [NSURL URLWithString:@"http://api.tampa.onebusaway.org/api/where/current-time.json?key=org.onebusaway.iphone"];
+}
+
++ (NSURL*)pugetSoundResultURL {
+    return [NSURL URLWithString:@"http://api.pugetsound.onebusaway.org/api/where/current-time.json?key=org.onebusaway.iphone"];
+}
+
++ (NSURL*)httpsPugetSoundResultURL {
+    return [NSURL URLWithString:@"https://api.pugetsound.onebusaway.org/api/where/current-time.json?key=org.onebusaway.iphone"];
+}
+
++ (NSURL*)busTimeResultURL {
+    return [NSURL URLWithString:@"http://bustime.mta.info/api/where/current-time.json?key=org.onebusaway.iphone"];
+}
+
++ (NSURL*)IPAndPortResultURL {
+    return [NSURL URLWithString:@"http://194.89.230.196:8080/api/where/current-time.json?key=org.onebusaway.iphone"];
+}
+
++ (NSURL*)portAndPathResultURL {
+    return [NSURL URLWithString:@"http://oba.rvtd.org:8080/onebusaway-api-webapp/api/where/current-time.json?key=org.onebusaway.iphone"];
+}
+
 #pragma mark - URL Normalization
 
 static NSString * const kOBACurrentTimeURLPath = @"/where/current-time.json";
 
+- (void)testBaseURLNormalization1 {
+    NSString *baseURLString = @"app.staging.obahart.org/api";
+    NSURL *resultURL = [NSURL URLWithString:@"http://app.staging.obahart.org/api"];
+    XCTAssertEqualObjects([OBAURLHelpers normalizeURLPath:@"/" relativeToBaseURL:baseURLString parameters:nil], resultURL);
+}
+
+- (void)testBaseURLNormalization2 {
+    NSString *baseURLString = @"http://app.staging.obahart.org/api";
+    NSURL *resultURL = [NSURL URLWithString:@"http://app.staging.obahart.org/api"];
+    XCTAssertEqualObjects([OBAURLHelpers normalizeURLPath:@"/" relativeToBaseURL:baseURLString parameters:nil], resultURL);
+}
+
+- (void)testBaseURLNormalization3 {
+    NSString *baseURLString = @"http://app.staging.obahart.org/api";
+    NSURL *resultURL = [NSURL URLWithString:@"http://app.staging.obahart.org/api"];
+    XCTAssertEqualObjects([OBAURLHelpers normalizeURLPath:@"/" relativeToBaseURL:baseURLString parameters:nil], resultURL);
+}
+
 - (void)testNormalization {
     NSString *baseURLString = @"http://oba.yrt.ca/";
-    NSURL *resultURL = [NSURL URLWithString:@"http://oba.yrt.ca/where/current-time.json?key=org.onebusaway.iphone"];
-    XCTAssertEqualObjects([OBAURLHelpers normalizeURLPath:kOBACurrentTimeURLPath relativeToBaseURL:baseURLString parameters:@{@"key": @"org.onebusaway.iphone"}], resultURL);
+    XCTAssertEqualObjects([OBAURLHelpers normalizeURLPath:kOBACurrentTimeURLPath relativeToBaseURL:baseURLString parameters:@{@"key": @"org.onebusaway.iphone"}], [OBAURLHelpers_Tests yorkResultURL]);
 }
 
 - (void)testNormalizationWithMissingScheme {
     NSString *baseURLString = @"oba.yrt.ca/";
-    NSURL *resultURL = [NSURL URLWithString:@"http://oba.yrt.ca/where/current-time.json?key=org.onebusaway.iphone"];
-    XCTAssertEqualObjects([OBAURLHelpers normalizeURLPath:kOBACurrentTimeURLPath relativeToBaseURL:baseURLString parameters:@{@"key": @"org.onebusaway.iphone"}], resultURL);
+    XCTAssertEqualObjects([OBAURLHelpers normalizeURLPath:kOBACurrentTimeURLPath relativeToBaseURL:baseURLString parameters:@{@"key": @"org.onebusaway.iphone"}], [OBAURLHelpers_Tests yorkResultURL]);
 }
 
 - (void)testNormalizationWithPath {
     NSString *baseURLString = @"http://api.tampa.onebusaway.org/api/";
-    NSURL *resultURL = [NSURL URLWithString:@"http://api.tampa.onebusaway.org/api/where/current-time.json?key=org.onebusaway.iphone"];
-    XCTAssertEqualObjects([OBAURLHelpers normalizeURLPath:kOBACurrentTimeURLPath relativeToBaseURL:baseURLString parameters:@{@"key": @"org.onebusaway.iphone"}], resultURL);
+    XCTAssertEqualObjects([OBAURLHelpers normalizeURLPath:kOBACurrentTimeURLPath relativeToBaseURL:baseURLString parameters:@{@"key": @"org.onebusaway.iphone"}], [OBAURLHelpers_Tests tampaResultURL]);
 }
 
 - (void)testNormalizationWithHTTPS {
     NSString *baseURLString = @"https://api.pugetsound.onebusaway.org/";
-    NSURL *resultURL = [NSURL URLWithString:@"https://api.pugetsound.onebusaway.org/where/current-time.json?key=org.onebusaway.iphone"];
-    XCTAssertEqualObjects([OBAURLHelpers normalizeURLPath:kOBACurrentTimeURLPath relativeToBaseURL:baseURLString parameters:@{@"key": @"org.onebusaway.iphone"}], resultURL);
+    XCTAssertEqualObjects([OBAURLHelpers normalizeURLPath:kOBACurrentTimeURLPath relativeToBaseURL:baseURLString parameters:@{@"key": @"org.onebusaway.iphone"}], [OBAURLHelpers_Tests httpsPugetSoundResultURL]);
 }
 
 - (void)testNormalizationWithMissingSlash {
     NSString *baseURLString = @"http://bustime.mta.info";
-    NSURL *resultURL = [NSURL URLWithString:@"http://bustime.mta.info/where/current-time.json?key=org.onebusaway.iphone"];
-    XCTAssertEqualObjects([OBAURLHelpers normalizeURLPath:kOBACurrentTimeURLPath relativeToBaseURL:baseURLString parameters:@{@"key": @"org.onebusaway.iphone"}], resultURL);
+    XCTAssertEqualObjects([OBAURLHelpers normalizeURLPath:kOBACurrentTimeURLPath relativeToBaseURL:baseURLString parameters:@{@"key": @"org.onebusaway.iphone"}], [OBAURLHelpers_Tests busTimeResultURL]);
 }
 
 - (void)testNormalizationWithIPAndPort {
     NSString *baseURLString = @"http://194.89.230.196:8080/";
-    NSURL *resultURL = [NSURL URLWithString:@"http://194.89.230.196:8080/where/current-time.json?key=org.onebusaway.iphone"];
-    XCTAssertEqualObjects([OBAURLHelpers normalizeURLPath:kOBACurrentTimeURLPath relativeToBaseURL:baseURLString parameters:@{@"key": @"org.onebusaway.iphone"}], resultURL);
+
+    XCTAssertEqualObjects([OBAURLHelpers normalizeURLPath:kOBACurrentTimeURLPath relativeToBaseURL:baseURLString parameters:@{@"key": @"org.onebusaway.iphone"}], [OBAURLHelpers_Tests IPAndPortResultURL]);
 }
 
 - (void)testNormalizationWithPortAndPath {
     NSString *baseURLString = @"http://oba.rvtd.org:8080/onebusaway-api-webapp/";
-    NSURL *resultURL = [NSURL URLWithString:@"http://oba.rvtd.org:8080/onebusaway-api-webapp/where/current-time.json?key=org.onebusaway.iphone"];
-    XCTAssertEqualObjects([OBAURLHelpers normalizeURLPath:kOBACurrentTimeURLPath relativeToBaseURL:baseURLString parameters:@{@"key": @"org.onebusaway.iphone"}], resultURL);
+    XCTAssertEqualObjects([OBAURLHelpers normalizeURLPath:kOBACurrentTimeURLPath relativeToBaseURL:baseURLString parameters:@{@"key": @"org.onebusaway.iphone"}], [OBAURLHelpers_Tests portAndPathResultURL]);
 }
 
 @end

--- a/ui/search/OBASearchResultsMapViewController.m
+++ b/ui/search/OBASearchResultsMapViewController.m
@@ -798,10 +798,6 @@ static const double kStopsInRegionRefreshDelayOnDrag = 0.1;
     }
 }
 
-- (void)didCompleteNetworkRequest {
-    self.hideFutureNetworkErrors = NO;
-}
-
 - (void)setAnnotationsFromResults {
     NSMutableArray *annotations = [[NSMutableArray alloc] init];
 


### PR DESCRIPTION
Fixes #305 - Custom API URLs aren't working (https://github.com/OneBusAway/onebusaway-iphone/issues/305)

* Rearrange the code in OBARegionListViewController to make it easier to figure out what it's really doing
* Add a progress spinner to OBARegionListViewController
Revise Custom API View Controller and URL Helper tests to account for issues in custom API management
* Move the Custom API View Controller's testing process over to PromiseKit to make the code easier to understand and fix a potential crashing bug.