### PR TITLE
Fix crash when viewing agencies on map

### DIFF
--- a/ui/search/OBASearchResultsMapViewController.m
+++ b/ui/search/OBASearchResultsMapViewController.m
@@ -836,20 +836,22 @@ static const double kStopsInRegionRefreshDelayOnDrag = 0.1;
    consider going forward. */
 + (void)setAnnotationsForMapView:(MKMapView*)mapView fromSearchResult:(OBASearchResult*)result bookmarkAnnotations:(NSArray*)bookmarks {
     NSMutableArray *allCurrentAnnotations = [[NSMutableArray alloc] init];
-    [allCurrentAnnotations addObjectsFromArray:bookmarks];
-
-    if (result.values.count > 0) {
-        @autoreleasepool {
-            NSPredicate *predicate = [NSPredicate predicateWithFormat:@"NOT (stopId IN %@)", [bookmarks valueForKey:@"stopId"]];
-            [allCurrentAnnotations addObjectsFromArray:[result.values filteredArrayUsingPredicate:predicate]];
-        }
-    }
 
     if (result.searchType == OBASearchTypeAgenciesWithCoverage) {
         for (OBAAgencyWithCoverageV2 *agencyWithCoverage in result.values) {
             OBAAgencyV2 *agency = agencyWithCoverage.agency;
             OBANavigationTargetAnnotation *an = [[OBANavigationTargetAnnotation alloc] initWithTitle:agency.name subtitle:nil coordinate:agencyWithCoverage.coordinate target:nil];
             [allCurrentAnnotations addObject:an];
+        }
+    }
+    else {
+        [allCurrentAnnotations addObjectsFromArray:bookmarks];
+
+        if (result.values.count > 0) {
+            @autoreleasepool {
+                NSPredicate *predicate = [NSPredicate predicateWithFormat:@"NOT (stopId IN %@)", [bookmarks valueForKey:@"stopId"]];
+                [allCurrentAnnotations addObjectsFromArray:[result.values filteredArrayUsingPredicate:predicate]];
+            }
         }
     }
 


### PR DESCRIPTION
Fix crash when viewing agencies on map by checking searchType before assuming results have stopId field. Fixes #619 


This change assumes bookmarks should not be shown when agencies are being shown.
If bookmarks and agencies should be shown at the same time, the following changes should be made to this PR:
- original line 839 should not be removed
- new line 848 should be removed
- new line 847 can be combined with new line 850 to create an else if statement