### PR TITLE
Fixes

### DIFF
--- a/ui/static_table/OBAStaticTableViewController.m
+++ b/ui/static_table/OBAStaticTableViewController.m
@@ -108,7 +108,7 @@
 - (UITableViewCell*)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     
     OBABaseRow *row = [self rowAtIndexPath:indexPath];
-    NSString *reuseIdentifier = [row.class cellReuseIdentifier];
+    NSString *reuseIdentifier = [row cellReuseIdentifier];
 
     UITableViewCell<OBATableCell> *cell = (UITableViewCell<OBATableCell> *)[tableView dequeueReusableCellWithIdentifier:reuseIdentifier forIndexPath:indexPath];
 

--- a/ui/static_table/cells/OBATableViewCell.h
+++ b/ui/static_table/cells/OBATableViewCell.h
@@ -10,5 +10,13 @@
 #import "OBATableCell.h"
 
 @interface OBATableViewCell : UITableViewCell<OBATableCell>
+@end
 
+@interface OBATableViewCellValue1 : OBATableViewCell
+@end
+
+@interface OBATableViewCellValue2 : OBATableViewCell
+@end
+
+@interface OBATableViewCellSubtitle : OBATableViewCell
 @end

--- a/ui/static_table/cells/OBATableViewCell.m
+++ b/ui/static_table/cells/OBATableViewCell.m
@@ -40,3 +40,36 @@
     return (OBATableRow*)self.tableRow;
 }
 @end
+
+@implementation OBATableViewCellValue1
+- (instancetype)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier {
+    self = [super initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:reuseIdentifier];
+
+    if (self) {
+        // no-op, i suppose?
+    }
+    return self;
+}
+@end
+
+@implementation OBATableViewCellValue2
+- (instancetype)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier {
+    self = [super initWithStyle:UITableViewCellStyleValue2 reuseIdentifier:reuseIdentifier];
+
+    if (self) {
+        // no-op, i suppose?
+    }
+    return self;
+}
+@end
+
+@implementation OBATableViewCellSubtitle
+- (instancetype)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier {
+    self = [super initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:reuseIdentifier];
+
+    if (self) {
+        // no-op, i suppose?
+    }
+    return self;
+}
+@end

--- a/ui/static_table/viewmodels/OBABaseRow.h
+++ b/ui/static_table/viewmodels/OBABaseRow.h
@@ -33,4 +33,11 @@
 
 + (void)registerViewsWithTableView:(UITableView*)tableView;
 + (NSString*)cellReuseIdentifier;
+
+/**
+ By default, this simply returns the class method of the same name. However,
+ this gives you the ability to return different cellReuseIdentifiers based
+ upon different configurations of your table row.
+ */
+- (NSString*)cellReuseIdentifier;
 @end

--- a/ui/static_table/viewmodels/OBABaseRow.m
+++ b/ui/static_table/viewmodels/OBABaseRow.m
@@ -48,4 +48,8 @@
     return NSStringFromClass(self.class);
 }
 
+- (NSString*)cellReuseIdentifier {
+    return [self.class cellReuseIdentifier];
+}
+
 @end

--- a/ui/static_table/viewmodels/OBATableRow.m
+++ b/ui/static_table/viewmodels/OBATableRow.m
@@ -10,6 +10,11 @@
 #import "OBAViewModelRegistry.h"
 #import "OBATableViewCell.h"
 
