### PR TITLE
Make sure bookmarks that aren't in groups show up on the map

### DIFF
--- a/OBAKit/Models/dao/OBAModelDAO.m
+++ b/OBAKit/Models/dao/OBAModelDAO.m
@@ -85,7 +85,7 @@ const NSInteger kMaxEntriesInMostRecentList = 10;
 }
 
 - (NSArray*)allBookmarks {
-    NSMutableArray *all = [[NSMutableArray alloc] init];
+    NSMutableArray *all = [[NSMutableArray alloc] initWithArray:self.bookmarks];
     for (OBABookmarkGroup *group in self.bookmarkGroups) {
         [all addObjectsFromArray:group.bookmarks];
     }


### PR DESCRIPTION
Only bookmarks in groups were appearing on the map. This corrects that defect.