### PR TITLE
Add an Info.plist flag to suppress an iTC question

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -33,6 +33,8 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>20160317.23</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>fb</string>


### PR DESCRIPTION
This flag should stop iTunes Connect from asking me on every TestFlight submission as to whether or not I've started using crypto in OBA.