### PR TITLE
Fix #565 -  Refresh stops rendering when zoom level change

### DIFF
--- a/OBAKit/Helpers/OBAMapHelpers.h
+++ b/OBAKit/Helpers/OBAMapHelpers.h
@@ -15,6 +15,7 @@ extern const double OBAMaxLatitudeDeltaToShowStops;
 extern const double OBARegionScaleFactor;
 extern const double OBAMaxMapDistanceFromCurrentLocationForNearby;
 extern const double OBAPaddingScaleFactor;
+extern const double OBARegionZoomLevelThreshold;
 
 @class OBAPlacemark;
 @class OBARegionBoundsV2;
@@ -105,4 +106,5 @@ NSInteger OBASortStopsByDistanceFromLocation(OBAStopV2 *stop1, OBAStopV2 *stop2,
 + (MKCoordinateRegion)computeRegionForNClosestStops:(NSArray *)stops center:(CLLocation *)location numberOfStops:(NSUInteger)numberOfStops;
 + (MKCoordinateRegion)computeRegionForStops:(NSArray*)stops;
 + (MKCoordinateRegion)computeRegionForCenter:(CLLocation*)center nearbyStops:(NSArray*)stops;
++ (NSUInteger)zoomLevelForMapRect:(MKMapRect)mRect withMapViewSizeInPixels:(CGSize)viewSizeInPixels;
 @end

--- a/OBAKit/Helpers/OBAMapHelpers.m
+++ b/OBAKit/Helpers/OBAMapHelpers.m
@@ -19,11 +19,13 @@ const double OBAMinMapRadiusInMeters = 150;
 //const double OBAMaxLatitudeDeltaToShowStops = 0.008;
 const double OBAMaxLatitudeDeltaToShowStops = 0.05;
 const double OBARegionScaleFactor = 1.5;
+const double OBARegionZoomLevelThreshold = 1;
 const double OBAMaxMapDistanceFromCurrentLocationForNearby = 800;
 const double OBAPaddingScaleFactor = 1.075;
 
 #define MERCATOR_OFFSET 268435456
 #define MERCATOR_RADIUS 85445659.44705395
+#define MAXIMUM_ZOOM                20
 
 NSInteger OBASortStopsByDistanceFromLocation(OBAStopV2 *stop1, OBAStopV2 *stop2, void *context) {
     CLLocation *location = (__bridge CLLocation *)context;
@@ -280,4 +282,14 @@ NSInteger OBASortStopsByDistanceFromLocation(OBAStopV2 *stop1, OBAStopV2 *stop2,
         return [OBAMapHelpers computeRegionForStops:stops];
     }
 }
+
++ (NSUInteger)zoomLevelForMapRect:(MKMapRect)mRect withMapViewSizeInPixels:(CGSize)viewSizeInPixels
+{
+    NSUInteger zoomLevel = MAXIMUM_ZOOM;
+    MKZoomScale zoomScale = mRect.size.width / viewSizeInPixels.width; //MKZoomScale is just a CGFloat typedef
+    double zoomExponent = log2(zoomScale);
+    zoomLevel = (NSUInteger)(MAXIMUM_ZOOM - ceil(zoomExponent));
+    return zoomLevel;
+}
+
 @end

--- a/ui/search/OBASearchResultsMapViewController.h
+++ b/ui/search/OBASearchResultsMapViewController.h
@@ -31,6 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic,strong) IBOutlet UIToolbar *toolbar;
 @property(nonatomic,strong) IBOutlet UILabel *mapLabel;
 
+
 - (IBAction)onCrossHairsButton:(id)sender;
 - (IBAction)showListView:(id)sender;
 


### PR DESCRIPTION
Added a zoom level control that updates stops when the zoom level changes:

```
if (!moreAccurateRegion && containedRegion && !zoomLevelChanged) {
          NSString *label = [self computeLabelForCurrentResults];
          [self applyMapLabelWithText:label];
          return;  // Do NOT update stops
}
```
cc'd @aaronbrethorst @barbeau 