### PR TITLE
Fix header issues in stop view when in landscape

### DIFF
--- a/ui/stops/OBAParallaxTableHeaderView.m
+++ b/ui/stops/OBAParallaxTableHeaderView.m
@@ -34,11 +34,12 @@
 
     if (self) {
         self.backgroundColor = [OBATheme backgroundColor];
+        self.clipsToBounds = YES;
 
         _headerImageView = ({
             UIImageView *imageView = [[UIImageView alloc] initWithFrame:self.bounds];
             imageView.backgroundColor = kHeaderImageViewBackgroundColor;
-            imageView.contentMode = UIViewContentModeScaleAspectFill;
+            imageView.contentMode = UIViewContentModeCenter;
             imageView.autoresizingMask = UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleHeight;
             imageView.alpha = 1.f;
             imageView;
@@ -85,8 +86,12 @@
     else {
         MKMapSnapshotter *snapshotter = ({
             MKMapSnapshotOptions *options = [[MKMapSnapshotOptions alloc] init];
-            options.region = [OBAMapHelpers coordinateRegionWithCenterCoordinate:self.stop.coordinate zoomLevel:15 viewSize:self.headerImageView.frame.size];
-            options.size = self.headerImageView.frame.size;
+
+            CGFloat squareDimension = MAX(CGRectGetWidth([UIScreen mainScreen].bounds), CGRectGetHeight([UIScreen mainScreen].bounds));
+            CGSize squareSize = CGSizeMake(squareDimension, squareDimension);
+
+            options.region = [OBAMapHelpers coordinateRegionWithCenterCoordinate:self.stop.coordinate zoomLevel:15 viewSize:squareSize];
+            options.size = squareSize;
             options.scale = [[UIScreen mainScreen] scale];
             [[MKMapSnapshotter alloc] initWithOptions:options];
         });


### PR DESCRIPTION
Fixes #566 - Rotation Issues on the Stop UI (https://github.com/OneBusAway/onebusaway-iphone/issues/566)

* Clip the stop header view to its bounds, which fixes the most serious issue: overlapping content
* Calculate a larger header image size that is capable of fitting itself to the bounds of the header in portrait and landscape, and use that as the header background instead.