### PR TITLE
Set 'required' as the content compression resistance priority for left and right labels on departure cells

### DIFF
--- a/ui/stops/OBAClassicDepartureCell.m
+++ b/ui/stops/OBAClassicDepartureCell.m
@@ -46,6 +46,7 @@
             l.minimumScaleFactor = 0.8f;
             l.adjustsFontSizeToFitWidth = YES;
             l.font = [OBATheme bodyFont];
+            [l setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
 
             if (kUseDebugColors) {
                 l.backgroundColor = [UIColor greenColor];
@@ -89,6 +90,7 @@
             l.adjustsFontSizeToFitWidth = YES;
             l.font = [OBATheme bodyFont];
             l.textAlignment = NSTextAlignmentRight;
+            [l setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
 
             if (kUseDebugColors) {
                 l.backgroundColor = [UIColor yellowColor];


### PR DESCRIPTION
Fixes #577 - Layout issues with long destination description (https://github.com/OneBusAway/onebusaway-iphone/issues/577)