### PR TITLE
UI Tweaks

### DIFF
--- a/OBAKit/Models/unmanaged/OBAArrivalAndDepartureV2.m
+++ b/OBAKit/Models/unmanaged/OBAArrivalAndDepartureV2.m
@@ -166,10 +166,10 @@
     NSLocalizedString(@"late", @"");
 
     if (minutes < 0) {
-        return [NSString stringWithFormat:@"departed %@ minutes %@", @(minDiff), suffixWord];
+        return [NSString stringWithFormat:NSLocalizedString(@"departed %@ min %@", @"e.g. departed 5 min late"), @(minDiff), suffixWord];
     }
     else {
-        return [NSString stringWithFormat:@"%@ minutes %@", @(minDiff), suffixWord];
+        return [NSString stringWithFormat:NSLocalizedString(@"%@ min %@", @"e.g. 3 min early"), @(minDiff), suffixWord];
     }
 }
 

--- a/OBAKit/OBAKit.h
+++ b/OBAKit/OBAKit.h
@@ -94,3 +94,4 @@ FOUNDATION_EXPORT const unsigned char OBAKitVersionString[];
 #import <OBAKit/OBAModelServiceRequest.h>
 #import <OBAKit/OBAImageHelpers.h>
 #import <OBAKit/OBAMapHelpers.h>
+#import <OBAKit/OBAUIBuilder.h>

--- a/OBAKit/UI/OBAUIBuilder.h
+++ b/OBAKit/UI/OBAUIBuilder.h
@@ -1,0 +1,13 @@
+//
+//  OBAUIBuilder.h
+//  org.onebusaway.iphone
+//
+//  Created by Aaron Brethorst on 3/12/16.
+//  Copyright © 2016 OneBusAway. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface OBAUIBuilder : NSObject
++ (UILabel*)label;
+@end

--- a/OBAKit/UI/OBAUIBuilder.m
+++ b/OBAKit/UI/OBAUIBuilder.m
@@ -1,0 +1,20 @@
+//
+//  OBAUIBuilder.m
+//  org.onebusaway.iphone
+//
+//  Created by Aaron Brethorst on 3/12/16.
+//  Copyright © 2016 OneBusAway. All rights reserved.
+//
+
+#import "OBAUIBuilder.h"
+
+@implementation OBAUIBuilder
+
++ (UILabel*)label {
+    UILabel *label = [[UILabel alloc] initWithFrame:CGRectZero];
+    label.numberOfLines = 1;
+    label.adjustsFontSizeToFitWidth = YES;
+    label.minimumScaleFactor = 0.8f;
+    return label;
+}
+@end

--- a/org.onebusaway.iphone.xcodeproj/project.pbxproj
+++ b/org.onebusaway.iphone.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		9320765F1C94042B005F7D4A /* OBASegmentedControlCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 9320765E1C94042B005F7D4A /* OBASegmentedControlCell.m */; };
 		932076621C940519005F7D4A /* OBASegmentedRow.m in Sources */ = {isa = PBXBuildFile; fileRef = 932076611C940519005F7D4A /* OBASegmentedRow.m */; };
 		932076641C94E6F2005F7D4A /* regions-v3.json in Resources */ = {isa = PBXBuildFile; fileRef = 932076631C94E6F2005F7D4A /* regions-v3.json */; };
+		932076681C95361A005F7D4A /* OBAUIBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 932076661C95361A005F7D4A /* OBAUIBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		932076691C95361A005F7D4A /* OBAUIBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 932076671C95361A005F7D4A /* OBAUIBuilder.m */; };
 		932BE49D1AB66D320011F2FB /* OBAAgenciesListViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 932BE4931AB66D320011F2FB /* OBAAgenciesListViewController.m */; };
 		932BE49E1AB66D320011F2FB /* OBAContactUsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 932BE4951AB66D320011F2FB /* OBAContactUsViewController.m */; };
 		932BE49F1AB66D320011F2FB /* OBAInfoViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 932BE4971AB66D320011F2FB /* OBAInfoViewController.m */; };
