### PR TITLE
Fix #624 - Add analytics to the service alerts button

### DIFF
--- a/OBAKit/Models/unmanaged/OBAReferencesV2.h
+++ b/OBAKit/Models/unmanaged/OBAReferencesV2.h
@@ -17,6 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void) addAgency:(OBAAgencyV2*)agency;
 - (OBAAgencyV2*) getAgencyForId:(NSString*)agencyId;
+- (NSDictionary*) getAllAgencies;
 
 - (void) addRoute:(OBARouteV2*)route;
 - (OBARouteV2*) getRouteForId:(NSString*)routeId;

--- a/OBAKit/Models/unmanaged/OBAReferencesV2.m
+++ b/OBAKit/Models/unmanaged/OBAReferencesV2.m
@@ -27,7 +27,11 @@
 
 - (OBAAgencyV2*) getAgencyForId:(NSString*)agencyId {
     return _agencies[agencyId];
-}    
+}
+
+- (NSDictionary*) getAllAgencies {
+    return [NSDictionary dictionaryWithDictionary:_agencies];;
+}
 
 - (void) addRoute:(OBARouteV2*)route {
     _routes[route.routeId] = route;

--- a/ui/situations/OBASituationsViewController.m
+++ b/ui/situations/OBASituationsViewController.m
@@ -12,6 +12,7 @@
 #import "UITableViewController+oba_Additions.h"
 #import "UITableViewCell+oba_Additions.h"
 #import "OBAAnalytics.h"
+#import "OBAAgencyV2.h"
 
 
 @implementation OBASituationsViewController
@@ -93,6 +94,16 @@
         OBASituationViewController * vc = [[OBASituationViewController alloc] initWithSituation:situation];
         vc.args = self.args;
         [self.navigationController pushViewController:vc animated:YES];
+        [self reportAnalytics:situation];
+    }
+}
+
+- (void) reportAnalytics:(OBASituationV2 *) situation {
+    
+    NSDictionary *agencies = [[situation references] getAllAgencies];
+    for(id key in agencies) {
+        OBAAgencyV2 * agency = agencies[key];
+        [OBAAnalytics reportEventWithCategory:OBAAnalyticsCategoryUIAction action:@"service_alerts" label:[NSString stringWithFormat:@"Clicked Service Alerts from: %@", agency.name] value:nil];
     }
 }
 


### PR DESCRIPTION
Following analytics report was added when a `service alerts button` is clicked:

 Event Category  | Event Action | Event Label |
| ------------- | ------------- | ------------- |
| ui_action  | service_alerts  | Clicked Service Alerts from: PSTA |

Screenshot from GA console:

![untitled 2](https://cloud.githubusercontent.com/assets/2777974/15409931/1d28e1fc-1de5-11e6-96ba-5fa290bd3971.png)

cc'd @barbeau 