### PR TITLE
Test coverage for every bookmark line of OBAModelDAO

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>20160405.23</string>
+	<string>20160528.14</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>

--- a/OBAKit/Models/dao/OBAModelDAO.h
+++ b/OBAKit/Models/dao/OBAModelDAO.h
@@ -45,7 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)saveBookmarkGroup:(OBABookmarkGroup *)bookmarkGroup;
 - (void)removeBookmarkGroup:(OBABookmarkGroup*)bookmarkGroup;
-- (void)moveBookmark:(OBABookmarkV2*)bookmark toGroup:(OBABookmarkGroup*)group;
+- (void)moveBookmark:(OBABookmarkV2*)bookmark toGroup:(nullable OBABookmarkGroup*)group;
 - (void)moveBookmark:(NSUInteger)startIndex to:(NSUInteger)endIndex inGroup:(OBABookmarkGroup*)group;
 
 - (OBAStopPreferencesV2*)stopPreferencesForStopWithId:(NSString*)stopId;

--- a/OBAKit/Models/unmanaged/OBAArrivalAndDepartureV2.h
+++ b/OBAKit/Models/unmanaged/OBAArrivalAndDepartureV2.h
@@ -13,40 +13,40 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface OBAArrivalAndDepartureV2 : OBAHasReferencesV2<OBAHasServiceAlerts>
 
-@property (nonatomic,strong) NSString * routeId;
-@property (weak, nonatomic,readonly) OBARouteV2 * route;
-@property (nonatomic,strong) NSString * routeShortName;
+@property(nonatomic,strong) NSString * routeId;
+@property(nonatomic,weak,readonly) OBARouteV2 * route;
+@property(nonatomic,strong) NSString * routeShortName;
 
-@property (nonatomic,strong) NSString * tripId;
-@property (weak, nonatomic,readonly) OBATripV2 * trip;
-@property (nonatomic,strong) NSString * tripHeadsign;
-@property (nonatomic) long long serviceDate;
+@property(nonatomic,strong) NSString * tripId;
+@property(nonatomic,weak,readonly) OBATripV2 * trip;
+@property(nonatomic,strong) NSString * tripHeadsign;
+@property(nonatomic,assign) long long serviceDate;
 
-@property (weak, nonatomic,readonly) OBAArrivalAndDepartureInstanceRef * instance;
-@property (weak, nonatomic,readonly) OBATripInstanceRef * tripInstance;
+@property(nonatomic,weak,readonly) OBAArrivalAndDepartureInstanceRef * instance;
+@property(nonatomic,weak,readonly) OBATripInstanceRef * tripInstance;
 
-@property (nonatomic,strong) NSString * stopId;
-@property (weak, nonatomic,readonly) OBAStopV2 * stop;
-@property (nonatomic) NSInteger stopSequence;
+@property(nonatomic,strong) NSString * stopId;
+@property(nonatomic,weak,readonly) OBAStopV2 * stop;
+@property(nonatomic,assign) NSInteger stopSequence;
 
-@property (nonatomic,strong) OBATripStatusV2 * tripStatus;
+@property(nonatomic,strong) OBATripStatusV2 * tripStatus;
 
-@property (nonatomic,strong) OBAFrequencyV2 * frequency;
+@property(nonatomic,strong) OBAFrequencyV2 * frequency;
 
-@property (nonatomic) BOOL predicted;
+@property(nonatomic,assign) BOOL predicted;
 
-@property (nonatomic) long long scheduledArrivalTime;
-@property (nonatomic) long long predictedArrivalTime;
-@property (nonatomic,readonly) long long bestArrivalTime;
+@property(nonatomic,assign) long long scheduledArrivalTime;
+@property(nonatomic,assign) long long predictedArrivalTime;
+@property(nonatomic,assign,readonly) long long bestArrivalTime;
 
-@property (nonatomic) long long scheduledDepartureTime;
-@property (nonatomic) long long predictedDepartureTime;
-@property (nonatomic,readonly) long long bestDepartureTime;
+@property(nonatomic,assign) long long scheduledDepartureTime;
+@property(nonatomic,assign) long long predictedDepartureTime;
+@property(nonatomic,assign,readonly) long long bestDepartureTime;
+
+@property(nonatomic,assign) double distanceFromStop;
+@property(nonatomic,assign) NSInteger numberOfStopsAway;
 
 - (BOOL)hasRealTimeData;
