### PR TITLE
Bug fixes

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.5.1</string>
+	<string>2.6.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/OBAKit/Info.plist
+++ b/OBAKit/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.5.1</string>
+	<string>2.6.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/ui/search/OBASearchResultsMapViewController.m
+++ b/ui/search/OBASearchResultsMapViewController.m
@@ -50,6 +50,7 @@ static const double kStopsInRegionRefreshDelayOnDrag = 0.1;
 @property(nonatomic,assign) BOOL secondSearchTry;
 @property(nonatomic,strong) OBANavigationTarget *savedNavigationTarget;
 @property(nonatomic,strong) UIView *titleView;
+@property(nonatomic,strong) MKUserTrackingBarButtonItem *trackingBarButtonItem;
 @end
 
 @implementation OBASearchResultsMapViewController
@@ -110,7 +111,7 @@ static const double kStopsInRegionRefreshDelayOnDrag = 0.1;
         self.savedNavigationTarget = nil;
     }
 
-    self.navigationItem.leftBarButtonItem = [self getArrowButton];
+    self.navigationItem.leftBarButtonItem = self.trackingBarButtonItem;
 
     self.listBarButtonItem = [[UIBarButtonItem alloc] initWithImage:[UIImage imageNamed:@"lines"] style:UIBarButtonItemStylePlain target:self action:@selector(showListView:)];
     self.listBarButtonItem.accessibilityLabel = NSLocalizedString(@"Nearby stops list", @"self.listBarButtonItem.accessibilityLabel");
@@ -183,7 +184,7 @@ static const double kStopsInRegionRefreshDelayOnDrag = 0.1;
 
 - (BOOL)searchBarShouldEndEditing:(UISearchBar *)searchBar {
     [self.navigationItem setRightBarButtonItem:self.listBarButtonItem animated:YES];
-    [self.navigationItem setLeftBarButtonItem:[self getArrowButton] animated:YES];
+    [self.navigationItem setLeftBarButtonItem:self.trackingBarButtonItem animated:YES];
     [searchBar setShowsCancelButton:NO animated:YES];
     [self animateOutScopeView];
 
@@ -1243,12 +1244,11 @@ static const double kStopsInRegionRefreshDelayOnDrag = 0.1;
     self.scopeView.tintColor = nil;
 }
 
-- (UIBarButtonItem *)getArrowButton {
-    UIBarButtonItem *arrowButton = [[UIBarButtonItem alloc] initWithImage:[UIImage imageNamed:@"lbs_arrow"] style:UIBarButtonItemStylePlain target:self action:@selector(onCrossHairsButton:)];
-
-    arrowButton.accessibilityLabel = NSLocalizedString(@"my location", @"arrowButton.accessibilityLabel");
-    arrowButton.accessibilityHint = NSLocalizedString(@"centers the map on current location", @"arrowButton.accessibilityHint");
-    return arrowButton;
+- (MKUserTrackingBarButtonItem*)trackingBarButtonItem {
+    if (!_trackingBarButtonItem) {
+        _trackingBarButtonItem = [[MKUserTrackingBarButtonItem alloc] initWithMapView:self.mapView];
+    }
+    return _trackingBarButtonItem;
 }
 
 @end

--- a/ui/stops/OBAParallaxTableHeaderView.m
+++ b/ui/stops/OBAParallaxTableHeaderView.m
@@ -60,7 +60,6 @@
             [label setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisVertical];
 
             label.userInteractionEnabled = YES;
-            label.text = NSLocalizedString(@"Determining walk time ", @"");
             label;
         });
 

--- a/ui/stops/OBAStopViewController.m
+++ b/ui/stops/OBAStopViewController.m
@@ -31,7 +31,6 @@ static NSTimeInterval const kRefreshTimeInterval = 30.0;
 static CGFloat const kTableHeaderHeight = 150.f;
 
 @interface OBAStopViewController ()<UIScrollViewDelegate>
-@property(nonatomic,strong) UIRefreshControl *refreshControl;
 @property(nonatomic,strong) NSTimer *refreshTimer;
 @property(nonatomic,strong) NSLock *reloadLock;
 @property(nonatomic,strong) OBAArrivalsAndDeparturesForStopV2 *arrivalsAndDepartures;
@@ -69,14 +68,12 @@ static CGFloat const kTableHeaderHeight = 150.f;
     self.tableView.contentOffset = CGPointMake(0, -kTableHeaderHeight);
 #endif
 
-    self.refreshControl = [[UIRefreshControl alloc] init];
-    [self.refreshControl addTarget:self action:@selector(reloadData:) forControlEvents:UIControlEventValueChanged];
-    [self.tableView addSubview:self.refreshControl];
+    self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemRefresh target:self action:@selector(reloadData:)];
 }
 
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
-    
+
     self.refreshTimer = [NSTimer scheduledTimerWithTimeInterval:kRefreshTimeInterval target:self selector:@selector(reloadData:) userInfo:nil repeats:YES];
 
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(willEnterForeground:) name:UIApplicationWillEnterForegroundNotification object:nil];
@@ -137,10 +134,6 @@ static CGFloat const kTableHeaderHeight = 150.f;
         return;
     }
 
-    if (animated) {
-        [self.refreshControl beginRefreshing];
-    }
-    
     __block NSString *message = nil;
     [[OBAApplication sharedApplication].modelService requestStopForID:self.stopID minutesBefore:self.minutesBefore minutesAfter:self.minutesAfter].then(^(OBAArrivalsAndDeparturesForStopV2 *response) {
         self.navigationItem.title = [NSString stringWithFormat:@"%@: %@", NSLocalizedString(@"Updated", @"message"), [OBACommon getTimeAsString]];
@@ -158,9 +151,6 @@ static CGFloat const kTableHeaderHeight = 150.f;
         message = error.localizedDescription ?: NSLocalizedString(@"Error connecting", @"requestDidFail");
         self.navigationItem.title = message;
     }).finally(^{
-        if (animated) {
-            [self.refreshControl endRefreshing];
-        }
         [self.reloadLock unlock];
     });
 }

--- a/ui/stops/OBAStopViewController.m
+++ b/ui/stops/OBAStopViewController.m
@@ -92,6 +92,11 @@ static CGFloat const kTableHeaderHeight = 150.f;
 #pragma mark - Notifications
 
 - (void)willEnterForeground:(NSNotification*)note {
+
+    // First, reload the table so that times adjust properly.
+    [self.tableView reloadData];
+
+    // And then reload remote data.
     [self reloadData:nil];
 }
 


### PR DESCRIPTION
A bunch of fixes for issues in the 2.6.0 milestone:

* Replace the pull to refresh control in Stops with a button again - Fixes #580 - Revert Stop Controller to a Refresh Button
* Remove the placeholder text for walk distance/time calculation, which is useless and just kind of annoying.
* Change tack, rev version number from 2.5.1 to 2.6.0. Let's go all-in - No bug fix release!
* Reload the Stop tableview as soon as the app returns to the foreground - Fixes #587 - Stop info doesn't refresh until new data is pulled from server
* Replace the map arrow button with a MKUserTrackingBarButtonItem  - Fixes #432 - Location button stays solid even when not tracking