### PR TITLE
Display Bookmarks on a Per-Region Basis

### DIFF
--- a/OBAKit/Models/dao/OBAModelDAO.h
+++ b/OBAKit/Models/dao/OBAModelDAO.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
     OBARegionV2 * _region;
     NSMutableArray * _mostRecentCustomApiUrls;
 }
-@property(nonatomic,strong,readonly,nullable) NSArray<OBABookmarkV2*> *bookmarksForCurrentRegion;
+@property(nonatomic,strong,readonly) NSArray<OBABookmarkV2*> *bookmarksForCurrentRegion;
 @property(weak, nonatomic,readonly) NSArray * bookmarks;
 @property(weak, nonatomic,readonly) NSArray * bookmarkGroups;
 @property(weak, nonatomic,readonly) NSArray * mostRecentStops;
@@ -44,7 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic,readonly) OBARegionV2 * region;
 @property(weak, nonatomic,readonly) NSArray * mostRecentCustomApiUrls;
 
-- (OBABookmarkV2*) createTransientBookmark:(OBAStopV2*)stop;
+- (OBABookmarkV2*)createTransientBookmark:(OBAStopV2*)stop;
 - (OBABookmarkV2*)bookmarkForStop:(OBAStopV2*)stop;
 - (void) addNewBookmark:(OBABookmarkV2*)bookmark;
 - (void) saveExistingBookmark:(OBABookmarkV2*)bookmark;

--- a/OBAKit/Models/dao/OBAModelDAO.m
+++ b/OBAKit/Models/dao/OBAModelDAO.m
@@ -80,7 +80,7 @@ const NSInteger kMaxEntriesInMostRecentList = 10;
         return [self.bookmarks filteredArrayUsingPredicate:predicate];
     }
     else {
-        return nil;
+        return @[];
     }
 }
 
@@ -129,18 +129,7 @@ const NSInteger kMaxEntriesInMostRecentList = 10;
 #pragma mark - Bookmarks
 
 - (OBABookmarkV2*)createTransientBookmark:(OBAStopV2*)stop {
-    OBABookmarkV2 * bookmark = [[OBABookmarkV2 alloc] init];
-    NSString * bookmarkName = stop.name;
-    if (stop.direction) {
-        bookmarkName = [NSString stringWithFormat:@"%@ [%@]",stop.name,stop.direction];
-    }
-    bookmark.name = bookmarkName;
-    bookmark.stopID = stop.stopId;
-    // Info: https://github.com/OneBusAway/onebusaway-iphone/issues/457
-//    bookmark.routeID = TODO - SOME WAY TO GET A ROUTE ID
-//    bookmark.headsign = stop.
-    bookmark.regionIdentifier = self.region ? self.region.identifier : NSNotFound;
-
+    OBABookmarkV2 * bookmark = [[OBABookmarkV2 alloc] initWithStop:stop region:self.region];
     return bookmark;
 }
 

--- a/OBAKit/Models/unmanaged/OBABookmarkV2.h
+++ b/OBAKit/Models/unmanaged/OBABookmarkV2.h
@@ -1,13 +1,20 @@
+#import <Foundation/Foundation.h>
+#import <MapKit/MapKit.h>
+
+@class OBARegionV2;
+@class OBAStopV2;
 @class OBABookmarkGroup;
-@import Foundation;
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface OBABookmarkV2 : NSObject<NSCoding>
+@interface OBABookmarkV2 : NSObject<NSCoding,MKAnnotation>
 @property(nonatomic,copy) NSString *name;
 @property(nonatomic,copy) NSString *stopID;
 @property(nonatomic,strong,nullable) OBABookmarkGroup *group;
 @property(nonatomic,assign) NSInteger regionIdentifier;
+@property(nonatomic,assign,readwrite) CLLocationCoordinate2D coordinate;
+
+- (instancetype)initWithStop:(OBAStopV2*)stop region:(OBARegionV2*)region;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/OBAKit/Models/unmanaged/OBABookmarkV2.m
+++ b/OBAKit/Models/unmanaged/OBABookmarkV2.m
@@ -1,16 +1,34 @@
 #import "OBABookmarkV2.h"
+#import "OBAStopV2.h"
+#import "OBARegionV2.h"
 
-#define IDENTIFIER_SEL NSStringFromSelector(@selector(regionIdentifier))
-#define NAME_SEL NSStringFromSelector(@selector(name))
-#define STOP_ID_SEL NSStringFromSelector(@selector(stopID))
+static NSString * const kRegionIdentifier = @"regionIdentifier";
+static NSString * const kName = @"name";
+static NSString * const kStopID = @"stopID";
+static NSString * const kLatitude = @"latitude";
+static NSString * const kLongitude = @"longitude";
 
 @implementation OBABookmarkV2
 
