### PR TITLE
Fix #62 - Show stop icons at a higher zoom level

### DIFF
--- a/OBAKit/Helpers/OBAMapHelpers.m
+++ b/OBAKit/Helpers/OBAMapHelpers.m
@@ -17,7 +17,7 @@
 const double OBADefaultMapRadiusInMeters = 100;
 const double OBAMinMapRadiusInMeters = 150;
 //const double OBAMaxLatitudeDeltaToShowStops = 0.008;
-const double OBAMaxLatitudeDeltaToShowStops = 0.01;
+const double OBAMaxLatitudeDeltaToShowStops = 0.05;
 const double OBARegionScaleFactor = 1.5;
 const double OBAMaxMapDistanceFromCurrentLocationForNearby = 800;
 const double OBAPaddingScaleFactor = 1.075;


### PR DESCRIPTION
I bump the zoom level.

The furthest zoom level looks like this in the app:

![screen shot 2016-03-14 at 11 28 13 am](https://cloud.githubusercontent.com/assets/2777974/13751268/c41f4026-e9df-11e5-9d06-bf3f070fc3c1.png)

cc'd @barbeau 
