### PR TITLE
Add a message to the bookmark controller when it's empty

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -11,6 +11,7 @@ pod 'libextobjc', '0.4.1'
 pod 'SVProgressHUD', :git => "https://github.com/aaronbrethorst/SVProgressHUD.git"
 pod 'Masonry', '0.6.4'
 pod 'DateTools', '1.7.0'
+pod 'DZNEmptyDataSet', '1.7.3'
 
 # pod 'PromiseKit', '3.0.2'
 pod 'PromiseKit/CorePromise', '3.0.2'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,6 +1,7 @@
 PODS:
   - ABReleaseNotesViewController (0.1.0)
   - DateTools (1.7.0)
+  - DZNEmptyDataSet (1.7.3)
   - GoogleAnalytics (3.14.0)
   - libextobjc (0.4.1):
     - libextobjc/EXTADT (= 0.4.1)
@@ -60,6 +61,7 @@ PODS:
 DEPENDENCIES:
   - ABReleaseNotesViewController (= 0.1.0)
   - DateTools (= 1.7.0)
+  - DZNEmptyDataSet (= 1.7.3)
   - GoogleAnalytics (= 3.14.0)
   - libextobjc (= 0.4.1)
   - Masonry (= 0.6.4)
@@ -82,6 +84,7 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   ABReleaseNotesViewController: b378ca2ec9494027a8ea584320453a0697073e56
   DateTools: 53288ee8b905fdc75897a1e6b5cc0144b14cba60
+  DZNEmptyDataSet: dd7cca17c1d07dfa78956859b1e70a52505678ef
   GoogleAnalytics: 9be1afdb8deeac4bb5f13ca7f7d3b9db2a1f43dc
   libextobjc: a650fc1bf489a3d3a9bc2e621efa3e1006fc5471
   Masonry: 281802d04d787ea2973179ee8bcb50500579ede2

--- a/credits.html
+++ b/credits.html
@@ -69,6 +69,18 @@ Permissions beyond the scope of this license may be available at <a href = "http
 
         THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     </code>
+    <h1>DZNEmptyDataSet</h1>
+    <code>
+        (The MIT License)
+
+        Copyright (c) 2016 Ignacio Romero Zurbuchen iromero@dzen.cl
+
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+        The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+        THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    </code>
     <h1>SVProgressHUD</h1>
     <code>
         Copyright (c) 2011-2014 Sam Vermette

--- a/ui/bookmarks/OBABookmarksViewController.m
+++ b/ui/bookmarks/OBABookmarksViewController.m
@@ -7,12 +7,13 @@
 //
 
 #import "OBABookmarksViewController.h"
+#import <DZNEmptyDataSet/UIScrollView+EmptyDataSet.h>
 #import "OBAApplication.h"
 #import "OBABookmarkGroup.h"
 #import "OBAStopViewController.h"
 #import "OBAEditStopBookmarkViewController.h"
 
-@interface OBABookmarksViewController ()
+@interface OBABookmarksViewController ()<DZNEmptyDataSetSource, DZNEmptyDataSetDelegate>
 
 @end
 
@@ -32,6 +33,11 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+
+    // Set up the empty data set UI.
+    self.tableView.emptyDataSetSource = self;
+    self.tableView.emptyDataSetDelegate = self;
+    self.tableView.tableFooterView = [UIView new];
 
     self.tableView.allowsSelectionDuringEditing = YES;
     self.navigationItem.leftBarButtonItem = self.editButtonItem;
@@ -74,7 +80,7 @@
         }
     }
 
-    OBATableSection *looseBookmarks = [[OBATableSection alloc] initWithTitle:NSLocalizedString(@"Ungrouped", @"") rows:[self tableRowsFromBookmarks:modelDAO.bookmarks]];
+    OBATableSection *looseBookmarks = [[OBATableSection alloc] initWithTitle:NSLocalizedString(@"Bookmarks", @"") rows:[self tableRowsFromBookmarks:modelDAO.bookmarks]];
     if (looseBookmarks.rows.count > 0) {
         [sections addObject:looseBookmarks];
     }
@@ -109,6 +115,38 @@
     }
 
     [tableView deleteRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
+}
+
+#pragma mark - DZNEmptyDataSet
+
+- (NSAttributedString *)titleForEmptyDataSet:(UIScrollView *)scrollView {
+    NSString *text = NSLocalizedString(@"No Bookmarks", @"");
+
+    NSDictionary *attributes = @{NSFontAttributeName: [OBATheme titleFont],
+                                 NSForegroundColorAttributeName: [OBATheme darkDisabledColor]};
+
+    return [[NSAttributedString alloc] initWithString:text attributes:attributes];
+}
+
+- (NSAttributedString *)descriptionForEmptyDataSet:(UIScrollView *)scrollView
+{
+    NSString *text = NSLocalizedString(@"Tap 'Add to Bookmarks' from a stop to save a bookmark to this screen.", @"");
+
+    NSMutableParagraphStyle *paragraph = [NSMutableParagraphStyle new];
+    paragraph.lineBreakMode = NSLineBreakByWordWrapping;
+    paragraph.alignment = NSTextAlignmentCenter;
+
+    NSDictionary *attributes = @{NSFontAttributeName: [OBATheme bodyFont],
+                                 NSForegroundColorAttributeName: [OBATheme lightDisabledColor],
+                                 NSParagraphStyleAttributeName: paragraph};
+
+    return [[NSAttributedString alloc] initWithString:text attributes:attributes];
+}
+
+- (CGFloat)verticalOffsetForEmptyDataSet:(UIScrollView *)scrollView
+{
+    // Totally arbitrary value. It just 'looks right'.
+    return -44;
 }
 
 #pragma mark - Accessors

--- a/ui/themes/OBATheme.h
+++ b/ui/themes/OBATheme.h
@@ -68,6 +68,16 @@
 + (UIColor*)colorWithRed:(NSUInteger)red green:(NSUInteger)green blue:(NSUInteger)blue alpha:(CGFloat)alpha;
 
 /**
+ Use this for UI elements that are not enabled or non-interactable.
+ */
++ (UIColor*)darkDisabledColor;
+
+/**
+ Use this for UI elements that are not enabled or non-interactable.
+ */
++ (UIColor*)lightDisabledColor;
+
+/**
  Standard text color.
  */
 + (UIColor*)textColor;

--- a/ui/themes/OBATheme.m
+++ b/ui/themes/OBATheme.m
@@ -82,6 +82,14 @@ static UIFont *_boldFootnoteFont = nil;
     return [UIColor colorWithRed:((CGFloat)red / 255.f) green:((CGFloat)green / 255.f) blue:((CGFloat)blue / 255.f) alpha:alpha];
 }
 
++ (UIColor*)darkDisabledColor {
+    return [UIColor darkGrayColor];
+}
+
++ (UIColor*)lightDisabledColor {
+    return [UIColor grayColor];
+}
+
 + (UIColor*)textColor {
     return [UIColor blackColor];
 }


### PR DESCRIPTION
Fixes #557 - Empty Bookmarks View Controller Needs Some Sort of Message (https://github.com/OneBusAway/onebusaway-iphone/issues/557)

* Add DZNEmptyDataSet to the Pods (mentioned in the credits, too)
* Add light and dark disabled colors to the theme.
* Add a message to the Bookmarks view controller when it's empty that explains why it is empty and how to fix this.