### PR TITLE
Add a special-case decode for bookmarks' stop IDs

### DIFF
--- a/OBAKit/Models/unmanaged/OBABookmarkV2.m
+++ b/OBAKit/Models/unmanaged/OBABookmarkV2.m
@@ -34,6 +34,12 @@ static NSString * const kStop = @"stop";
         if (stopIds && stopIds.count > 0) {
             _stopId = stopIds[0];
         }
+        else if ([coder containsValueForKey:@"stopID"]) {
+            // TODO: remove this block of code once 2.5.1 ships.
+            // It's the result of a dumb bug I introduced in one
+            // beta version of 2.5.0.
+            _stopId = [coder decodeObjectForKey:@"stopID"];
+        }
         else {
             _stopId = [coder decodeObjectForKey:kStopId];
         }


### PR DESCRIPTION
Fixes #572 - The latest build of OBA eats older bookmarks (https://github.com/OneBusAway/onebusaway-iphone/issues/572)

Also, add a special case to fix the name of bookmarks saved with the last beta build of OBA 2.5.0.