+static NSString * const OBACellStyleDefaultReuseIdentifier = @"OBAUITableViewCellStyleDefaultCellIdentifier";
+static NSString * const OBACellStyleValue1ReuseIdentifier = @"OBACellStyleValue1ReuseIdentifier";
+static NSString * const OBACellStyleValue2ReuseIdentifier = @"OBACellStyleValue2ReuseIdentifier";
+static NSString * const OBACellStyleSubtitleReuseIdentifier = @"OBACellStyleSubtitleReuseIdentifier";
+
 @implementation OBATableRow
 
 + (void)load {
@@ -45,10 +50,23 @@
 #pragma mark - Public
 
 + (void)registerViewsWithTableView:(UITableView *)tableView {
-    [tableView registerClass:[OBATableViewCell class] forCellReuseIdentifier:[self cellReuseIdentifier]];
+    [tableView registerClass:[OBATableViewCell class] forCellReuseIdentifier:OBACellStyleDefaultReuseIdentifier];
+    [tableView registerClass:[OBATableViewCellValue1 class] forCellReuseIdentifier:OBACellStyleValue1ReuseIdentifier];
+    [tableView registerClass:[OBATableViewCellValue2 class] forCellReuseIdentifier:OBACellStyleValue2ReuseIdentifier];
+    [tableView registerClass:[OBATableViewCellSubtitle class] forCellReuseIdentifier:OBACellStyleSubtitleReuseIdentifier];
 }
 
-+ (NSString*)cellReuseIdentifier {
-    return NSStringFromClass(self.class);
+- (NSString*)cellReuseIdentifier {
+    switch (self.style) {
+        case UITableViewCellStyleValue1:
+            return OBACellStyleValue1ReuseIdentifier;
+        case UITableViewCellStyleValue2:
+            return OBACellStyleValue2ReuseIdentifier;
+        case UITableViewCellStyleSubtitle:
+            return OBACellStyleSubtitleReuseIdentifier;
+        case UITableViewCellStyleDefault:
+        default:
+            return OBACellStyleDefaultReuseIdentifier;
+    }
 }
 @end

--- a/ui/stops/OBAParallaxTableHeaderView.h
+++ b/ui/stops/OBAParallaxTableHeaderView.h
@@ -13,6 +13,4 @@
 @interface OBAParallaxTableHeaderView : UIView
 @property(nonatomic,assign) BOOL highContrastMode;
 - (void)populateTableHeaderFromArrivalsAndDeparturesModel:(OBAArrivalsAndDeparturesForStopV2*)result;
-- (void)loadETAToLocation:(CLLocationCoordinate2D)coordinate;
-- (void)requestsPresentationOfViewController:(void (^)(UIViewController*))presenter;
 @end

--- a/ui/stops/OBAStopViewController.m
+++ b/ui/stops/OBAStopViewController.m
@@ -149,7 +149,6 @@ static CGFloat const kTableHeaderHeight = 150.f;
 
         [self populateTableFromArrivalsAndDeparturesModel:self.arrivalsAndDepartures];
         [self.parallaxHeaderView populateTableHeaderFromArrivalsAndDeparturesModel:self.arrivalsAndDepartures];
-        [self.parallaxHeaderView loadETAToLocation:self.arrivalsAndDepartures.stop.coordinate];
     }).catch(^(NSError *error) {
         message = error.localizedDescription ?: NSLocalizedString(@"Error connecting", @"requestDidFail");
         // TODO: show an error!
@@ -378,9 +377,6 @@ static CGFloat const kTableHeaderHeight = 150.f;
 - (void)createTableHeaderView {
     self.parallaxHeaderView = [[OBAParallaxTableHeaderView alloc] initWithFrame:CGRectMake(0, 0, CGRectGetWidth(self.tableView.frame), kTableHeaderHeight)];
     self.parallaxHeaderView.highContrastMode = [[OBAApplication sharedApplication] useHighContrastUI];
-    [self.parallaxHeaderView requestsPresentationOfViewController:^(UIViewController* viewController) {
-        [self.navigationController pushViewController:viewController animated:YES];
-    }];
 
 #if ENABLE_PARALLAX_WHICH_NEEDS_FIXING
     [self.tableView addSubview:self.parallaxHeaderView];


### PR DESCRIPTION
Create three new table row classes for each cell style

* Cell reuse identifiers are now determined on an object instance basis, instead of a class basis.
* The specified cell style on an OBATableRow now works correctly.

---

Get Walking Directions to Stops

* Tapping the 'distance/time' label in the header of a stop opens Apple Maps and gives you walking directions
* Stop publicly exposing -loadETAToLocation: - it isn't necessary