-
-@property (nonatomic) double distanceFromStop;
-@property (nonatomic) NSInteger numberOfStopsAway;
 
 /**
  Walks through a series of possible options for giving this arrival and departure a user-sensible name.

--- a/OBAKit/Models/unmanaged/OBAArrivalAndDepartureV2.m
+++ b/OBAKit/Models/unmanaged/OBAArrivalAndDepartureV2.m
@@ -7,7 +7,7 @@
 
 @implementation OBAArrivalAndDepartureV2
 
-- (id) init {
+- (instancetype)init {
     self = [super init];
     if (self) {
         _situationIds = [[NSMutableArray alloc] init];
@@ -192,6 +192,15 @@
     else {
         return [NSString stringWithFormat:NSLocalizedString(@"%@ min %@", @"e.g. 3 min early"), @(minDiff), suffixWord];
     }
+}
+
+#pragma mark - NSObject
+
+- (NSString*)description {
+
+    NSDictionary *dict = [self dictionaryWithValuesForKeys:@[@"routeId", @"route", @"routeShortName", @"tripId", @"trip", @"tripHeadsign", @"serviceDate", @"instance", @"tripInstance", @"stopId", @"stop", @"stopSequence", @"tripStatus", @"frequency", @"predicted", @"scheduledArrivalTime", @"predictedArrivalTime", @"bestArrivalTime", @"scheduledDepartureTime", @"predictedDepartureTime", @"bestDepartureTime", @"distanceFromStop", @"numberOfStopsAway"]];
+
+    return [NSString stringWithFormat:@"<%@: %p> %@", self.class, self, dict];
 }
 
 @end

--- a/OBAKit/Models/unmanaged/OBATripStatusV2.m
+++ b/OBAKit/Models/unmanaged/OBATripStatusV2.m
@@ -12,4 +12,8 @@
     return [OBATripInstanceRef tripInstance:self.activeTripId serviceDate:self.serviceDate vehicleId:self.vehicleId];
 }
 
+- (NSString*)description {
+    NSDictionary *dict = [self dictionaryWithValuesForKeys:@[@"activeTripId", @"activeTrip", @"serviceDate", @"frequency", @"location", @"predicted", @"scheduleDeviation", @"vehicleId", @"lastUpdateTime", @"lastKnownLocation", @"tripInstance"]];
+    return [NSString stringWithFormat:@"<%@: %p> %@", self.class, self, dict];
+}
 @end

--- a/OBAKit/Models/unmanaged/OBATripV2.h
+++ b/OBAKit/Models/unmanaged/OBATripV2.h
@@ -15,9 +15,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) NSString * directionId;
 @property (nonatomic, strong) NSString * blockId;
 
-@property (weak, nonatomic, readonly) OBARouteV2 * route;
+@property(weak, nonatomic, readonly) OBARouteV2 * route;
 
-@property (weak, nonatomic, readonly) NSString * asLabel;
+@property(nonatomic,copy,readonly) NSString *asLabel;
 
 @end
 

--- a/OBAKit/Models/unmanaged/OBATripV2.m
+++ b/OBAKit/Models/unmanaged/OBATripV2.m
@@ -1,25 +1,33 @@
 #import "OBATripV2.h"
 
-
 @implementation OBATripV2
 
-- (OBARouteV2*) route {
+- (OBARouteV2*)route {
     OBAReferencesV2 * refs = self.references;
     return [refs getRouteForId:self.routeId];
 }
 
-- (NSString*) asLabel {
-    OBARouteV2 * r = self.route;
-    NSString * rShortName = self.routeShortName;
-    if( ! rShortName )
-        rShortName = [r safeShortName];
-    NSString * headsign = self.tripHeadsign;
-    if( ! headsign )
-        headsign = r.longName;
-    if( ! headsign )
-        headsign = @"Headed somewhere...";
-    
-    return [NSString stringWithFormat:@"%@ - %@",rShortName,headsign];    
+- (NSString*)asLabel {
+    NSString * rShortName = self.routeShortName ?: self.route.safeShortName;
+    NSString *headsign = nil;
+
+    if (self.tripHeadsign) {
+        headsign = self.tripHeadsign;
+    }
+    else if (self.route.longName) {
+        headsign = self.route.longName;
+    }
+    else {
+        headsign = NSLocalizedString(@"Headed somewhere...",@"");
+    }
+
+    return [NSString stringWithFormat:@"%@ - %@",rShortName, headsign];
+}
+
+- (NSString*)description {
+    NSDictionary *dict = [self dictionaryWithValuesForKeys:@[@"tripId", @"routeId", @"routeShortName", @"tripShortName", @"tripHeadsign", @"serviceId", @"shapeId", @"directionId", @"blockId", @"route", @"asLabel"]];
+
+    return [NSString stringWithFormat:@"<%@: %p> %@", self.class, self, dict];
 }
 
 @end


### PR DESCRIPTION
* Add more test coverage to OBAModelDAO, a sufficient amount to ensure that every line of the OBAModelDAO that relates to bookmarks is covered.
* Improve -description methods and some class header cleanup