@@ -331,6 +333,8 @@
 		932076601C940519005F7D4A /* OBASegmentedRow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBASegmentedRow.h; sourceTree = "<group>"; };
 		932076611C940519005F7D4A /* OBASegmentedRow.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBASegmentedRow.m; sourceTree = "<group>"; };
 		932076631C94E6F2005F7D4A /* regions-v3.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "regions-v3.json"; path = "Resources/regions-v3.json"; sourceTree = "<group>"; };
+		932076661C95361A005F7D4A /* OBAUIBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAUIBuilder.h; sourceTree = "<group>"; };
+		932076671C95361A005F7D4A /* OBAUIBuilder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAUIBuilder.m; sourceTree = "<group>"; };
 		932BE4921AB66D320011F2FB /* OBAAgenciesListViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAAgenciesListViewController.h; sourceTree = "<group>"; };
 		932BE4931AB66D320011F2FB /* OBAAgenciesListViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAAgenciesListViewController.m; sourceTree = "<group>"; };
 		932BE4941AB66D320011F2FB /* OBAContactUsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAContactUsViewController.h; sourceTree = "<group>"; };
@@ -837,6 +841,15 @@
 			path = Bookmarks;
 			sourceTree = "<group>";
 		};
+		932076651C95360E005F7D4A /* UI */ = {
+			isa = PBXGroup;
+			children = (
+				932076661C95361A005F7D4A /* OBAUIBuilder.h */,
+				932076671C95361A005F7D4A /* OBAUIBuilder.m */,
+			);
+			path = UI;
+			sourceTree = "<group>";
+		};
 		932BE4901AB66D320011F2FB /* ui */ = {
 			isa = PBXGroup;
 			children = (
@@ -1296,6 +1309,7 @@
 		936F44FE1C780E7600C61656 /* OBAKit */ = {
 			isa = PBXGroup;
 			children = (
+				932076651C95360E005F7D4A /* UI */,
 				934D004B1C83924D00A76A90 /* Models */,
 				934D00BE1C83924D00A76A90 /* OBAApplication.h */,
 				934D00BF1C83924D00A76A90 /* OBAApplication.m */,
@@ -1502,6 +1516,7 @@
 				934D011A1C83924D00A76A90 /* OBARouteV2.h in Headers */,
 				934D00381C83924400A76A90 /* OBALogger.h in Headers */,
 				934D00D41C83924D00A76A90 /* OBATripStopTimeMapAnnotation.h in Headers */,
+				932076681C95361A005F7D4A /* OBAUIBuilder.h in Headers */,
 				934D00DE1C83924D00A76A90 /* OBACreateObjectJsonDigesterRule.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1873,6 +1888,7 @@
 				934D00E11C83924D00A76A90 /* OBAJsonDigester.m in Sources */,
 				934D00351C83924400A76A90 /* OBADateHelpers.m in Sources */,
 				934D01211C83924D00A76A90 /* OBAServiceAlertsModel.m in Sources */,
+				932076691C95361A005F7D4A /* OBAUIBuilder.m in Sources */,
 				934D00ED1C83924D00A76A90 /* OBASetPropertyJsonDigesterRule.m in Sources */,
 				934D01171C83924D00A76A90 /* OBAReportProblemWithStopV2.m in Sources */,
 				934D013B1C83924D00A76A90 /* OBAVehicleStatusV2.m in Sources */,

--- a/ui/stops/OBADepartureCellHelpers.m
+++ b/ui/stops/OBADepartureCellHelpers.m
@@ -35,12 +35,12 @@
         return [OBATheme delayedDepartureColor];
     }
     else {
-        return [UIColor blackColor];
+        return [OBATheme textColor];
     }
 }
 
 + (UIFont*)fontForStatus:(OBADepartureStatus)status {
-    return status == OBADepartureStatusDelayed || status == OBADepartureStatusEarly ? [OBATheme boldBodyFont] : [OBATheme bodyFont];
+    return [OBATheme bodyFont];
 }
 
 @end

--- a/ui/stops/OBAParallaxTableHeaderView.h
+++ b/ui/stops/OBAParallaxTableHeaderView.h
@@ -14,4 +14,5 @@
 @property(nonatomic,assign) BOOL highContrastMode;
 - (void)populateTableHeaderFromArrivalsAndDeparturesModel:(OBAArrivalsAndDeparturesForStopV2*)result;
 - (void)loadETAToLocation:(CLLocationCoordinate2D)coordinate;
+- (void)requestsPresentationOfViewController:(void (^)(UIViewController*))presenter;
 @end

--- a/ui/stops/OBAStopViewController.m
+++ b/ui/stops/OBAStopViewController.m
@@ -288,9 +288,6 @@ static CGFloat const kTableHeaderHeight = 150.f;
         OBAStopSectionHeaderView *header = [[OBAStopSectionHeaderView alloc] initWithFrame:CGRectMake(0, 0, CGRectGetWidth(self.tableView.frame), 44.f)];
         header.layoutMargins = self.tableView.layoutMargins;
         header.routeNameText = title;
-        [header setFavoriteButtonTapped:^(BOOL selected) {
-            // TODO!
-        }];
         header;
     });
     return section;
@@ -381,6 +378,9 @@ static CGFloat const kTableHeaderHeight = 150.f;
 - (void)createTableHeaderView {
     self.parallaxHeaderView = [[OBAParallaxTableHeaderView alloc] initWithFrame:CGRectMake(0, 0, CGRectGetWidth(self.tableView.frame), kTableHeaderHeight)];
     self.parallaxHeaderView.highContrastMode = [[OBAApplication sharedApplication] useHighContrastUI];
+    [self.parallaxHeaderView requestsPresentationOfViewController:^(UIViewController* viewController) {
+        [self.navigationController pushViewController:viewController animated:YES];
+    }];
 
 #if ENABLE_PARALLAX_WHICH_NEEDS_FIXING
     [self.tableView addSubview:self.parallaxHeaderView];


### PR DESCRIPTION
* Add a new class, OBAUIBuilder, which will be responsible for providing pre-initialized view objects with commonly-used properties preset
* Fix the stupid issue where a departure was listed as "1 minutes early" by abbreviating "minutes" as "min"
* Stop bolding early and late departures. They're already colored differently, and I find the bold text really distracting.
* Parallax header styling tweaks
* Replace another static color with a OBATheme call
* Enable presentation of view controllers from the parallax header