-#pragma mark - NSCoder
+- (instancetype)initWithStop:(OBAStopV2*)stop region:(OBARegionV2*)region {
+    self = [self init];
+
+    if (self) {
+        _name = stop.direction ? [NSString stringWithFormat:@"%@ [%@]",stop.name,stop.direction] : [stop.name copy];
+        _stopID = [stop.stopId copy];
+        _coordinate = stop.coordinate;
+        //    bookmark.routeID = TODO - SOME WAY TO GET A ROUTE ID
+        //    bookmark.headsign = stop.
+        _regionIdentifier = region.identifier;
+    }
+    return self;
+}
+
+#pragma mark - NSCoding
 
 - (id)initWithCoder:(NSCoder*)coder {
     if (self = [super init]) {
-        _name = [coder decodeObjectForKey:NAME_SEL];
+        _name = [coder decodeObjectForKey:kName];
 
         // Handle legacy bookmark models.
         NSArray *stopIds = [coder decodeObjectForKey:@"stopIds"];
@@ -18,28 +36,47 @@
             _stopID = stopIds[0];
         }
         else {
-            _stopID = [coder decodeObjectForKey:STOP_ID_SEL];
+            _stopID = [coder decodeObjectForKey:kStopID];
         }
 
         // Normally, we'd simply try decoding the object and use the fact that
-        // nil would simply resolve to 0, but the Tampa region has the ID of 0,
-        // so we're stuck trying to be clever here to work around that issue.
-        if ([coder containsValueForKey:IDENTIFIER_SEL]) {
-            _regionIdentifier = [coder decodeIntegerForKey:IDENTIFIER_SEL];
+        // nil would simply resolve to 0 to our advantage, but the Tampa region
+        // has the ID of 0, so we're stuck trying to be clever here to work
+        // around that issue.
+        if ([coder containsValueForKey:kRegionIdentifier]) {
+            _regionIdentifier = [coder decodeIntegerForKey:kRegionIdentifier];
         }
         else {
             _regionIdentifier = NSNotFound;
+        }
+
+        _coordinate = kCLLocationCoordinate2DInvalid;
+        if ([coder containsValueForKey:kLatitude] && [coder containsValueForKey:kLongitude]) {
+            _coordinate = CLLocationCoordinate2DMake([coder decodeDoubleForKey:kLatitude], [coder decodeDoubleForKey:kLongitude]);
         }
     }
     return self;
 }
 
-
 - (void)encodeWithCoder:(NSCoder*)coder {
-    [coder encodeObject:_name forKey:NAME_SEL];
-    [coder encodeObject:_stopID forKey:STOP_ID_SEL];
-    [coder encodeInteger:_regionIdentifier forKey:IDENTIFIER_SEL];
+    [coder encodeObject:_name forKey:kName];
+    [coder encodeObject:_stopID forKey:kStopID];
+    [coder encodeInteger:_regionIdentifier forKey:kRegionIdentifier];
+    [coder encodeDouble:_coordinate.latitude forKey:kLatitude];
+    [coder encodeDouble:_coordinate.longitude forKey:kLongitude];
 }
+
+#pragma mark - MKAnnotation
+
+- (NSString*)title {
+    return self.name;
+}
+
+- (NSString*)subtitle {
+    return @"TBD!";
+}
+
+#pragma mark - NSObject
 
 - (NSString*)description {
     return [NSString stringWithFormat:@"<%@: %p> :: {name: %@, group: %@, stopID: %@, regionIdentifier: %@}", self.class, self, self.name, self.group, self.stopID, @(self.regionIdentifier)];

--- a/ui/bookmarks/OBABookmarksViewController.m
+++ b/ui/bookmarks/OBABookmarksViewController.m
@@ -68,11 +68,16 @@
     for (OBABookmarkGroup *group in modelDAO.bookmarkGroups) {
         NSArray *rows = [self tableRowsFromBookmarks:group.bookmarks];
         OBATableSection *section = [[OBATableSection alloc] initWithTitle:group.name rows:rows];
-        [sections addObject:section];
+
+        if (section.rows.count > 0) {
+            [sections addObject:section];
+        }
     }
 
-    OBATableSection *looseBookmarks = [[OBATableSection alloc] initWithTitle:nil rows:[self tableRowsFromBookmarks:modelDAO.bookmarks]];
-    [sections addObject:looseBookmarks];
+    OBATableSection *looseBookmarks = [[OBATableSection alloc] initWithTitle:NSLocalizedString(@"Ungrouped", @"") rows:[self tableRowsFromBookmarks:modelDAO.bookmarks]];
+    if (looseBookmarks.rows.count > 0) {
+        [sections addObject:looseBookmarks];
+    }
 
     self.sections = sections;
     [self.tableView reloadData];
@@ -84,14 +89,12 @@
     return YES;
 }
 
-// Disabled for now. This requires more time and attention than I can give it at the moment.
-// I'd love to re-enable this feature, and soon, though.
+// TODO: Disabled for now. This requires more time and attention than I can give it at the
+// moment. I'd love to re-enable this feature, and soon, though.
 - (BOOL)tableView:(UITableView*)tableView canMoveRowAtIndexPath:(NSIndexPath *)indexPath {
     return NO;
 }
 
-// After a row has the minus or plus button invoked (based on the UITableViewCellEditingStyle for the cell), the dataSource must commit the change
-// Not called for edit actions using UITableViewRowAction - the action's handler will be invoked instead
 - (void)tableView:(UITableView *)tableView commitEditingStyle:(UITableViewCellEditingStyle)editingStyle forRowAtIndexPath:(NSIndexPath *)indexPath {
 
     OBATableSection *tableSection = self.sections[indexPath.section];
@@ -120,6 +123,15 @@
     NSMutableArray *rows = [NSMutableArray array];
 
     for (OBABookmarkV2 *bm in bookmarks) {
+
+        if (bm.regionIdentifier != NSNotFound && bm.regionIdentifier != [self currentRegion].identifier) {
+            // We are special-casing bookmarks that don't have a region set on them, as there's no way to know
+            // for sure which region they belong to. However, if this bookmark has a valid regionIdentifier and
+            // the current region's identifier doesn't match the bookmark, then this bookmark belongs to a
+            // different region. Skip it.
+            continue;
+        }
+
         OBATableRow *row = [[OBATableRow alloc] initWithTitle:bm.name action:^{
             OBAStopViewController *controller = [[OBAStopViewController alloc] initWithStopID:bm.stopID];
             [self.navigationController pushViewController:controller animated:YES];

--- a/ui/search/OBASearchResultsMapViewController.m
+++ b/ui/search/OBASearchResultsMapViewController.m
@@ -853,8 +853,11 @@ static const double kStopsInRegionRefreshDelayOnDrag = 0.1;
 }
 
 - (NSArray*)bookmarkAnnotations {
-    NSArray *bookmarks = [OBAApplication sharedApplication].modelDao.bookmarks;
-
+//    NSArray *bookmarks = [OBAApplication sharedApplication].modelDao.bookmarksForCurrentRegion;
+//
+//    return [bookmarks filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(OBABookmarkV2* bookmark, NSDictionary *bindings) {
+//        return CLLocationCoordinate2DIsValid(bookmark.coordinate) && bookmark.coordinate.latitude != 0 && bookmark.coordinate.longitude != 0;
+//    }]];
     return @[];
 }
 

--- a/ui/stops/OBAStopViewController.m
+++ b/ui/stops/OBAStopViewController.m
@@ -147,11 +147,15 @@ static CGFloat const kTableHeaderHeight = 150.f;
 
         self.arrivalsAndDepartures = response;
 
+        // This will update existing bookmarks as they are accessed and ensure
+        // that they have the correct coordinate and region set on them.
+        [OBAStopViewController updateBookmarkForStop:self.arrivalsAndDepartures.stop inModelDAO:[OBAApplication sharedApplication].modelDao];
+
         [self populateTableFromArrivalsAndDeparturesModel:self.arrivalsAndDepartures];
         [self.parallaxHeaderView populateTableHeaderFromArrivalsAndDeparturesModel:self.arrivalsAndDepartures];
     }).catch(^(NSError *error) {
         message = error.localizedDescription ?: NSLocalizedString(@"Error connecting", @"requestDidFail");
-        // TODO: show an error!
+        self.navigationItem.title = message;
     }).finally(^{
         if (animated) {
             [self.refreshControl endRefreshing];
@@ -402,6 +406,18 @@ static CGFloat const kTableHeaderHeight = 150.f;
     }
 
     return NO;
+}
+
+#pragma mark - Private
+
++ (void)updateBookmarkForStop:(OBAStopV2*)stop inModelDAO:(OBAModelDAO*)modelDAO {
+    OBABookmarkV2 *bookmark = [modelDAO bookmarkForStop:stop];
+
+    if (bookmark) {
+        bookmark.coordinate = stop.coordinate;
+        bookmark.regionIdentifier = modelDAO.region.identifier;
+        [modelDAO saveExistingBookmark:bookmark];
+    }
 }
 
 @end


### PR DESCRIPTION
Fixes #120 - bookmarks should be on a per-region basis (https://github.com/OneBusAway/onebusaway-iphone/issues/120)

* Only display bookmarks that belong to the current region (or don't have an assigned region)
* Create a new, more useful initializer for OBABookmarkV2
* Automatically update bookmarks with their region and coordinates as they're accessed
* Show a section title for ungrouped bookmarks
* Elide bookmark sections that don't contain any bookmarks