### PR TITLE
Create bookmarks on a per-stop/route basis

### DIFF
--- a/AnyPromise+OBABackCompat.h
+++ b/AnyPromise+OBABackCompat.h
@@ -1,0 +1,15 @@
+//
+//  AnyPromise+OBABackCompat.h
+//  org.onebusaway.iphone
+//
+//  Created by Aaron Brethorst on 7/14/16.
+//  Copyright © 2016 OneBusAway. All rights reserved.
+//
+
+#import <PromiseKit/PromiseKit.h>
+
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < __IPHONE_10_0
+@interface AnyPromise (OBABackCompat)
+- (AnyPromise * __nonnull(^ __nonnull)(dispatch_block_t __nonnull))finally;
+@end
+#endif

--- a/AnyPromise+OBABackCompat.m
+++ b/AnyPromise+OBABackCompat.m
@@ -1,0 +1,21 @@
+//
+//  AnyPromise+OBABackCompat.m
+//  org.onebusaway.iphone
+//
+//  Created by Aaron Brethorst on 7/14/16.
+//  Copyright © 2016 OneBusAway. All rights reserved.
+//
+
+#import "AnyPromise+OBABackCompat.h"
+
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < __IPHONE_10_0
+
+@implementation AnyPromise (OBABackCompat)
+
+- (AnyPromise * __nonnull(^ __nonnull)(dispatch_block_t __nonnull))finally {
+    return [self always];
+}
+
+@end
+
+#endif

--- a/OBAApplicationDelegate.m
+++ b/OBAApplicationDelegate.m
@@ -259,7 +259,7 @@ static NSString *const kApptentiveKey = @"3363af9a6661c98dec30fedea451a06dd7d7bc
 
         NSArray *stopIds = (NSArray *)shortcutItem.userInfo[@"stopIds"];
         if (stopIds.count > 0) {
-            UIViewController *vc = [OBAStopViewController stopControllerWithStopID:stopIds[0]];
+            OBAStopViewController *vc = [[OBAStopViewController alloc] initWithStopID:stopIds[0]];
             [self.recentsNavigationController popToRootViewControllerAnimated:NO];
             [self.recentsNavigationController pushViewController:vc animated:YES];
         }

--- a/OBAKit/Categories/NSObject+OBADescription.h
+++ b/OBAKit/Categories/NSObject+OBADescription.h
@@ -8,6 +8,11 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface NSObject (OBADescription)
 - (NSString*)oba_description:(NSArray<NSString*>*)keys;
+- (NSString*)oba_description:(NSArray<NSString*>*)keys keyPaths:(nullable NSArray<NSString*>*)keyPaths;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/OBAKit/Categories/NSObject+OBADescription.m
+++ b/OBAKit/Categories/NSObject+OBADescription.m
@@ -11,7 +11,15 @@
 @implementation NSObject (OBADescription)
 
 - (NSString*)oba_description:(NSArray<NSString*>*)keys {
-    NSDictionary *dict = [self dictionaryWithValuesForKeys:keys];
+    return [self oba_description:keys keyPaths:nil];
+}
+
+- (NSString*)oba_description:(NSArray<NSString*>*)keys keyPaths:(NSArray<NSString *> *)keyPaths {
+    NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithDictionary:[self dictionaryWithValuesForKeys:keys]];
+
+    for (NSString *keyPath in keyPaths) {
+        dict[keyPath] = [self valueForKeyPath:keyPath];
+    }
 
     return [NSString stringWithFormat:@"<%@: %p> %@", self.class, self, dict];
 }

--- a/OBAKit/Helpers/OBACommon.h
+++ b/OBAKit/Helpers/OBACommon.h
@@ -39,6 +39,9 @@ NSString * OBAStringFromBool(BOOL yn);
 
 @interface OBACommon : NSObject
 
++ (void)setRunningInsideTests:(BOOL)runningInsideTests;
++ (BOOL)isRunningInsideTests;
+
 + (NSString*) getTimeAsString;
 + (NSString*) getBestNameFirst:(NSString*)firstName second:(NSString*)secondName;
 + (NSString*) getBestNameFirst:(NSString*)firstName second:(NSString*)secondName third:(NSString*)thirdName;

--- a/OBAKit/Helpers/OBACommon.m
+++ b/OBAKit/Helpers/OBACommon.m
@@ -17,6 +17,8 @@
 #import "OBACommon.h"
 #import "OBADateHelpers.h"
 
+static BOOL obaCommonRunningInsideTests = NO;
+
 NSString * const OBAErrorDomain = @"org.onebusaway.iphone2";
 
 const NSInteger kOBAErrorDuplicateEntity = 1000;
@@ -44,8 +46,15 @@ NSString * OBAStringFromBool(BOOL yn) {
 
 @end
 
-
 @implementation OBACommon
+
++ (void)setRunningInsideTests:(BOOL)runningInsideTests {
+    obaCommonRunningInsideTests = runningInsideTests;
+}
+
++ (BOOL)isRunningInsideTests {
+    return obaCommonRunningInsideTests;
+}
 
 + (NSString*) getTimeAsString {
     return [OBADateHelpers formatShortTimeNoDate:[NSDate date]];

--- a/OBAKit/Helpers/OBAMacros.h
+++ b/OBAKit/Helpers/OBAMacros.h
@@ -6,6 +6,8 @@
 //  Copyright © 2016 One Bus Away. All rights reserved.
 //
 
+#import "OBACommon.h"
+
 #ifndef OBAMacros_h
 #define OBAMacros_h
 
@@ -23,8 +25,11 @@
 
 #define SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(v)  ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedAscending)
 
+#define OBAAssert(__param) \
+    if (![OBACommon isRunningInsideTests]) { NSParameterAssert(__param); }
+
 #define OBAGuard(CONDITION) \
-    if (!CONDITION) { NSParameterAssert(CONDITION); } \
+    if (!(CONDITION)) { OBAAssert(CONDITION); } \
     if (CONDITION) {}
 
 #define OBAGuardClass(object, typeName) \

--- a/OBAKit/Models/dao/OBAModelDAO.h
+++ b/OBAKit/Models/dao/OBAModelDAO.h
@@ -38,9 +38,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithModelPersistenceLayer:(id<OBAModelPersistenceLayer>)persistenceLayer;
 
-- (OBABookmarkV2*)bookmarkForStop:(OBAStopV2*)stop;
+- (OBABookmarkV2*)bookmarkForArrivalAndDeparture:(OBAArrivalAndDepartureV2*)arrival;
+- (nullable OBABookmarkV2*)bookmarkAtIndex:(NSUInteger)index inGroup:(nullable OBABookmarkGroup*)group;
 - (void)saveBookmark:(OBABookmarkV2*)bookmark;
 - (void)moveBookmark:(NSUInteger)startIndex to:(NSUInteger)endIndex;
+- (void)moveBookmark:(OBABookmarkV2*)bookmark toIndex:(NSUInteger)index inGroup:(nullable OBABookmarkGroup*)group;
 - (void)removeBookmark:(OBABookmarkV2*)bookmark;
 
 - (void)saveBookmarkGroup:(OBABookmarkGroup *)bookmarkGroup;

--- a/OBAKit/Models/dao/OBAModelPersistenceLayer.h
+++ b/OBAKit/Models/dao/OBAModelPersistenceLayer.h
@@ -8,6 +8,9 @@
 
 #import <Foundation/Foundation.h>
 
+@class CLLocation;
+@class OBARegionV2;
+
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol OBAModelPersistenceLayer <NSObject>

--- a/OBAKit/Models/unmanaged/OBAArrivalAndDepartureV2.h
+++ b/OBAKit/Models/unmanaged/OBAArrivalAndDepartureV2.h
@@ -13,19 +13,19 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface OBAArrivalAndDepartureV2 : OBAHasReferencesV2<OBAHasServiceAlerts>
 
-@property(nonatomic,strong) NSString * routeId;
+@property(nonatomic,copy) NSString *routeId;
 @property(nonatomic,weak,readonly) OBARouteV2 * route;
-@property(nonatomic,strong) NSString * routeShortName;
+@property(nonatomic,copy) NSString *routeShortName;
 
-@property(nonatomic,strong) NSString * tripId;
+@property(nonatomic,copy) NSString * tripId;
 @property(nonatomic,weak,readonly) OBATripV2 * trip;
-@property(nonatomic,strong) NSString * tripHeadsign;
+@property(nonatomic,copy) NSString * tripHeadsign;
 @property(nonatomic,assign) long long serviceDate;
 
 @property(nonatomic,weak,readonly) OBAArrivalAndDepartureInstanceRef * instance;
 @property(nonatomic,weak,readonly) OBATripInstanceRef * tripInstance;
 
-@property(nonatomic,strong) NSString * stopId;
+@property(nonatomic,copy) NSString * stopId;
 @property(nonatomic,weak,readonly) OBAStopV2 * stop;
 @property(nonatomic,assign) NSInteger stopSequence;
 
@@ -47,6 +47,12 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic,assign) NSInteger numberOfStopsAway;
 
 - (BOOL)hasRealTimeData;
+
+/**
+ This string is composed of this object's routeId, tripHeadsign, and bestAvailableName.
+ It is designed to offer a unique key for determining bookmark existence during the process of creating one.
+ */
+- (NSString*)bookmarkKey;
 
 /**
  Walks through a series of possible options for giving this arrival and departure a user-sensible name.

--- a/OBAKit/Models/unmanaged/OBAArrivalAndDepartureV2.m
+++ b/OBAKit/Models/unmanaged/OBAArrivalAndDepartureV2.m
@@ -52,11 +52,11 @@
     return nil;
 }
 
-- (OBAArrivalAndDepartureInstanceRef *) instance {
+- (OBAArrivalAndDepartureInstanceRef*)instance {
     return [[OBAArrivalAndDepartureInstanceRef alloc] initWithTripInstance:self.tripInstance stopId:self.stopId stopSequence:self.stopSequence];
 }
 
-- (OBATripInstanceRef *) tripInstance {
+- (OBATripInstanceRef*)tripInstance {
     return [OBATripInstanceRef tripInstance:self.tripId serviceDate:self.serviceDate vehicleId:self.tripStatus.vehicleId];
 }
 
@@ -75,26 +75,23 @@
 #pragma mark - OBAHasServiceAlerts
 
 - (NSArray<OBASituationV2*>*)situations {
+    NSMutableArray *rSituations = [NSMutableArray array];
 
-    NSMutableArray * rSituations = [NSMutableArray array];
-
-    OBAReferencesV2 * refs = self.references;
-
-    for( NSString * situationId in self.situationIds ) {
-        OBASituationV2 * situation = [refs getSituationForId:situationId];
-        if( situation )
+    for (NSString *situationId in self.situationIds) {
+        OBASituationV2 *situation = [self.references getSituationForId:situationId];
+        if (situation) {
             [rSituations addObject:situation];
+        }
     }
 
-    return rSituations;
+    return [NSArray arrayWithArray:rSituations];
 }
 
-- (void) addSituationId:(NSString*)situationId {
+- (void)addSituationId:(NSString*)situationId {
     [self.situationIds addObject:situationId];
 }
 
 - (OBADepartureStatus)departureStatus {
-
     if (!self.hasRealTimeData) {
         return OBADepartureStatusUnknown;
     }
@@ -122,8 +119,12 @@
     if (trip.routeShortName) {
         return trip.routeShortName;
     }
-
-    return trip.route.shortName ?: trip.route.longName;
+    else if (trip.route.shortName) {
+        return trip.route.shortName;
+    }
+    else {
+        return trip.route.longName;
+    }
 }
 
 + (NSString*)statusStringFromFrequency:(OBAFrequencyV2*)frequency {
@@ -135,7 +136,6 @@
 
     NSString *formatString = NSLocalizedString(@"Every %@ mins %@ %@", @"frequency status string");
     NSString *fromOrUntil = [now compare:startTime] == NSOrderedAscending ? NSLocalizedString(@"from", @"") : NSLocalizedString(@"until", @"");
-
     NSDate *terminalDate = [now compare:startTime] == NSOrderedAscending ? startTime : endTime;
 
     return [NSString stringWithFormat:formatString, @(headway), fromOrUntil, [OBADateHelpers formatShortTimeNoDate:terminalDate]];
@@ -193,6 +193,12 @@
     else {
         return [NSString stringWithFormat:NSLocalizedString(@"%@ min %@", @"e.g. 3 min early"), @(minDiff), suffixWord];
     }
+}
+
+#pragma mark - Bookmarks
+
+- (NSString*)bookmarkKey {
+    return [NSString stringWithFormat:@"%@_%@_%@", self.routeId, self.tripHeadsign, self.bestAvailableName];
 }
 
 #pragma mark - NSObject

--- a/OBAKit/Models/unmanaged/OBAArrivalsAndDeparturesForStopV2.h
+++ b/OBAKit/Models/unmanaged/OBAArrivalsAndDeparturesForStopV2.h
@@ -7,7 +7,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface OBAArrivalsAndDeparturesForStopV2 : OBAHasReferencesV2<OBAHasServiceAlerts>
 @property(nonatomic,strong) NSString *stopId;
-@property(weak, nonatomic,readonly) OBAStopV2 *stop;
+@property(nonatomic,weak,readonly) OBAStopV2 *stop;
 @property(nonatomic,strong,readonly) NSArray<OBAArrivalAndDepartureV2*> *arrivalsAndDepartures;
 
 - (void)addArrivalAndDeparture:(OBAArrivalAndDepartureV2*)arrivalAndDeparture;

--- a/OBAKit/Models/unmanaged/OBAArrivalsAndDeparturesForStopV2.m
+++ b/OBAKit/Models/unmanaged/OBAArrivalsAndDeparturesForStopV2.m
@@ -1,5 +1,6 @@
 #import "OBAArrivalsAndDeparturesForStopV2.h"
 #import "OBASituationV2.h"
+#import "NSObject+OBADescription.h"
 
 @interface OBAArrivalsAndDeparturesForStopV2 ()
 @property(nonatomic,strong) NSMutableArray *arrivalsAndDeparturesM;
@@ -17,7 +18,7 @@
     return self;
 }
 
--(OBAStopV2*) stop {
+- (OBAStopV2*) stop {
     OBAReferencesV2 * refs = [self references];
     return [refs getStopForId:self.stopId];
 }
@@ -49,6 +50,12 @@
 
 - (void) addSituationId:(NSString*)situationId {
     [_situationIds addObject:situationId];
+}
+
+#pragma mark - NSObject
+
+- (NSString*)description {
+    return [self oba_description:@[@"stopId", @"stop", @"arrivalsAndDepartures"]];
 }
 
 @end

--- a/OBAKit/Models/unmanaged/OBABookmarkGroup.h
+++ b/OBAKit/Models/unmanaged/OBABookmarkGroup.h
@@ -13,8 +13,8 @@ NS_ASSUME_NONNULL_BEGIN
 @class OBABookmarkV2;
 
 @interface OBABookmarkGroup : NSObject<NSCoding>
-@property (nonatomic, strong) NSMutableArray *bookmarks;
-@property (nonatomic, strong) NSString *name;
+@property(nonatomic,strong) NSMutableArray *bookmarks;
+@property(nonatomic,copy) NSString *name;
 
 - (instancetype)initWithName:(NSString*)name;
 

--- a/OBAKit/Models/unmanaged/OBABookmarkGroup.m
+++ b/OBAKit/Models/unmanaged/OBABookmarkGroup.m
@@ -8,13 +8,14 @@
 
 #import "OBABookmarkGroup.h"
 #import "OBABookmarkV2.h"
+#import "NSObject+OBADescription.h"
 
 @implementation OBABookmarkGroup
 
 - (id)initWithName:(NSString *)name
 {
     if (self = [super init]) {
-        _name = name;
+        _name = [name copy];
         _bookmarks = [NSMutableArray array];
     }
     return self;
@@ -40,8 +41,8 @@
 
 #pragma mark - NSObject
 
-- (NSString*) description {
-    return [NSString stringWithFormat:@"<%@ %p> {name: %@, bookmarks: [%@]}", NSStringFromClass(self.class), self, self.name, self.bookmarks];
+- (NSString*)description {
+    return [self oba_description:@[@"name", @"bookmarks"]];
 }
 
 @end

--- a/OBAKit/Models/unmanaged/OBABookmarkV2.h
+++ b/OBAKit/Models/unmanaged/OBABookmarkV2.h
@@ -5,18 +5,44 @@
 @class OBARegionV2;
 @class OBAStopV2;
 @class OBABookmarkGroup;
+@class OBAArrivalAndDepartureV2;
+@class OBAArrivalsAndDeparturesForStopV2;
+
+typedef NS_ENUM(NSUInteger, OBABookmarkVersion) {
+    OBABookmarkVersion252 = 0,
+    OBABookmarkVersion260,
+};
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface OBABookmarkV2 : NSObject<NSCoding,MKAnnotation>
+@interface OBABookmarkV2 : NSObject<NSCoding,NSCopying,MKAnnotation>
 @property(nonatomic,copy) NSString *name;
+@property(nonatomic,copy) NSString *routeShortName;
 @property(nonatomic,copy) NSString *stopId;
+@property(nonatomic,copy) NSString *tripHeadsign;
+@property(nonatomic,copy) NSString *routeID;
 @property(nonatomic,copy,nullable) OBAStopV2 *stop;
 @property(nonatomic,strong,nullable) OBABookmarkGroup *group;
 @property(nonatomic,assign) NSInteger regionIdentifier;
 @property(nonatomic,assign,readonly) OBARouteType routeType;
+@property(nonatomic,assign) NSUInteger sortOrder;
+@property(nonatomic,assign) OBABookmarkVersion bookmarkVersion;
 
-- (instancetype)initWithStop:(OBAStopV2*)stop region:(OBARegionV2*)region;
+- (instancetype)initWithArrivalAndDeparture:(OBAArrivalAndDepartureV2*)arrivalAndDeparture region:(OBARegionV2*)region;
+
+/**
+ Basically, an -isEqual: for comparing bookmarks to OBAArrivalAndDepartureV2 objects.
+ */
+- (BOOL)matchesArrivalAndDeparture:(OBAArrivalAndDepartureV2*)arrivalAndDeparture;
+
+/**
+ Extracts all OBAArrivalAndDepartureV2 objects from `dep` that match this bookmark.
+ @param dep The arrivals and departures object to filter.
+
+ @return A filtered list of OBAArrivalAndDepartureV2 that match this bookmark.
+ */
+- (NSArray<OBAArrivalAndDepartureV2*>*)matchingArrivalsAndDeparturesForStop:(OBAArrivalsAndDeparturesForStopV2*)dep;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/OBAKit/Models/unmanaged/OBARouteV2.h
+++ b/OBAKit/Models/unmanaged/OBARouteV2.h
@@ -5,15 +5,14 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface OBARouteV2 : OBAHasReferencesV2<NSCopying,NSCoding>
+@property(nonatomic,strong) NSString * routeId;
+@property(nonatomic,strong) NSString * shortName;
+@property(nonatomic,strong) NSString * longName;
+@property(nonatomic,strong) NSNumber * routeType;
 
-@property (nonatomic, strong) NSString * routeId;
-@property (nonatomic, strong) NSString * shortName;
-@property (nonatomic, strong) NSString * longName;
-@property (nonatomic, strong) NSNumber * routeType;
-
-@property(nonatomic, strong) NSString * agencyId;
-@property(nonatomic, copy, readonly) OBAAgencyV2 *agency;
-@property(nonatomic, copy, readonly) NSString * safeShortName;
+@property(nonatomic,strong) NSString * agencyId;
+@property(nonatomic,copy, readonly) OBAAgencyV2 *agency;
+@property(nonatomic,copy, readonly) NSString * safeShortName;
 
 - (NSComparisonResult) compareUsingName:(OBARouteV2*)aRoute;
 

--- a/OBAKit/Models/unmanaged/OBARouteV2.m
+++ b/OBAKit/Models/unmanaged/OBARouteV2.m
@@ -1,4 +1,5 @@
 #import "OBARouteV2.h"
+#import "NSObject+OBADescription.h"
 
 @interface OBARouteV2 ()
 @property(nonatomic,copy,readwrite) OBAAgencyV2 *agency;
@@ -63,6 +64,12 @@
     NSString * name1 = [self safeShortName];
     NSString * name2 = [aRoute safeShortName];
     return [name1 compare:name2 options:NSNumericSearch];
+}
+
+#pragma mark - NSObject
+
+- (NSString*)description {
+    return [self oba_description:@[@"routeId", @"shortName", @"longName", @"routeType", @"agencyId", @"agency", @"safeShortName"]];
 }
 
 @end

--- a/OBAKit/OBAApplication.m
+++ b/OBAKit/OBAApplication.m
@@ -36,6 +36,7 @@ NSString *const kOBAApplicationSettingsRegionRefreshNotification = @"kOBAApplica
 
 - (void)start {
     self.references = [[OBAReferencesV2 alloc] init];
+
     id<OBAModelPersistenceLayer> persistence = [[OBAModelDAOUserPreferencesImpl alloc] init];
     self.modelDao = [[OBAModelDAO alloc] initWithModelPersistenceLayer:persistence];
     self.locationManager = [[OBALocationManager alloc] initWithModelDao:self.modelDao];
@@ -111,17 +112,8 @@ NSString *const kOBAApplicationSettingsRegionRefreshNotification = @"kOBAApplica
     NSString *userId = [userDefaults stringForKey:kOBAHiddenPreferenceUserId];
 
     if (!userId) {
-        CFUUIDRef theUUID = CFUUIDCreate(kCFAllocatorDefault);
-
-        if (theUUID) {
-            userId = CFBridgingRelease(CFUUIDCreateString(kCFAllocatorDefault, theUUID));
-            CFRelease(theUUID);
-            [userDefaults setObject:userId forKey:kOBAHiddenPreferenceUserId];
-            [userDefaults synchronize];
-        }
-        else {
-            userId = @"anonymous";
-        }
+        [userDefaults setObject:[[NSUUID UUID] UUIDString] forKey:kOBAHiddenPreferenceUserId];
+        [userDefaults synchronize];
     }
 
     return userId;

--- a/OneBusAwayTests/OBAKitTests/models/OBAArrivalAndDepartureV2_Tests.m
+++ b/OneBusAwayTests/OBAKitTests/models/OBAArrivalAndDepartureV2_Tests.m
@@ -30,13 +30,13 @@
     self.modelFactory = [[OBAModelFactory alloc] initWithReferences:references];
 }
 
-- (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
-    [super tearDown];
-}
+- (void)testBookmarkKey {
+    OBAArrivalAndDepartureV2 *dep = [[OBAArrivalAndDepartureV2 alloc] init];
+    dep.routeId = @"ROUTE";
+    dep.tripHeadsign = @"HEADSIGN";
+    dep.routeShortName = @"SHORTROUTE";
 
-- (void)testExample {
-    XCTAssertTrue(YES);
+    XCTAssertEqualObjects(dep.bookmarkKey, @"ROUTE_HEADSIGN_SHORTROUTE");
 }
 
 @end

--- a/OneBusAwayTests/OBAKitTests/models/OBABookmarkV2_Tests.m
+++ b/OneBusAwayTests/OBAKitTests/models/OBABookmarkV2_Tests.m
@@ -7,25 +7,30 @@
 //
 
 #import <XCTest/XCTest.h>
+#import <OCMock/OCMock.h>
 #import "OBATestHelpers.h"
 #import <OBAKit/OBABookmarkV2.h>
+#import <OBAKit/OBAArrivalsAndDeparturesForStopV2.h>
+#import "OBAModelDAO.h"
+#import "OBATestHarnessPersistenceLayer.h"
 
 /**
  TODO: WRITE *MORE* TESTS
  */
 
 @interface OBABookmarkV2_Tests : XCTestCase
+@property(nonatomic,strong) OBATestHarnessPersistenceLayer *persistenceLayer;
+@property(nonatomic,strong) OBAModelDAO *modelDAO;
 @end
 
 @implementation OBABookmarkV2_Tests
 
 - (void)setUp {
     [super setUp];
-}
 
-- (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
-    [super tearDown];
+    self.persistenceLayer = [[OBATestHarnessPersistenceLayer alloc] init];
+    self.modelDAO = [[OBAModelDAO alloc] initWithModelPersistenceLayer:self.persistenceLayer];
+    self.modelDAO.region = [OBATestHelpers pugetSoundRegion];
 }
 
 - (void)testMigratingBookmarkWithStopIDsArray {

--- a/Podfile
+++ b/Podfile
@@ -1,18 +1,26 @@
 # Uncomment this line to define a global platform for your project
 platform :ios, '9.0'
 
+use_pk_400 = !ENV['xcode8'].nil?
+
 inhibit_all_warnings!
 
 target 'OBAKit' do
   use_frameworks!
 
-  # pod 'PromiseKit', '3.0.2'
-  pod 'PromiseKit/CorePromise', '3.0.2'
-  pod 'PromiseKit/CoreLocation', '3.0.2'
-  pod 'PromiseKit/CloudKit', '3.0.2'
-  pod 'PromiseKit/Foundation', '3.0.2'
-  pod 'PromiseKit/MapKit', '3.0.2'
-
+  if use_pk_400
+    pod 'PromiseKit/CorePromise', git: 'https://github.com/mxcl/PromiseKit.git', branch: '4.0.0-beta2'
+    pod 'PromiseKit/CoreLocation', git: 'https://github.com/mxcl/PromiseKit.git', branch: '4.0.0-beta2'
+    pod 'PromiseKit/CloudKit', git: 'https://github.com/mxcl/PromiseKit.git', branch: '4.0.0-beta2'
+    pod 'PromiseKit/Foundation', git: 'https://github.com/mxcl/PromiseKit.git', branch: '4.0.0-beta2'
+    pod 'PromiseKit/MapKit', git: 'https://github.com/mxcl/PromiseKit.git', branch: '4.0.0-beta2'
+  else
+   pod 'PromiseKit/CorePromise', '3.2.0'
+   pod 'PromiseKit/CoreLocation', '3.2.0'
+   pod 'PromiseKit/CloudKit', '3.2.0'
+   pod 'PromiseKit/Foundation', '3.2.0'
+   pod 'PromiseKit/MapKit', '3.2.0'
+ end
 end
 
 target 'OneBusAway' do
@@ -22,23 +30,30 @@ target 'OneBusAway' do
   pod 'ABReleaseNotesViewController', '0.1.1'
   pod 'GoogleAnalytics', '3.14.0'
   pod 'libextobjc', '0.4.1'
-  pod 'SVProgressHUD', :git => "https://github.com/aaronbrethorst/SVProgressHUD.git"
+  pod 'SVProgressHUD', '2.0.3'
   pod 'Masonry', '0.6.4'
   pod 'DateTools', '1.7.0'
   pod 'DZNEmptyDataSet', '1.7.3'
   pod 'apptentive-ios', '3.1.1'
 
-  # pod 'PromiseKit', '3.0.2'
-  pod 'PromiseKit/CorePromise', '3.0.2'
-  pod 'PromiseKit/CoreLocation', '3.0.2'
-  pod 'PromiseKit/CloudKit', '3.0.2'
-  pod 'PromiseKit/Foundation', '3.0.2'
-  pod 'PromiseKit/MapKit', '3.0.2'
-
+  if use_pk_400
+    pod 'PromiseKit/CorePromise', git: 'https://github.com/mxcl/PromiseKit.git', branch: '4.0.0-beta2'
+    pod 'PromiseKit/CoreLocation', git: 'https://github.com/mxcl/PromiseKit.git', branch: '4.0.0-beta2'
+    pod 'PromiseKit/CloudKit', git: 'https://github.com/mxcl/PromiseKit.git', branch: '4.0.0-beta2'
+    pod 'PromiseKit/Foundation', git: 'https://github.com/mxcl/PromiseKit.git', branch: '4.0.0-beta2'
+    pod 'PromiseKit/MapKit', git: 'https://github.com/mxcl/PromiseKit.git', branch: '4.0.0-beta2'
+  else
+   pod 'PromiseKit/CorePromise', '3.2.0'
+   pod 'PromiseKit/CoreLocation', '3.2.0'
+   pod 'PromiseKit/CloudKit', '3.2.0'
+   pod 'PromiseKit/Foundation', '3.2.0'
+   pod 'PromiseKit/MapKit', '3.2.0'
+ end
 
   target 'OneBusAwayTests' do
     inherit! :search_paths
     # Pods for testing
+    pod 'OCMock', '~> 3.3'
   end
 
 end
@@ -47,6 +62,7 @@ post_install do |installer_representation|
   installer_representation.pods_project.targets.each do |target|
     target.build_configurations.each do |config|
       config.build_settings['ONLY_ACTIVE_ARCH'] = 'NO'
+      config.build_settings['ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES'] = 'NO'
     end
   end
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -40,6 +40,7 @@ PODS:
   - libextobjc/RuntimeExtensions (0.4.1)
   - libextobjc/UmbrellaHeader (0.4.1)
   - Masonry (0.6.4)
+  - OCMock (3.3.1)
   - OMGHTTPURLRQ (3.1.2):
     - OMGHTTPURLRQ/RQ (= 3.1.2)
   - OMGHTTPURLRQ/FormURLEncode (3.1.2)
@@ -47,17 +48,17 @@ PODS:
     - OMGHTTPURLRQ/FormURLEncode
     - OMGHTTPURLRQ/UserAgent
   - OMGHTTPURLRQ/UserAgent (3.1.2)
-  - PromiseKit/CloudKit (3.0.2):
+  - PromiseKit/CloudKit (3.2.0):
     - PromiseKit/CorePromise
-  - PromiseKit/CoreLocation (3.0.2):
+  - PromiseKit/CoreLocation (3.2.0):
     - PromiseKit/CorePromise
-  - PromiseKit/CorePromise (3.0.2)
-  - PromiseKit/Foundation (3.0.2):
+  - PromiseKit/CorePromise (3.2.0)
+  - PromiseKit/Foundation (3.2.0):
     - OMGHTTPURLRQ (~> 3.1.0)
     - PromiseKit/CorePromise
-  - PromiseKit/MapKit (3.0.2):
+  - PromiseKit/MapKit (3.2.0):
     - PromiseKit/CorePromise
-  - SVProgressHUD (2.0.0)
+  - SVProgressHUD (2.0.3)
 
 DEPENDENCIES:
   - ABReleaseNotesViewController (= 0.1.1)
@@ -67,21 +68,13 @@ DEPENDENCIES:
   - GoogleAnalytics (= 3.14.0)
   - libextobjc (= 0.4.1)
   - Masonry (= 0.6.4)
-  - PromiseKit/CloudKit (= 3.0.2)
-  - PromiseKit/CoreLocation (= 3.0.2)
-  - PromiseKit/CorePromise (= 3.0.2)
-  - PromiseKit/Foundation (= 3.0.2)
-  - PromiseKit/MapKit (= 3.0.2)
-  - SVProgressHUD (from `https://github.com/aaronbrethorst/SVProgressHUD.git`)
-
-EXTERNAL SOURCES:
-  SVProgressHUD:
-    :git: https://github.com/aaronbrethorst/SVProgressHUD.git
-
-CHECKOUT OPTIONS:
-  SVProgressHUD:
-    :commit: 227836711de8955578530359dbffc3636bca2e9b
-    :git: https://github.com/aaronbrethorst/SVProgressHUD.git
+  - OCMock (~> 3.3)
+  - PromiseKit/CloudKit (= 3.2.0)
+  - PromiseKit/CoreLocation (= 3.2.0)
+  - PromiseKit/CorePromise (= 3.2.0)
+  - PromiseKit/Foundation (= 3.2.0)
+  - PromiseKit/MapKit (= 3.2.0)
+  - SVProgressHUD (= 2.0.3)
 
 SPEC CHECKSUMS:
   ABReleaseNotesViewController: 98de9eb73a806192341b228a7a36e37d42d7c174
@@ -91,10 +84,11 @@ SPEC CHECKSUMS:
   GoogleAnalytics: 9be1afdb8deeac4bb5f13ca7f7d3b9db2a1f43dc
   libextobjc: a650fc1bf489a3d3a9bc2e621efa3e1006fc5471
   Masonry: 281802d04d787ea2973179ee8bcb50500579ede2
+  OCMock: f3f61e6eaa16038c30caa5798c5e49d3307b6f22
   OMGHTTPURLRQ: 38316b56d88125c600bcdb16df8329147da2b0ee
-  PromiseKit: ab1a380f7a30cf8cce663a2411e8b3580b10313d
-  SVProgressHUD: d10505169d392b402f4ea4b7d842324ca797e073
+  PromiseKit: 1db024241265f428137a9f3c00ff9590740c4be6
+  SVProgressHUD: b0830714205bea1317ea1a2ebc71e5633af334d4
 
-PODFILE CHECKSUM: c9daf1be4c6de0a1e003c3cd1a40c69bbed51354
+PODFILE CHECKSUM: 44fe2e8c0ca8bb61cc678d0acb53f65df32f2d1a
 
 COCOAPODS: 1.0.1

--- a/gpx_files/sandiego.gpx
+++ b/gpx_files/sandiego.gpx
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<gpx
+xmlns="http://www.topografix.com/GPX/1/1"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd"
+version="1.1"
+creator="gpx-poi.com">
+   <wpt lat="32.715723" lon="-117.161065">
+      <time>2015-12-01T03:01:44Z</time>
+   </wpt>
+</gpx>

--- a/main.m
+++ b/main.m
@@ -15,8 +15,7 @@
  */
 
 #import <UIKit/UIKit.h>
-
-BOOL executingTests;
+#import <OBAKit/OBAKit.h>
 
 @interface OBATestAppDelegate : UIResponder <UIApplicationDelegate>
 @end
@@ -25,12 +24,19 @@ BOOL executingTests;
 
 int main(int argc, char *argv[]) {
     @autoreleasepool {
+        NSDictionary *processInfoEnv = [NSProcessInfo processInfo].environment;
 
-        executingTests = [[[NSProcessInfo processInfo].environment[@"XCInjectBundle"] pathExtension] isEqual:@"xctest"];
+        BOOL executingTests = [[processInfoEnv[@"XCInjectBundle"] pathExtension] isEqual:@"xctest"];
+        if (!executingTests) {
+            executingTests = !!processInfoEnv[@"XCInjectBundleInto"];
+        }
 
         NSString *appDelegateClass = executingTests ? @"OBATestAppDelegate" : @"OBAApplicationDelegate";
+
+        [OBACommon setRunningInsideTests:executingTests];
 
         int retVal = UIApplicationMain(argc, argv, nil, appDelegateClass);
         return retVal;
     }
 }
+

--- a/org.onebusaway.iphone.xcodeproj/project.pbxproj
+++ b/org.onebusaway.iphone.xcodeproj/project.pbxproj
@@ -122,6 +122,7 @@
 		934446D91AB12C5D005B3333 /* OBAModalActivityIndicator.m in Sources */ = {isa = PBXBuildFile; fileRef = 934446D61AB12C5D005B3333 /* OBAModalActivityIndicator.m */; };
 		934446DA1AB12C5D005B3333 /* OBAProgressIndicatorView.m in Sources */ = {isa = PBXBuildFile; fileRef = 934446D81AB12C5D005B3333 /* OBAProgressIndicatorView.m */; };
 		934522601C1BA976006F75BC /* OBATheme.m in Sources */ = {isa = PBXBuildFile; fileRef = 9345225F1C1BA976006F75BC /* OBATheme.m */; };
+		9347860E1D3453E9002A5627 /* sandiego.gpx in Resources */ = {isa = PBXBuildFile; fileRef = 9347860D1D3453E9002A5627 /* sandiego.gpx */; };
 		934B62971CF825D200D8FA85 /* OBATripScheduleSectionBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 934B62961CF825D200D8FA85 /* OBATripScheduleSectionBuilder.m */; };
 		934B62A21CFBA5FA00D8FA85 /* NSObject+OBADescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 934B62A01CFBA5FA00D8FA85 /* NSObject+OBADescription.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		934B62A31CFBA5FA00D8FA85 /* NSObject+OBADescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 934B62A11CFBA5FA00D8FA85 /* NSObject+OBADescription.m */; };
@@ -275,6 +276,7 @@
 		93528AAE1C8D50D200783E9A /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 93528AAD1C8D50D200783E9A /* MapKit.framework */; };
 		93528AB11C8D517100783E9A /* CloudKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 93528AB01C8D517100783E9A /* CloudKit.framework */; };
 		93631E4C1604F96800CB7209 /* OBAApplicationDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 93631E4B1604F96800CB7209 /* OBAApplicationDelegate.m */; };
+		9364BF851CFE9F420039F7D4 /* OBABookmarkRouteDisambiguationViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 9364BF841CFE9F420039F7D4 /* OBABookmarkRouteDisambiguationViewController.m */; };
 		936D2EDB1C78D7140060B7E1 /* OBADataSourceConfig_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 936D2EDA1C78D7140060B7E1 /* OBADataSourceConfig_Tests.m */; };
 		936D2EDD1C78D7300060B7E1 /* OBAURLHelpers_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 936D2EDC1C78D7300060B7E1 /* OBAURLHelpers_Tests.m */; };
 		936D2EE21C79B4030060B7E1 /* OBAStopViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 936D2EE11C79B4030060B7E1 /* OBAStopViewController.m */; };
@@ -299,6 +301,8 @@
 		936F45DC1C78D06600C61656 /* OneBusAwayTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 936F45DB1C78D06600C61656 /* OneBusAwayTests.m */; };
 		9388E9DD1A9BCC8900C9F6CE /* feedback_message_body.html in Resources */ = {isa = PBXBuildFile; fileRef = 9388E9DC1A9BCC8900C9F6CE /* feedback_message_body.html */; };
 		9399E3DF1C8930C300962292 /* OBASeparatorSectionView.m in Sources */ = {isa = PBXBuildFile; fileRef = 9399E3DE1C8930C300962292 /* OBASeparatorSectionView.m */; };
+		939C23B11D36228A002A4145 /* OBABookmarkedRouteRow.m in Sources */ = {isa = PBXBuildFile; fileRef = 939C23B01D36228A002A4145 /* OBABookmarkedRouteRow.m */; };
+		939C23B91D371DE8002A4145 /* OBABookmarkedRouteCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 939C23B81D371DE8002A4145 /* OBABookmarkedRouteCell.m */; };
 		939E8E5B1C7B815E008FCA4C /* OBABaseRow.m in Sources */ = {isa = PBXBuildFile; fileRef = 939E8E5A1C7B815E008FCA4C /* OBABaseRow.m */; };
 		93A923A21C21DCD600A657C8 /* SafariServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 93A923A11C21DCD600A657C8 /* SafariServices.framework */; };
 		93AD36431603FE7E00BDF03F /* OBAArrivalEntryTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 93AD363A1603FE7E00BDF03F /* OBAArrivalEntryTableViewCell.m */; };
@@ -312,6 +316,7 @@
 		93E4A7621CE65B2100E769B0 /* atlanta.gpx in Resources */ = {isa = PBXBuildFile; fileRef = 93E4A7611CE65B2100E769B0 /* atlanta.gpx */; };
 		93F05A631C8E080000BF36B1 /* OBAAnimation.m in Sources */ = {isa = PBXBuildFile; fileRef = 93F05A621C8E080000BF36B1 /* OBAAnimation.m */; };
 		93F64E971BE5ACC300323527 /* OBAAlerts.m in Sources */ = {isa = PBXBuildFile; fileRef = 93F64E961BE5ACC300323527 /* OBAAlerts.m */; };
+		93F8F4431D375B77008659D2 /* OBAArrivalAndDepartureSectionBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 93F8F4421D375B77008659D2 /* OBAArrivalAndDepartureSectionBuilder.m */; };
 		C4402BFD381C435E877939FF /* Pods_OneBusAwayTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FEDB575BE5B5DDBA090E58E0 /* Pods_OneBusAwayTests.framework */; };
 		D651BB2811C9D5DE001BE733 /* iTunesArtwork in Resources */ = {isa = PBXBuildFile; fileRef = D651BB2711C9D5DE001BE733 /* iTunesArtwork */; };
 		D6575AEC0FEE13CF00D6D987 /* Entitlements.plist in Resources */ = {isa = PBXBuildFile; fileRef = D6575AEB0FEE13CF00D6D987 /* Entitlements.plist */; };
@@ -521,6 +526,7 @@
 		934446D81AB12C5D005B3333 /* OBAProgressIndicatorView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAProgressIndicatorView.m; sourceTree = "<group>"; };
 		9345225E1C1BA976006F75BC /* OBATheme.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBATheme.h; sourceTree = "<group>"; };
 		9345225F1C1BA976006F75BC /* OBATheme.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBATheme.m; sourceTree = "<group>"; };
+		9347860D1D3453E9002A5627 /* sandiego.gpx */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = sandiego.gpx; sourceTree = "<group>"; };
 		934B62951CF825D200D8FA85 /* OBATripScheduleSectionBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBATripScheduleSectionBuilder.h; sourceTree = "<group>"; };
 		934B62961CF825D200D8FA85 /* OBATripScheduleSectionBuilder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBATripScheduleSectionBuilder.m; sourceTree = "<group>"; };
 		934B62A01CFBA5FA00D8FA85 /* NSObject+OBADescription.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSObject+OBADescription.h"; sourceTree = "<group>"; };
@@ -677,6 +683,8 @@
 		93528AB01C8D517100783E9A /* CloudKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CloudKit.framework; path = System/Library/Frameworks/CloudKit.framework; sourceTree = SDKROOT; };
 		93631E4A1604F96800CB7209 /* OBAApplicationDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAApplicationDelegate.h; sourceTree = "<group>"; };
 		93631E4B1604F96800CB7209 /* OBAApplicationDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = OBAApplicationDelegate.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
+		9364BF831CFE9F420039F7D4 /* OBABookmarkRouteDisambiguationViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBABookmarkRouteDisambiguationViewController.h; sourceTree = "<group>"; };
+		9364BF841CFE9F420039F7D4 /* OBABookmarkRouteDisambiguationViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBABookmarkRouteDisambiguationViewController.m; sourceTree = "<group>"; };
 		936D2EDA1C78D7140060B7E1 /* OBADataSourceConfig_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBADataSourceConfig_Tests.m; sourceTree = "<group>"; };
 		936D2EDC1C78D7300060B7E1 /* OBAURLHelpers_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAURLHelpers_Tests.m; sourceTree = "<group>"; };
 		936D2EE01C79B4030060B7E1 /* OBAStopViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAStopViewController.h; sourceTree = "<group>"; };
@@ -719,6 +727,10 @@
 		9388E9DC1A9BCC8900C9F6CE /* feedback_message_body.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; name = feedback_message_body.html; path = Resources/feedback_message_body.html; sourceTree = "<group>"; };
 		9399E3DD1C8930C300962292 /* OBASeparatorSectionView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBASeparatorSectionView.h; sourceTree = "<group>"; };
 		9399E3DE1C8930C300962292 /* OBASeparatorSectionView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBASeparatorSectionView.m; sourceTree = "<group>"; };
+		939C23AF1D36228A002A4145 /* OBABookmarkedRouteRow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBABookmarkedRouteRow.h; sourceTree = "<group>"; };
+		939C23B01D36228A002A4145 /* OBABookmarkedRouteRow.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBABookmarkedRouteRow.m; sourceTree = "<group>"; };
+		939C23B71D371DE8002A4145 /* OBABookmarkedRouteCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBABookmarkedRouteCell.h; sourceTree = "<group>"; };
+		939C23B81D371DE8002A4145 /* OBABookmarkedRouteCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBABookmarkedRouteCell.m; sourceTree = "<group>"; };
 		939CEB241C0E406500E1D2B7 /* rvtd.gpx */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = rvtd.gpx; sourceTree = "<group>"; };
 		939E8E4C1C78DCB1008FCA4C /* Pods.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Pods.framework; path = "Pods/../build/Debug-iphoneos/Pods.framework"; sourceTree = "<group>"; };
 		939E8E591C7B815E008FCA4C /* OBABaseRow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBABaseRow.h; sourceTree = "<group>"; };
@@ -745,6 +757,8 @@
 		93F05A621C8E080000BF36B1 /* OBAAnimation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAAnimation.m; sourceTree = "<group>"; };
 		93F64E951BE5ACC300323527 /* OBAAlerts.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAAlerts.h; sourceTree = "<group>"; };
 		93F64E961BE5ACC300323527 /* OBAAlerts.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAAlerts.m; sourceTree = "<group>"; };
+		93F8F4411D375B77008659D2 /* OBAArrivalAndDepartureSectionBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAArrivalAndDepartureSectionBuilder.h; sourceTree = "<group>"; };
+		93F8F4421D375B77008659D2 /* OBAArrivalAndDepartureSectionBuilder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAArrivalAndDepartureSectionBuilder.m; sourceTree = "<group>"; };
 		9ABEF18E98158A7476ECDB64 /* Pods-OneBusAway.adhocdistribution.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OneBusAway.adhocdistribution.xcconfig"; path = "Pods/Target Support Files/Pods-OneBusAway/Pods-OneBusAway.adhocdistribution.xcconfig"; sourceTree = "<group>"; };
 		A553375C73FCAF3CA3D5D44A /* Pods-OneBusAway.appstoredistribution.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OneBusAway.appstoredistribution.xcconfig"; path = "Pods/Target Support Files/Pods-OneBusAway/Pods-OneBusAway.appstoredistribution.xcconfig"; sourceTree = "<group>"; };
 		B522CE42A9FA4C2EBC350330 /* Pods-OneBusAwayTests.adhocdistribution.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OneBusAwayTests.adhocdistribution.xcconfig"; path = "Pods/Target Support Files/Pods-OneBusAwayTests/Pods-OneBusAwayTests.adhocdistribution.xcconfig"; sourceTree = "<group>"; };
@@ -1102,6 +1116,8 @@
 				93B8BA281C9C646E0079A3DA /* OBAArrivalAndDepartureViewController.m */,
 				934B62951CF825D200D8FA85 /* OBATripScheduleSectionBuilder.h */,
 				934B62961CF825D200D8FA85 /* OBATripScheduleSectionBuilder.m */,
+				93F8F4411D375B77008659D2 /* OBAArrivalAndDepartureSectionBuilder.h */,
+				93F8F4421D375B77008659D2 /* OBAArrivalAndDepartureSectionBuilder.m */,
 			);
 			path = trip_details;
 			sourceTree = "<group>";
@@ -1123,6 +1139,7 @@
 		932BE4E21AB66E3C0011F2FB /* bookmarks */ = {
 			isa = PBXGroup;
 			children = (
+				939C23AE1D362209002A4145 /* tableview */,
 				932BE4E31AB66E3C0011F2FB /* OBAEditBookmarkGroupViewController.h */,
 				932BE4E41AB66E3C0011F2FB /* OBAEditBookmarkGroupViewController.m */,
 				932BE4E51AB66E3C0011F2FB /* OBAEditStopBookmarkGroupViewController.h */,
@@ -1131,6 +1148,8 @@
 				932BE4E81AB66E3C0011F2FB /* OBAEditStopBookmarkViewController.m */,
 				9320764A1C915441005F7D4A /* OBABookmarksViewController.h */,
 				9320764B1C915441005F7D4A /* OBABookmarksViewController.m */,
+				9364BF831CFE9F420039F7D4 /* OBABookmarkRouteDisambiguationViewController.h */,
+				9364BF841CFE9F420039F7D4 /* OBABookmarkRouteDisambiguationViewController.m */,
 			);
 			path = bookmarks;
 			sourceTree = "<group>";
@@ -1186,6 +1205,7 @@
 		934445F71AB105FB005B3333 /* gpx_files */ = {
 			isa = PBXGroup;
 			children = (
+				9347860D1D3453E9002A5627 /* sandiego.gpx */,
 				93E4A7611CE65B2100E769B0 /* atlanta.gpx */,
 				939CEB241C0E406500E1D2B7 /* rvtd.gpx */,
 				934445F81AB105FB005B3333 /* capitolhill.gpx */,
@@ -1553,6 +1573,17 @@
 			path = section_headers;
 			sourceTree = "<group>";
 		};
+		939C23AE1D362209002A4145 /* tableview */ = {
+			isa = PBXGroup;
+			children = (
+				939C23AF1D36228A002A4145 /* OBABookmarkedRouteRow.h */,
+				939C23B01D36228A002A4145 /* OBABookmarkedRouteRow.m */,
+				939C23B71D371DE8002A4145 /* OBABookmarkedRouteCell.h */,
+				939C23B81D371DE8002A4145 /* OBABookmarkedRouteCell.m */,
+			);
+			path = tableview;
+			sourceTree = "<group>";
+		};
 		93AD36371603FE4600BDF03F /* controls */ = {
 			isa = PBXGroup;
 			children = (
@@ -1822,6 +1853,7 @@
 					};
 					936F44FC1C780E7600C61656 = {
 						CreatedOnToolsVersion = 7.2.1;
+						DevelopmentTeam = HJFS9K2ZYE;
 					};
 					936F45D81C78D06600C61656 = {
 						CreatedOnToolsVersion = 7.2.1;
@@ -1866,6 +1898,7 @@
 				93E4A7621CE65B2100E769B0 /* atlanta.gpx in Resources */,
 				932BE5011AB66F990011F2FB /* OBAArrivalEntryTableViewCell.xib in Resources */,
 				932BE5151AB672940011F2FB /* OBATextFieldTableViewCell.xib in Resources */,
+				9347860E1D3453E9002A5627 /* sandiego.gpx in Resources */,
 				932BE5031AB66FCB0011F2FB /* OBACreditsViewController.xib in Resources */,
 				9330DEEA16050CA600E14AF4 /* credits.html in Resources */,
 				9388E9DD1A9BCC8900C9F6CE /* feedback_message_body.html in Resources */,
@@ -2033,6 +2066,7 @@
 				932BE4FF1AB66EF20011F2FB /* OBARecentStopsViewController.m in Sources */,
 				936D62821C8CEA930070152B /* OBADepartureCellHelpers.m in Sources */,
 				1D60589B0D05DD56006BFB54 /* main.m in Sources */,
+				939C23B11D36228A002A4145 /* OBABookmarkedRouteRow.m in Sources */,
 				932BE4CF1AB66D710011F2FB /* OBATripDetailsViewController.m in Sources */,
 				93AD36431603FE7E00BDF03F /* OBAArrivalEntryTableViewCell.m in Sources */,
 				934446D91AB12C5D005B3333 /* OBAModalActivityIndicator.m in Sources */,
@@ -2071,6 +2105,7 @@
 				932BE49D1AB66D320011F2FB /* OBAAgenciesListViewController.m in Sources */,
 				669B2F781AEBFCB300CF2367 /* OBAAnalytics.m in Sources */,
 				932BE4E91AB66E3C0011F2FB /* OBAEditBookmarkGroupViewController.m in Sources */,
+				93F8F4431D375B77008659D2 /* OBAArrivalAndDepartureSectionBuilder.m in Sources */,
 				932BE4A11AB66D320011F2FB /* OBARegionListViewController.m in Sources */,
 				932BE4EA1AB66E3C0011F2FB /* OBAEditStopBookmarkGroupViewController.m in Sources */,
 				9399E3DF1C8930C300962292 /* OBASeparatorSectionView.m in Sources */,
@@ -2080,6 +2115,7 @@
 				93E4A3011CF7D42300EF9595 /* OBAClassicDepartureView.m in Sources */,
 				939E8E5B1C7B815E008FCA4C /* OBABaseRow.m in Sources */,
 				934446CF1AB12B29005B3333 /* OBARequestDrivenTableViewController.m in Sources */,
+				939C23B91D371DE8002A4145 /* OBABookmarkedRouteCell.m in Sources */,
 				936D627F1C8CE24A0070152B /* OBAClassicDepartureCell.m in Sources */,
 				932BE4D11AB66D710011F2FB /* OBATripScheduleMapViewController.m in Sources */,
 				932BE4DE1AB66DA90011F2FB /* OBACustomApiViewController.m in Sources */,
@@ -2089,6 +2125,7 @@
 				936D62881C8D00150070152B /* OBALabelFooterView.m in Sources */,
 				936D62791C8A64240070152B /* OBAParallaxTableHeaderView.m in Sources */,
 				934446D11AB12B29005B3333 /* OBAWebViewController.m in Sources */,
+				9364BF851CFE9F420039F7D4 /* OBABookmarkRouteDisambiguationViewController.m in Sources */,
 				932BE4BE1AB66D5C0011F2FB /* OBAReportProblemWithRecentTripsViewController.m in Sources */,
 				932BE4D91AB66D890011F2FB /* OBADiversionViewController.m in Sources */,
 				932BE4F61AB66E990011F2FB /* OBASearchController.m in Sources */,

--- a/org.onebusaway.iphone.xcodeproj/xcshareddata/xcschemes/OBAKit.xcscheme
+++ b/org.onebusaway.iphone.xcodeproj/xcshareddata/xcschemes/OBAKit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/org.onebusaway.iphone.xcodeproj/xcshareddata/xcschemes/OneBusAway.xcscheme
+++ b/org.onebusaway.iphone.xcodeproj/xcshareddata/xcschemes/OneBusAway.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0800"
    version = "1.8">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -77,8 +77,8 @@
       <AdditionalOptions>
       </AdditionalOptions>
       <LocationScenarioReference
-         identifier = "com.apple.dt.IDEFoundation.CurrentLocationScenarioIdentifier"
-         referenceType = "1">
+         identifier = "../gpx_files/capitolhill.gpx"
+         referenceType = "0">
       </LocationScenarioReference>
    </LaunchAction>
    <ProfileAction

--- a/ui/bookmarks/OBABookmarkRouteDisambiguationViewController.h
+++ b/ui/bookmarks/OBABookmarkRouteDisambiguationViewController.h
@@ -1,0 +1,22 @@
+//
+//  OBABookmarkRouteDisambiguationViewController.h
+//  org.onebusaway.iphone
+//
+//  Created by Aaron Brethorst on 5/31/16.
+//  Copyright © 2016 OneBusAway. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import "OBAStaticTableViewController.h"
+
+@class OBAArrivalsAndDeparturesForStopV2;
+@class OBARegionV2;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface OBABookmarkRouteDisambiguationViewController : OBAStaticTableViewController
+@property(nonatomic,strong) OBARegionV2 *region;
+- (instancetype)initWithArrivalsAndDeparturesForStop:(OBAArrivalsAndDeparturesForStopV2*)arrivalsAndDepartures;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ui/bookmarks/OBABookmarkRouteDisambiguationViewController.m
+++ b/ui/bookmarks/OBABookmarkRouteDisambiguationViewController.m
@@ -1,0 +1,78 @@
+//
+//  OBABookmarkRouteDisambiguationViewController.m
+//  org.onebusaway.iphone
+//
+//  Created by Aaron Brethorst on 5/31/16.
+//  Copyright © 2016 OneBusAway. All rights reserved.
+//
+
+#import "OBABookmarkRouteDisambiguationViewController.h"
+#import <OBAKit/OBAArrivalsAndDeparturesForStopV2.h>
+#import "OBATableRow.h"
+#import "OBAEditStopBookmarkViewController.h"
+#import "OBAApplication.h"
+
+@interface OBABookmarkRouteDisambiguationViewController ()
+@property(nonatomic,strong) OBAArrivalsAndDeparturesForStopV2 *arrivalsAndDepartures;
+@end
+
+@implementation OBABookmarkRouteDisambiguationViewController
+
+- (instancetype)initWithArrivalsAndDeparturesForStop:(OBAArrivalsAndDeparturesForStopV2*)arrivalsAndDepartures {
+    self = [super init];
+
+    if (self) {
+        self.title = NSLocalizedString(@"Choose a Route", @"Title of OBABookmarkRouteDisambiguationViewController");
+        _arrivalsAndDepartures = arrivalsAndDepartures;
+    }
+    return self;
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+    self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Cancel", @"") style:UIBarButtonItemStylePlain target:self action:@selector(cancel)];
+
+    OBATableSection *section = [[OBATableSection alloc] init];
+
+    NSMutableSet *representedItems = [NSMutableSet set];
+
+    for (OBAArrivalAndDepartureV2 *dep in self.arrivalsAndDepartures.arrivalsAndDepartures) {
+
+        // make sure we don't double up bookmarks :-|
+        if ([representedItems containsObject:dep.bookmarkKey]) {
+            continue;
+        }
+        else {
+            [representedItems addObject:dep.bookmarkKey];
+        }
+
+        [section addRow:^OBABaseRow *{
+            OBATableRow *row = [[OBATableRow alloc] initWithTitle:[NSString stringWithFormat:@"%@ - %@", dep.bestAvailableName, dep.tripHeadsign] action:^{
+                OBABookmarkV2 *bookmark = [[OBABookmarkV2 alloc] initWithArrivalAndDeparture:dep region:self.region];
+                OBAEditStopBookmarkViewController *bookmarkViewController = [[OBAEditStopBookmarkViewController alloc] initWithBookmark:bookmark];
+                [self.navigationController pushViewController:bookmarkViewController animated:YES];
+            }];
+            row.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+            return row;
+        }];
+    }
+    self.sections = @[section];
+}
+
+#pragma mark - Actions
+
+- (void)cancel {
+    [self dismissViewControllerAnimated:YES completion:nil];
+}
+
+#pragma mark - Accessors
+
+- (OBARegionV2*)region {
+    if (!_region) {
+        _region = [OBAApplication sharedApplication].modelDao.region;
+    }
+    return _region;
+}
+
+@end

--- a/ui/bookmarks/OBABookmarksViewController.h
+++ b/ui/bookmarks/OBABookmarksViewController.h
@@ -9,6 +9,10 @@
 #import "OBAStaticTableViewController.h"
 #import "OBANavigationTargetAware.h"
 
-@interface OBABookmarksViewController : OBAStaticTableViewController <OBANavigationTargetAware>
+@class OBAModelDAO;
+@class OBAModelService;
 
+@interface OBABookmarksViewController : OBAStaticTableViewController <OBANavigationTargetAware>
+@property(nonatomic,strong) OBAModelDAO *modelDAO;
+@property(nonatomic,strong) OBAModelService *modelService;
 @end

--- a/ui/bookmarks/OBABookmarksViewController.m
+++ b/ui/bookmarks/OBABookmarksViewController.m
@@ -11,6 +11,11 @@
 #import "OBABookmarkGroup.h"
 #import "OBAStopViewController.h"
 #import "OBAEditStopBookmarkViewController.h"
+#import <OBAKit/OBAModelDAO.h>
+#import <OBAKit/OBAArrivalAndDepartureV2.h>
+#import "OBABookmarkedRouteRow.h"
+#import "OBAArrivalAndDepartureSectionBuilder.h"
+#import "OBAClassicDepartureRow.h"
 
 @implementation OBABookmarksViewController
 
@@ -31,6 +36,9 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
 
+    self.tableView.estimatedRowHeight = 80.f;
+    self.tableView.rowHeight = UITableViewAutomaticDimension;
+
     self.tableView.allowsSelectionDuringEditing = YES;
     self.navigationItem.leftBarButtonItem = self.editButtonItem;
 }
@@ -50,7 +58,7 @@
     [self loadData];
 }
 
-#pragma mark OBANavigationTargetAware
+#pragma mark -  OBANavigationTargetAware
 
 - (OBANavigationTarget *)navigationTarget {
     return [OBANavigationTarget target:OBANavigationTargetTypeBookmarks];
@@ -66,10 +74,7 @@
     for (OBABookmarkGroup *group in modelDAO.bookmarkGroups) {
         NSArray *rows = [self tableRowsFromBookmarks:group.bookmarks];
         OBATableSection *section = [[OBATableSection alloc] initWithTitle:group.name rows:rows];
-
-        if (section.rows.count > 0) {
-            [sections addObject:section];
-        }
+        [sections addObject:section];
     }
 
     OBATableSection *looseBookmarks = [[OBATableSection alloc] initWithTitle:NSLocalizedString(@"Bookmarks", @"") rows:[self tableRowsFromBookmarks:modelDAO.ungroupedBookmarks]];
@@ -81,20 +86,77 @@
     [self.tableView reloadData];
 }
 
+#pragma mark - Editing
+
+- (void)setEditing:(BOOL)editing animated:(BOOL)animated {
+    [super setEditing:editing animated:animated];
+
+    UIBarButtonItem *rightBarItem = nil;
+
+    if (editing) {
+        rightBarItem = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Add Group", @"") style:UIBarButtonItemStylePlain target:self action:@selector(addBookmarkGroup)];
+    }
+
+    self.navigationItem.rightBarButtonItem = rightBarItem;
+}
+
+#pragma mark - Actions
+
+- (void)addBookmarkGroup {
+    UIAlertController *alertController = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"Add Bookmark Group", @"") message:nil preferredStyle:UIAlertControllerStyleAlert];
+    [alertController addTextFieldWithConfigurationHandler:^(UITextField *textField) {
+        textField.placeholder = NSLocalizedString(@"Name of Group", @"");
+    }];
+
+    [alertController addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", @"") style:UIAlertActionStyleCancel handler:nil]];
+    [alertController addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Save", @"") style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+        OBABookmarkGroup *group = [[OBABookmarkGroup alloc] initWithName:alertController.textFields[0].text];
+        [self.modelDAO saveBookmarkGroup:group];
+        [self loadData];
+    }]];
+
+    [self presentViewController:alertController animated:YES completion:nil];
+}
+
 #pragma mark - UITableView
 
 - (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath {
     return YES;
 }
 
-// TODO: Disabled for now. This requires more time and attention than I can give it at the
-// moment. I'd love to re-enable this feature, and soon, though.
 - (BOOL)tableView:(UITableView*)tableView canMoveRowAtIndexPath:(NSIndexPath *)indexPath {
-    return NO;
+    return YES;
 }
 
 - (void)tableView:(UITableView *)tableView commitEditingStyle:(UITableViewCellEditingStyle)editingStyle forRowAtIndexPath:(NSIndexPath *)indexPath {
 
+    if (editingStyle == UITableViewCellEditingStyleDelete) {
+        [self deleteRowAtIndexPath:indexPath tableView:tableView];
+    }
+}
+
+- (void)tableView:(UITableView*)tableView moveRowAtIndexPath:(NSIndexPath *)sourceIndexPath toIndexPath:(NSIndexPath *)destinationIndexPath {
+    OBABookmarkGroup *sourceGroup = sourceIndexPath.section == self.modelDAO.bookmarkGroups.count ? nil : self.modelDAO.bookmarkGroups[sourceIndexPath.section];
+    OBABookmarkGroup *destinationGroup = destinationIndexPath.section == self.modelDAO.bookmarkGroups.count ? nil : self.modelDAO.bookmarkGroups[destinationIndexPath.section];
+
+    OBABookmarkV2 *bookmark = [self.modelDAO bookmarkAtIndex:sourceIndexPath.row inGroup:sourceGroup];
+
+    if (bookmark) {
+        [self.modelDAO moveBookmark:bookmark toIndex:destinationIndexPath.row inGroup:destinationGroup];
+    }
+}
+
+- (NSArray<UITableViewRowAction *> *)tableView:(UITableView *)tableView editActionsForRowAtIndexPath:(NSIndexPath *)indexPath {
+    UITableViewRowAction *action = [UITableViewRowAction rowActionWithStyle:UITableViewRowActionStyleDestructive title:NSLocalizedString(@"Delete", @"Title of delete bookmark row action.") handler:^(UITableViewRowAction *action, NSIndexPath *indexPath) {
+        [self deleteRowAtIndexPath:indexPath tableView:tableView];
+    }];
+
+    return @[action];
+}
+
+#pragma mark - Table Row Deletion
+
+- (void)deleteRowAtIndexPath:(NSIndexPath*)indexPath tableView:(UITableView*)tableView {
     OBATableSection *tableSection = self.sections[indexPath.section];
     OBATableRow *tableRow = tableSection.rows[indexPath.row];
 
@@ -113,6 +175,20 @@
 
 - (OBARegionV2*)currentRegion {
     return [OBAApplication sharedApplication].modelDao.region;
+}
+
+- (OBAModelDAO*)modelDAO {
+    if (!_modelDAO) {
+        _modelDAO = [OBAApplication sharedApplication].modelDao;
+    }
+    return _modelDAO;
+}
+
+- (OBAModelService*)modelService {
+    if (!_modelService) {
+        _modelService = [OBAApplication sharedApplication].modelService;
+    }
+    return _modelService;
 }
 
 #pragma mark - Private
@@ -136,25 +212,72 @@
             continue;
         }
 
-        OBATableRow *row = [[OBATableRow alloc] initWithTitle:bm.name action:^{
-            OBAStopViewController *controller = [[OBAStopViewController alloc] initWithStopID:bm.stopId];
-            [self.navigationController pushViewController:controller animated:YES];
-        }];
+        OBABaseRow *row = [self tableRowForBookmark:bm];
 
-        row.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
-
-        [row setEditAction:^{
-            OBAEditStopBookmarkViewController *editor = [[OBAEditStopBookmarkViewController alloc] initWithBookmark:bm forStop:bm.stop];
-            UINavigationController *nav = [[UINavigationController alloc] initWithRootViewController:editor];
-            [self presentViewController:nav animated:YES completion:nil];
-        }];
-        [row setDeleteModel:^{
-            [[OBAApplication sharedApplication].modelDao removeBookmark:bm];
-        }];
         [rows addObject:row];
     }
 
     return rows;
+}
+
+#pragma mark - Row Builders
+
+/** 
+ This is the entry point to all of the row builders.
+ */
+- (OBABaseRow*)tableRowForBookmark:(OBABookmarkV2*)bookmark {
+    if (bookmark.bookmarkVersion > OBABookmarkVersion252) {
+        return [self rowForBookmarkVersion260:bookmark];
+    }
+    else {
+        return [self rowForBookmarkVersion252:bookmark];
+    }
+}
+
+- (OBABaseRow*)rowForBookmarkVersion252:(OBABookmarkV2*)bm {
+    OBATableRow *row = [[OBATableRow alloc] initWithTitle:bm.name action:^{
+        OBAStopViewController *controller = [[OBAStopViewController alloc] initWithStopID:bm.stopId];
+        [self.navigationController pushViewController:controller animated:YES];
+    }];
+
+    [self performCommonBookmarkRowConfiguration:row forBookmark:bm];
+
+    return row;
+}
+
+- (OBABaseRow*)rowForBookmarkVersion260:(OBABookmarkV2*)bookmark {
+    OBABookmarkedRouteRow *row = [[OBABookmarkedRouteRow alloc] initWithAction:^{
+        OBAStopViewController *controller = [[OBAStopViewController alloc] initWithStopID:bookmark.stopId];
+        [self.navigationController pushViewController:controller animated:YES];
+    }];
+    row.bookmark = bookmark;
+
+    [self.modelService requestStopForID:bookmark.stopId minutesBefore:0 minutesAfter:35].then(^(OBAArrivalsAndDeparturesForStopV2 *response) {
+        NSArray<OBAArrivalAndDepartureV2*> *matchingDepartures = [bookmark matchingArrivalsAndDeparturesForStop:response];
+        ((OBABookmarkedRouteRow*)row).nextDeparture = matchingDepartures.firstObject;
+        NSIndexPath *indexPath = [self indexPathForRow:row];
+        [self.tableView reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
+    }).catch(^(NSError *error) {
+        NSLog(@"Failed to load departure for bookmark: %@", error);
+    });
+
+    [self performCommonBookmarkRowConfiguration:row forBookmark:bookmark];
+
+    return row;
+}
+
+- (void)performCommonBookmarkRowConfiguration:(OBABaseRow*)row forBookmark:(OBABookmarkV2*)bookmark {
+    row.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+
+    [row setEditAction:^{
+        OBAEditStopBookmarkViewController *editor = [[OBAEditStopBookmarkViewController alloc] initWithBookmark:bookmark];
+        UINavigationController *nav = [[UINavigationController alloc] initWithRootViewController:editor];
+        [self presentViewController:nav animated:YES completion:nil];
+    }];
+
+    [row setDeleteModel:^{
+        [[OBAApplication sharedApplication].modelDao removeBookmark:bookmark];
+    }];
 }
 
 @end

--- a/ui/bookmarks/OBAEditStopBookmarkViewController.h
+++ b/ui/bookmarks/OBAEditStopBookmarkViewController.h
@@ -17,12 +17,12 @@
 #import <OBAKit/OBABookmarkV2.h>
 #import "OBAEditStopBookmarkGroupViewController.h"
 
-@class OBAStopV2;
+@class OBAArrivalAndDepartureV2;
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface OBAEditStopBookmarkViewController : UITableViewController <OBABookmarkGroupVCDelegate>
-- (instancetype)initWithBookmark:(OBABookmarkV2 *)bookmark forStop:(OBAStopV2*)stop;
+- (instancetype)initWithBookmark:(OBABookmarkV2 *)bookmark;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ui/bookmarks/OBAEditStopBookmarkViewController.m
+++ b/ui/bookmarks/OBAEditStopBookmarkViewController.m
@@ -24,24 +24,25 @@
 #import "OBAAnalytics.h"
 #import "UITableViewCell+oba_Additions.h"
 #import "OBAApplication.h"
+#import <OBAKit/OBAKit.h>
 
 @interface OBAEditStopBookmarkViewController ()
-@property (nonatomic, strong) OBABookmarkV2 *bookmark;
-@property (nonatomic, strong) OBABookmarkGroup *selectedGroup;
-@property (nonatomic, strong) NSHashTable *requests;
-@property (nonatomic, strong) NSMutableDictionary *stops;
-@property (nonatomic, strong) UITextField *textField;
+@property(nonatomic,strong) OBABookmarkV2 *bookmark;
+@property(nonatomic,strong) OBABookmarkGroup *selectedGroup;
+@property(nonatomic,strong) NSHashTable *requests;
+@property(nonatomic,strong) NSMutableDictionary *stops;
+@property(nonatomic,strong) UITextField *textField;
 @end
 
 @implementation OBAEditStopBookmarkViewController
 
-- (instancetype)initWithBookmark:(OBABookmarkV2 *)bookmark forStop:(OBAStopV2*)stop {
+- (instancetype)initWithBookmark:(OBABookmarkV2 *)bookmark {
     self = [super init];
 
     if (self) {
         self.tableView.scrollEnabled = NO;
 
-        _bookmark = bookmark ?: [[OBABookmarkV2 alloc] initWithStop:stop region:[OBAApplication sharedApplication].modelDao.region];
+        _bookmark = bookmark;
         _selectedGroup = _bookmark.group;
 
         _requests = [NSHashTable weakObjectsHashTable];

--- a/ui/bookmarks/tableview/OBABookmarkedRouteCell.h
+++ b/ui/bookmarks/tableview/OBABookmarkedRouteCell.h
@@ -1,0 +1,14 @@
+//
+//  OBABookmarkedRouteCell.h
+//  org.onebusaway.iphone
+//
+//  Created by Aaron Brethorst on 7/13/16.
+//  Copyright © 2016 OneBusAway. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import "OBATableCell.h"
+
+@interface OBABookmarkedRouteCell : UITableViewCell<OBATableCell>
+
+@end

--- a/ui/bookmarks/tableview/OBABookmarkedRouteCell.m
+++ b/ui/bookmarks/tableview/OBABookmarkedRouteCell.m
@@ -1,0 +1,88 @@
+//
+//  OBABookmarkedRouteCell.m
+//  org.onebusaway.iphone
+//
+//  Created by Aaron Brethorst on 7/13/16.
+//  Copyright © 2016 OneBusAway. All rights reserved.
+//
+
+#import "OBABookmarkedRouteCell.h"
+#import "OBAClassicDepartureView.h"
+#import "OBABookmarkedRouteRow.h"
+#import "OBATableRow.h"
+
+#import <Masonry/Masonry.h>
+#import <OBAKit/OBAUIBuilder.h>
+#import <OBAKit/OBABookmarkV2.h>
+#import "OBAArrivalAndDepartureSectionBuilder.h"
+
+@interface OBABookmarkedRouteCell ()
+@property(nonatomic,strong) UILabel *titleLabel;
+@property(nonatomic,strong) OBAClassicDepartureView *departureView;
+@end
+
+@implementation OBABookmarkedRouteCell
+@synthesize tableRow = _tableRow;
+
+- (instancetype)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier {
+    self = [super initWithStyle:style reuseIdentifier:reuseIdentifier];
+
+    if (self) {
+        self.contentView.clipsToBounds = YES;
+        self.contentView.frame = self.bounds;
+        self.contentView.autoresizingMask = UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleHeight;
+
+        _titleLabel = [OBAUIBuilder label];
+        _titleLabel.numberOfLines = 0;
+        [self.contentView addSubview:_titleLabel];
+
+        _departureView = [[OBAClassicDepartureView alloc] initWithFrame:CGRectZero];
+        [self.contentView addSubview:_departureView];
+
+        [self setupConstraints];
+    }
+    return self;
+}
+
+- (void)setupConstraints {
+    [self.titleLabel mas_makeConstraints:^(MASConstraintMaker *make) {
+        make.left.top.and.right.equalTo(self.contentView).insets(self.layoutMargins);
+    }];
+
+    [self.departureView mas_makeConstraints:^(MASConstraintMaker *make) {
+        make.top.equalTo(self.titleLabel.mas_bottom);
+        make.left.right.and.bottom.equalTo(self.contentView).insets(self.layoutMargins);
+    }];
+}
+
+- (void)prepareForReuse {
+    [super prepareForReuse];
+
+    self.titleLabel.text = nil;
+
+    self.departureView.routeNameLabel.text = nil;
+    self.departureView.destinationLabel.text = nil;
+    self.departureView.timeAndStatusLabel.text = nil;
+    self.departureView.minutesUntilDepartureLabel.text = nil;
+}
+
+- (void)setTableRow:(OBATableRow *)tableRow
+{
+    OBAGuardClass(tableRow, OBABookmarkedRouteRow) else {
+        return;
+    }
+
+    _tableRow = [tableRow copy];
+
+    self.titleLabel.text = [self tableDataRow].bookmark.name;
+
+    if ([self tableDataRow].nextDeparture) {
+        self.departureView.classicDepartureRow = [OBAArrivalAndDepartureSectionBuilder createDepartureRow:[self tableDataRow].nextDeparture];
+    }
+}
+
+- (OBABookmarkedRouteRow*)tableDataRow {
+    return (OBABookmarkedRouteRow*)self.tableRow;
+}
+
+@end

--- a/ui/bookmarks/tableview/OBABookmarkedRouteRow.h
+++ b/ui/bookmarks/tableview/OBABookmarkedRouteRow.h
@@ -1,0 +1,17 @@
+//
+//  OBABookmarkedRouteRow.h
+//  org.onebusaway.iphone
+//
+//  Created by Aaron Brethorst on 7/13/16.
+//  Copyright © 2016 OneBusAway. All rights reserved.
+//
+
+#import "OBABaseRow.h"
+
+@class OBABookmarkV2;
+@class OBAArrivalAndDepartureV2;
+
+@interface OBABookmarkedRouteRow : OBABaseRow
+@property(nonatomic,copy) OBABookmarkV2 *bookmark;
+@property(nonatomic,strong) OBAArrivalAndDepartureV2 *nextDeparture;
+@end

--- a/ui/bookmarks/tableview/OBABookmarkedRouteRow.m
+++ b/ui/bookmarks/tableview/OBABookmarkedRouteRow.m
@@ -1,0 +1,32 @@
+//
+//  OBABookmarkedRouteRow.m
+//  org.onebusaway.iphone
+//
+//  Created by Aaron Brethorst on 7/13/16.
+//  Copyright © 2016 OneBusAway. All rights reserved.
+//
+
+#import "OBABookmarkedRouteRow.h"
+#import <OBAKit/OBAKit.h>
+#import "OBAViewModelRegistry.h"
+#import "OBABookmarkedRouteCell.h"
+
+@implementation OBABookmarkedRouteRow
+
++ (void)load {
+    [OBAViewModelRegistry registerClass:self.class];
+}
+
+- (id)copyWithZone:(NSZone *)zone {
+    OBABookmarkedRouteRow *row = [super copyWithZone:zone];
+    row->_bookmark = [_bookmark copyWithZone:zone];
+    row->_nextDeparture = _nextDeparture;
+
+    return row;
+}
+
++ (void)registerViewsWithTableView:(UITableView *)tableView {
+    [tableView registerClass:[OBABookmarkedRouteCell class] forCellReuseIdentifier:[self cellReuseIdentifier]];
+}
+
+@end

--- a/ui/recent_stops/OBARecentStopsViewController.m
+++ b/ui/recent_stops/OBARecentStopsViewController.m
@@ -54,7 +54,7 @@
 
         [section addRow:^OBABaseRow*{
             OBATableRow *tableRow = [[OBATableRow alloc] initWithTitle:stop.title action:^{
-                UIViewController *vc = [OBAStopViewController stopControllerWithStopID:stop.stopIds[0]];
+                OBAStopViewController *vc = [[OBAStopViewController alloc] initWithStopID:stop.stopIds[0]];
                 [self.navigationController pushViewController:vc animated:YES];
             }];
             tableRow.accessoryType = UITableViewCellAccessoryDisclosureIndicator;

--- a/ui/search/OBASearchResultsListViewController.m
+++ b/ui/search/OBASearchResultsListViewController.m
@@ -181,7 +181,7 @@
         case OBASearchTypeRouteStops: {
             if (self.result.count == 0) break;
             OBAStopV2 * stop = (_result.values)[indexPath.row];
-            UIViewController *vc = [OBAStopViewController stopControllerWithStopID:stop.stopId];
+            OBAStopViewController *vc = [[OBAStopViewController alloc] initWithStopID:stop.stopId];
             [self.navigationController pushViewController:vc animated:YES];
             break;
         }

--- a/ui/search/OBASearchResultsMapViewController.h
+++ b/ui/search/OBASearchResultsMapViewController.h
@@ -22,6 +22,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class OBAModelDAO;
+
 @interface OBASearchResultsMapViewController : UIViewController <OBANavigationTargetAware, OBASearchControllerDelegate, MKMapViewDelegate,OBALocationManagerDelegate,OBAProgressIndicatorDelegate, UISearchBarDelegate>
 @property(nonatomic,strong) OBAApplicationDelegate * appDelegate;
 @property(nonatomic,strong) IBOutlet OBAScopeView *scopeView;

--- a/ui/search/OBASearchResultsMapViewController.m
+++ b/ui/search/OBASearchResultsMapViewController.m
@@ -576,8 +576,8 @@ static const double kStopsInRegionRefreshDelayOnDrag = 0.1;
     id annotation = view.annotation;
 
     if ([annotation respondsToSelector:@selector(stopId)]) {
-        UIViewController *vc = [OBAStopViewController stopControllerWithStopID:[annotation stopId]];
-        [self.navigationController pushViewController:vc animated:YES];
+        OBAStopViewController *stopController = [[OBAStopViewController alloc] initWithStopID:[annotation stopId]];
+        [self.navigationController pushViewController:stopController animated:YES];
     }
     else if ([annotation isKindOfClass:[OBAPlacemark class]]) {
         OBAPlacemark *placemark = annotation;

--- a/ui/static_table/OBAStaticTableViewController.h
+++ b/ui/static_table/OBAStaticTableViewController.h
@@ -29,6 +29,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic,copy,nullable) NSString *emptyDataSetDescription;
 
 - (OBABaseRow*)rowAtIndexPath:(NSIndexPath*)indexPath;
+
+- (nullable NSIndexPath*)indexPathForRow:(OBABaseRow*)row;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ui/static_table/OBAStaticTableViewController.m
+++ b/ui/static_table/OBAStaticTableViewController.m
@@ -58,6 +58,21 @@
     return row;
 }
 
+- (nullable NSIndexPath*)indexPathForRow:(OBABaseRow*)row {
+    for (NSInteger i=0; i<self.sections.count; i++) {
+        OBATableSection *section = self.sections[i];
+        for (NSInteger j=0; j<section.rows.count; j++) {
+            OBABaseRow *candidate = section.rows[j];
+
+            if ([row isEqual:candidate]) {
+                return [NSIndexPath indexPathForRow:j inSection:i];
+            }
+        }
+    }
+
+    return nil;
+}
+
 #pragma mark - UITableView Section Headers
 
 - (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section {
@@ -142,6 +157,16 @@
     else if (!tableView.editing && row.action) {
         row.action();
     }
+}
+
+- (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath {
+    OBABaseRow *row = [self rowAtIndexPath:indexPath];
+    return row.rowActions.count > 0;
+}
+
+- (NSArray<UITableViewRowAction *> *)tableView:(UITableView *)tableView editActionsForRowAtIndexPath:(NSIndexPath *)indexPath {
+    OBABaseRow *row = [self rowAtIndexPath:indexPath];
+    return row.rowActions ?: @[];
 }
 
 #pragma mark - DZNEmptyDataSet

--- a/ui/static_table/cells/OBATableViewCell.m
+++ b/ui/static_table/cells/OBATableViewCell.m
@@ -44,10 +44,6 @@
 @implementation OBATableViewCellValue1
 - (instancetype)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier {
     self = [super initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:reuseIdentifier];
-
-    if (self) {
-        // no-op, i suppose?
-    }
     return self;
 }
 @end
@@ -55,10 +51,6 @@
 @implementation OBATableViewCellValue2
 - (instancetype)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier {
     self = [super initWithStyle:UITableViewCellStyleValue2 reuseIdentifier:reuseIdentifier];
-
-    if (self) {
-        // no-op, i suppose?
-    }
     return self;
 }
 @end
@@ -66,10 +58,6 @@
 @implementation OBATableViewCellSubtitle
 - (instancetype)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier {
     self = [super initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:reuseIdentifier];
-
-    if (self) {
-        // no-op, i suppose?
-    }
     return self;
 }
 @end

--- a/ui/static_table/viewmodels/OBABaseRow.h
+++ b/ui/static_table/viewmodels/OBABaseRow.h
@@ -8,6 +8,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface OBABaseRow : NSObject<NSCopying>
 
 /**
@@ -21,6 +23,11 @@
 @property(nonatomic,copy) void (^editAction)();
 
 /**
+ Optional 'swipe to reveal' buttons for this row.
+ */
+@property(nullable,nonatomic,copy) NSArray<UITableViewRowAction*> *rowActions;
+
+/**
  This block is provided as a convenience for table views where you can delete models. Since it may be difficult
  to associate your row with a model (due to sorting differences or whatever), this block provides an easy way
  to get back to—and delete—the underlying data.
@@ -29,7 +36,9 @@
 
 @property(nonatomic,assign) NSUInteger indentationLevel;
 
-- (instancetype)initWithAction:(void (^)())action NS_DESIGNATED_INITIALIZER;
+@property(nonatomic,assign) UITableViewCellAccessoryType accessoryType;
+
+- (instancetype)initWithAction:(nullable void (^)())action NS_DESIGNATED_INITIALIZER;
 
 + (void)registerViewsWithTableView:(UITableView*)tableView;
 + (NSString*)cellReuseIdentifier;
@@ -41,3 +50,5 @@
  */
 - (NSString*)cellReuseIdentifier;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ui/static_table/viewmodels/OBABaseRow.m
+++ b/ui/static_table/viewmodels/OBABaseRow.m
@@ -34,7 +34,8 @@
     newRow->_editAction = [_editAction copyWithZone:zone];
     newRow->_deleteModel = [_deleteModel copyWithZone:zone];
     newRow->_indentationLevel = _indentationLevel;
-    
+    newRow->_accessoryType = _accessoryType;
+
     return newRow;
 }
 

--- a/ui/static_table/viewmodels/OBATableRow.h
+++ b/ui/static_table/viewmodels/OBATableRow.h
@@ -12,7 +12,6 @@
 @property(nonatomic,copy) NSString *title;
 @property(nonatomic,copy) NSString *subtitle;
 @property(nonatomic,assign) UITableViewCellStyle style;
-@property(nonatomic,assign) UITableViewCellAccessoryType accessoryType;
 @property(nonatomic,strong) UIImage *image;
 @property(nonatomic,assign) NSTextAlignment textAlignment;
 

--- a/ui/static_table/viewmodels/OBATableRow.m
+++ b/ui/static_table/viewmodels/OBATableRow.m
@@ -36,11 +36,10 @@ static NSString * const OBACellStyleSubtitleReuseIdentifier = @"OBACellStyleSubt
 }
 
 - (id)copyWithZone:(NSZone *)zone {
-    OBATableRow *newRow = [[self.class allocWithZone:zone] init];
+    OBATableRow *newRow = [super copyWithZone:zone];
     newRow->_title = [_title copyWithZone:zone];
     newRow->_subtitle = [_subtitle copyWithZone:zone];
     newRow->_style = _style;
-    newRow->_accessoryType = _accessoryType;
     newRow->_image = _image;
     newRow->_textAlignment = _textAlignment;
 

--- a/ui/stops/OBAClassicDepartureCell.m
+++ b/ui/stops/OBAClassicDepartureCell.m
@@ -23,9 +23,12 @@
 
     if (self) {
         self.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
-        _departureView = [[OBAClassicDepartureView alloc] initWithFrame:self.contentView.bounds];
-        _departureView.autoresizingMask = UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleHeight;
+        _departureView = [[OBAClassicDepartureView alloc] initWithFrame:CGRectZero];
         [self.contentView addSubview:_departureView];
+
+        [_departureView mas_makeConstraints:^(MASConstraintMaker *make) {
+            make.edges.equalTo(self.contentView).insets(self.layoutMargins);
+        }];
     }
 
     return self;
@@ -51,6 +54,8 @@
     }
 
     _tableRow = [tableRow copy];
+
+    self.accessoryType = [self classicDepartureRow].accessoryType;
 
     self.departureView.classicDepartureRow = [self classicDepartureRow];
 }

--- a/ui/stops/OBAClassicDepartureView.m
+++ b/ui/stops/OBAClassicDepartureView.m
@@ -22,6 +22,10 @@
 
 @implementation OBAClassicDepartureView
 
+- (instancetype)init {
+    return [self initWithFrame:CGRectZero];
+}
+
 - (instancetype)initWithFrame:(CGRect)frame {
     self = [super initWithFrame:frame];
 
@@ -32,11 +36,6 @@
             l.adjustsFontSizeToFitWidth = YES;
             l.font = [OBATheme bodyFont];
             [l setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
-
-            if (kUseDebugColors) {
-                l.backgroundColor = [UIColor greenColor];
-            }
-
             l;
         });
 
@@ -47,11 +46,6 @@
             l.adjustsFontSizeToFitWidth = YES;
             l.font = [OBATheme bodyFont];
             l.textAlignment = NSTextAlignmentCenter;
-
-            if (kUseDebugColors) {
-                l.backgroundColor = [UIColor redColor];
-            }
-
             l;
         });
 
@@ -62,11 +56,6 @@
             l.adjustsFontSizeToFitWidth = YES;
             l.font = [OBATheme bodyFont];
             l.textAlignment = NSTextAlignmentCenter;
-
-            if (kUseDebugColors) {
-                l.backgroundColor = [UIColor purpleColor];
-            }
-
             l;
         });
 
@@ -77,20 +66,21 @@
             l.font = [OBATheme bodyFont];
             l.textAlignment = NSTextAlignmentRight;
             [l setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
-
-            if (kUseDebugColors) {
-                l.backgroundColor = [UIColor yellowColor];
-            }
-
             l;
         });
+
+        if (kUseDebugColors) {
+            self.backgroundColor = [UIColor purpleColor];
+            _routeNameLabel.backgroundColor = [UIColor greenColor];
+            _destinationLabel.backgroundColor = [UIColor blueColor];
+            _timeAndStatusLabel.backgroundColor = [UIColor redColor];
+            _minutesUntilDepartureLabel.backgroundColor = [UIColor magentaColor];
+        }
 
         UIStackView *centerStack = ({
             UIStackView *sv = [[UIStackView alloc] initWithArrangedSubviews:@[_destinationLabel, _timeAndStatusLabel]];
             sv.axis = UILayoutConstraintAxisVertical;
             sv.distribution = UIStackViewDistributionFillProportionally;
-            sv.layoutMarginsRelativeArrangement = YES;
-            sv.layoutMargins = UIEdgeInsetsMake(0, [OBATheme halfDefaultPadding], 0, [OBATheme halfDefaultPadding]);
             sv.distribution = UIStackViewDistributionEqualSpacing;
             sv;
         });
@@ -99,8 +89,6 @@
             UIStackView *stack = [[UIStackView alloc] initWithArrangedSubviews:@[_routeNameLabel, centerStack, _minutesUntilDepartureLabel]];
             stack.axis = UILayoutConstraintAxisHorizontal;
             stack.distribution = UIStackViewDistributionEqualSpacing;
-            stack.layoutMarginsRelativeArrangement = YES;
-            stack.layoutMargins = UIEdgeInsetsMake([OBATheme halfDefaultPadding], self.layoutMargins.left, [OBATheme halfDefaultPadding], 0);
             stack;
         });
         [self addSubview:horizontalStack];

--- a/ui/stops/OBAStopViewController.h
+++ b/ui/stops/OBAStopViewController.h
@@ -9,9 +9,12 @@
 #import "OBAStaticTableViewController.h"
 #import "OBANavigationTargetAware.h"
 
+@class OBAModelDAO;
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface OBAStopViewController : OBAStaticTableViewController<OBANavigationTargetAware>
+@property(nonatomic,strong) OBAModelDAO *modelDAO;
 @property(nonatomic,copy,readonly) NSString *stopID;
 @property(nonatomic,assign) NSUInteger minutesBefore;
 @property(nonatomic,assign) NSUInteger minutesAfter;
@@ -20,9 +23,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder NS_UNAVAILABLE;
 - (instancetype)initWithNibName:(nullable NSString *)nibNameOrNil bundle:(nullable NSBundle *)nibBundleOrNil NS_UNAVAILABLE;
-
-// This allows us to quickly and easily switch between the old stop UI and the new stop UI.
-+ (UIViewController*)stopControllerWithStopID:(NSString*)stopID;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ui/stops/OBAStopViewController.m
+++ b/ui/stops/OBAStopViewController.m
@@ -24,8 +24,7 @@
 #import "OBASegmentedRow.h"
 #import "OBAArrivalAndDepartureViewController.h"
 #import "OBAStaticTableViewController+Builders.h"
-
-#define ENABLE_PARALLAX_WHICH_NEEDS_FIXING 0
+#import "OBABookmarkRouteDisambiguationViewController.h"
 
 static NSTimeInterval const kRefreshTimeInterval = 30.0;
 static CGFloat const kTableHeaderHeight = 150.f;
@@ -41,10 +40,6 @@ static CGFloat const kTableHeaderHeight = 150.f;
 @end
 
 @implementation OBAStopViewController
-
-+ (UIViewController*)stopControllerWithStopID:(NSString*)stopID {
-    return [[OBAStopViewController alloc] initWithStopID:stopID];
-}
 
 - (instancetype)initWithStopID:(NSString*)stopID {
     self = [super initWithNibName:nil bundle:nil];
@@ -63,11 +58,6 @@ static CGFloat const kTableHeaderHeight = 150.f;
     [super viewDidLoad];
 
     [self createTableHeaderView];
-
-#if ENABLE_PARALLAX_WHICH_NEEDS_FIXING
-    self.tableView.contentInset = UIEdgeInsetsMake(kTableHeaderHeight, 0, 0, 0);
-    self.tableView.contentOffset = CGPointMake(0, -kTableHeaderHeight);
-#endif
 
     self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemRefresh target:self action:@selector(reloadData:)];
     self.refreshControl = [[UIRefreshControl alloc] init];
@@ -104,22 +94,6 @@ static CGFloat const kTableHeaderHeight = 150.f;
     [self reloadData:nil];
 }
 
-#pragma mark - UIScrollViewDelegate
-
-#if ENABLE_PARALLAX_WHICH_NEEDS_FIXING
-- (void)scrollViewDidScroll:(UIScrollView *)scrollView {
-    
-    CGRect headerRect = CGRectMake(0, -kTableHeaderHeight, CGRectGetWidth(scrollView.frame), kTableHeaderHeight);
-    
-    if (scrollView.contentOffset.y < -kTableHeaderHeight) {
-        headerRect.origin.y = scrollView.contentOffset.y;
-        headerRect.size.height = -scrollView.contentOffset.y;
-    }
-
-    self.parallaxHeaderView.frame = headerRect;
-}
-#endif
-
 #pragma mark - OBANavigationTargetAware
 
 - (OBANavigationTarget *)navigationTarget {
@@ -129,6 +103,15 @@ static CGFloat const kTableHeaderHeight = 150.f;
 - (void)setNavigationTarget:(OBANavigationTarget *)navigationTarget {
     _stopID = [[navigationTarget parameterForKey:@"stopId"] copy];
     [self reloadData:nil];
+}
+
+#pragma mark - Accessors
+
+- (OBAModelDAO*)modelDAO {
+    if (!_modelDAO) {
+        _modelDAO = [OBAApplication sharedApplication].modelDao;
+    }
+    return _modelDAO;
 }
 
 #pragma mark - Data Loading
@@ -155,10 +138,6 @@ static CGFloat const kTableHeaderHeight = 150.f;
         [[NSNotificationCenter defaultCenter] postNotificationName:OBAViewedArrivalsAndDeparturesForStopNotification object:response.stop];
 
         self.arrivalsAndDepartures = response;
-
-        // This will update existing bookmarks as they are accessed and ensure
-        // that they have the correct coordinate and region set on them.
-        [OBAStopViewController updateBookmarkForStop:self.arrivalsAndDepartures.stop inModelDAO:[OBAApplication sharedApplication].modelDao];
 
         [self populateTableFromArrivalsAndDeparturesModel:self.arrivalsAndDepartures];
         [self.parallaxHeaderView populateTableHeaderFromArrivalsAndDeparturesModel:self.arrivalsAndDepartures];
@@ -198,27 +177,7 @@ static CGFloat const kTableHeaderHeight = 150.f;
     // Departures
     // TODO: DRY up this whole thing.
     if (prefs.sortTripsByType == OBASortTripsByDepartureTimeV2) {
-        NSMutableArray *departureRows = [NSMutableArray array];
-
-        for (OBAArrivalAndDepartureV2 *dep in result.arrivalsAndDepartures) {
-
-            if (![self shouldShowRouteID:dep.routeId forPrefs:prefs]) {
-                continue;
-            }
-
-            NSString *dest = dep.tripHeadsign.capitalizedString;
-            OBAClassicDepartureRow *row = [[OBAClassicDepartureRow alloc] initWithRouteName:dep.bestAvailableName destination:dest departsAt:[NSDate dateWithTimeIntervalSince1970:(dep.bestDepartureTime / 1000)] statusText:[dep statusText] departureStatus:[dep departureStatus] action:^{
-                OBAArrivalAndDepartureViewController *vc = [[OBAArrivalAndDepartureViewController alloc] initWithArrivalAndDeparture:dep];
-                [self.navigationController pushViewController:vc animated:YES];
-            }];
-
-            [departureRows addObject:row];
-        }
-
-        OBATableSection *section = [[OBATableSection alloc] initWithTitle:nil rows:departureRows];
-        section.headerView = [[OBAClassicDepartureSectionHeaderView alloc] initWithFrame:CGRectMake(0, 0, CGRectGetWidth(self.tableView.frame), 30)];
-        section.headerView.layoutMargins = UIEdgeInsetsMake(0, self.tableView.layoutMargins.left, 0, self.tableView.layoutMargins.right);
-
+        OBATableSection *section = [self buildClassicDepartureSectionWithDeparture:result prefs:prefs];
         [sections addObject:section];
     }
     else {
@@ -253,15 +212,77 @@ static CGFloat const kTableHeaderHeight = 150.f;
     [self.tableView reloadData];
 }
 
+- (OBATableSection *)buildClassicDepartureSectionWithDeparture:(OBAArrivalsAndDeparturesForStopV2 *)result prefs:(OBAStopPreferencesV2 *)prefs {
+    NSMutableArray *departureRows = [NSMutableArray array];
+
+    for (OBAArrivalAndDepartureV2 *dep in result.arrivalsAndDepartures) {
+
+        if (![self shouldShowRouteID:dep.routeId forPrefs:prefs]) {
+            continue;
+        }
+
+        NSString *dest = dep.tripHeadsign.capitalizedString;
+        OBAClassicDepartureRow *row = [[OBAClassicDepartureRow alloc] initWithRouteName:dep.bestAvailableName destination:dest departsAt:[NSDate dateWithTimeIntervalSince1970:(dep.bestDepartureTime / 1000)] statusText:[dep statusText] departureStatus:[dep departureStatus] action:^{
+            OBAArrivalAndDepartureViewController *vc = [[OBAArrivalAndDepartureViewController alloc] initWithArrivalAndDeparture:dep];
+            [self.navigationController pushViewController:vc animated:YES];
+        }];
+
+        row.rowActions = @[[self tableViewRowActionForArrivalAndDeparture:dep]];
+        [departureRows addObject:row];
+    }
+
+    OBATableSection *section = [[OBATableSection alloc] initWithTitle:nil rows:departureRows];
+    section.headerView = [[OBAClassicDepartureSectionHeaderView alloc] initWithFrame:CGRectMake(0, 0, CGRectGetWidth(self.tableView.frame), 30)];
+    section.headerView.layoutMargins = UIEdgeInsetsMake(0, self.tableView.layoutMargins.left, 0, self.tableView.layoutMargins.right);
+    return section;
+}
+
+#pragma mark - Row Actions
+
+- (UITableViewRowAction*)tableViewRowActionForArrivalAndDeparture:(OBAArrivalAndDepartureV2*)dep {
+    UITableViewRowAction *rowAction = nil;
+
+    if ([self hasBookmarkForArrivalAndDeparture:dep]) {
+        rowAction = [UITableViewRowAction rowActionWithStyle:UITableViewRowActionStyleDestructive title:NSLocalizedString(@"Remove\r\nBookmark", @"") handler:^(UITableViewRowAction *action, NSIndexPath *indexPath) {
+            [self promptToRemoveBookmarkForArrivalAndDeparture:dep];
+        }];
+    }
+    else {
+        rowAction = [UITableViewRowAction rowActionWithStyle:UITableViewRowActionStyleNormal title:NSLocalizedString(@"Add Bookmark", @"") handler:^(UITableViewRowAction *action, NSIndexPath *indexPath) {
+            OBABookmarkV2 *bookmark = [[OBABookmarkV2 alloc] initWithArrivalAndDeparture:dep region:self.modelDAO.region];
+            OBAEditStopBookmarkViewController *editor = [[OBAEditStopBookmarkViewController alloc] initWithBookmark:bookmark];
+            UINavigationController *nav = [[UINavigationController alloc] initWithRootViewController:editor];
+            [self.navigationController presentViewController:nav animated:YES completion:nil];
+        }];
+        rowAction.backgroundColor = [OBATheme nonOpaquePrimaryColor];
+    }
+    return rowAction;
+}
+
+#pragma mark - Bookmarks
+
+- (BOOL)hasBookmarkForArrivalAndDeparture:(OBAArrivalAndDepartureV2*)arrivalAndDeparture {
+    return !![self.modelDAO bookmarkForArrivalAndDeparture:arrivalAndDeparture];
+}
+
+- (void)promptToRemoveBookmarkForArrivalAndDeparture:(OBAArrivalAndDepartureV2*)dep {
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"Are you sure you want to remove this bookmark?", @"Tap on Remove Bookmarks on OBAStopViewController.") message:nil preferredStyle:UIAlertControllerStyleAlert];
+    [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Remove", @"") style:UIAlertActionStyleDestructive handler:^(UIAlertAction *action) {
+        OBABookmarkV2 *bookmark = [self.modelDAO bookmarkForArrivalAndDeparture:dep];
+        [self.modelDAO removeBookmark:bookmark];
+    }]];
+    [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", @"") style:UIAlertActionStyleCancel handler:nil]];
+    [self presentViewController:alert animated:YES completion:nil];
+}
+
 #pragma mark - Table Section Creation
 
 - (OBATableSection*)createToggleDepartureFilterSection {
-
     OBASegmentedRow *segmentedRow = [[OBASegmentedRow alloc] initWithSelectionChange:^(NSUInteger selectedIndex) {
         self.hideFilteredRoutes = !self.hideFilteredRoutes;
         [self populateTableFromArrivalsAndDeparturesModel:self.arrivalsAndDepartures];
     }];
-    segmentedRow.items = @[NSLocalizedString(@"Show All Departures", @""), NSLocalizedString(@"Show Filtered Departures", @"")];
+    segmentedRow.items = @[NSLocalizedString(@"All Departures", @""), NSLocalizedString(@"Filtered Departures", @"")];
 
     segmentedRow.selectedItemIndex = self.hideFilteredRoutes ? 1 : 0;
 
@@ -310,11 +331,10 @@ static CGFloat const kTableHeaderHeight = 150.f;
     NSMutableArray *actionRows = [[NSMutableArray alloc] init];
 
     // Add to Bookmarks
-    OBABookmarkV2 *bookmark = [modelDAO bookmarkForStop:stop];
-    NSString *bookmarksTitle = bookmark ? NSLocalizedString(@"Edit Bookmark", @"") : NSLocalizedString(@"Add to Bookmarks", @"");
+    NSString *bookmarksTitle = NSLocalizedString(@"Add Bookmark", @"");
     OBATableRow *addToBookmarks = [[OBATableRow alloc] initWithTitle:bookmarksTitle action:^{
-        OBAEditStopBookmarkViewController *viewController = [[OBAEditStopBookmarkViewController alloc] initWithBookmark:bookmark forStop:stop];
-        UINavigationController *nav = [[UINavigationController alloc] initWithRootViewController:viewController];
+        OBABookmarkRouteDisambiguationViewController *disambiguator = [[OBABookmarkRouteDisambiguationViewController alloc] initWithArrivalsAndDeparturesForStop:self.arrivalsAndDepartures];
+        UINavigationController *nav = [[UINavigationController alloc] initWithRootViewController:disambiguator];
         [self presentViewController:nav animated:YES completion:nil];
     }];
     [actionRows addObject:addToBookmarks];
@@ -369,11 +389,7 @@ static CGFloat const kTableHeaderHeight = 150.f;
     self.parallaxHeaderView = [[OBAParallaxTableHeaderView alloc] initWithFrame:CGRectMake(0, 0, CGRectGetWidth(self.tableView.frame), kTableHeaderHeight)];
     self.parallaxHeaderView.highContrastMode = [[OBAApplication sharedApplication] useHighContrastUI];
 
-#if ENABLE_PARALLAX_WHICH_NEEDS_FIXING
-    [self.tableView addSubview:self.parallaxHeaderView];
-#else
     self.tableView.tableHeaderView = self.parallaxHeaderView;
-#endif
 }
 
 - (BOOL)shouldShowRouteID:(NSString*)routeID forPrefs:(OBAStopPreferencesV2*)prefs {
@@ -393,18 +409,6 @@ static CGFloat const kTableHeaderHeight = 150.f;
     }
 
     return NO;
-}
-
-#pragma mark - Private
-
-+ (void)updateBookmarkForStop:(OBAStopV2*)stop inModelDAO:(OBAModelDAO*)modelDAO {
-    OBABookmarkV2 *bookmark = [modelDAO bookmarkForStop:stop];
-
-    if (bookmark) {
-        bookmark.stop = stop;
-        bookmark.regionIdentifier = modelDAO.region.identifier;
-        [modelDAO saveBookmark:bookmark];
-    }
 }
 
 @end

--- a/ui/trip_details/OBAArrivalAndDepartureSectionBuilder.h
+++ b/ui/trip_details/OBAArrivalAndDepartureSectionBuilder.h
@@ -1,0 +1,16 @@
+//
+//  OBAArrivalAndDepartureSectionBuilder.h
+//  org.onebusaway.iphone
+//
+//  Created by Aaron Brethorst on 7/13/16.
+//  Copyright © 2016 OneBusAway. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <OBAKit/OBAKit.h>
+#import "OBAClassicDepartureRow.h"
+
+@interface OBAArrivalAndDepartureSectionBuilder : NSObject
++ (OBAClassicDepartureRow *)createDepartureRow:(OBAArrivalAndDepartureV2*)arrivalAndDeparture;
+
+@end

--- a/ui/trip_details/OBAArrivalAndDepartureSectionBuilder.m
+++ b/ui/trip_details/OBAArrivalAndDepartureSectionBuilder.m
@@ -1,0 +1,20 @@
+//
+//  OBAArrivalAndDepartureSectionBuilder.m
+//  org.onebusaway.iphone
+//
+//  Created by Aaron Brethorst on 7/13/16.
+//  Copyright © 2016 OneBusAway. All rights reserved.
+//
+
+#import "OBAArrivalAndDepartureSectionBuilder.h"
+
+@implementation OBAArrivalAndDepartureSectionBuilder
+
++ (OBAClassicDepartureRow *)createDepartureRow:(OBAArrivalAndDepartureV2*)arrivalAndDeparture {
+    NSString *dest = arrivalAndDeparture.tripHeadsign.capitalizedString;
+    OBAClassicDepartureRow *departureRow = [[OBAClassicDepartureRow alloc] initWithRouteName:arrivalAndDeparture.bestAvailableName destination:dest departsAt:[NSDate dateWithTimeIntervalSince1970:(arrivalAndDeparture.bestDepartureTime / 1000)] statusText:[arrivalAndDeparture statusText] departureStatus:[arrivalAndDeparture departureStatus] action:nil];
+
+    return departureRow;
+}
+
+@end

--- a/ui/trip_details/OBAArrivalAndDepartureViewController.m
+++ b/ui/trip_details/OBAArrivalAndDepartureViewController.m
@@ -16,6 +16,7 @@
 #import "OBASeparatorSectionView.h"
 #import "OBAClassicDepartureView.h"
 #import "OBATripScheduleSectionBuilder.h"
+#import "OBAArrivalAndDepartureSectionBuilder.h"
 
 static NSTimeInterval const kRefreshTimeInterval = 30;
 
@@ -160,13 +161,6 @@ static NSTimeInterval const kRefreshTimeInterval = 30;
 
 #pragma mark - Section/Row Construction
 
-+ (OBAClassicDepartureRow *)createDepartureRow:(OBAArrivalAndDepartureV2*)arrivalAndDeparture {
-    NSString *dest = arrivalAndDeparture.tripHeadsign.capitalizedString;
-    OBAClassicDepartureRow *departureRow = [[OBAClassicDepartureRow alloc] initWithRouteName:arrivalAndDeparture.bestAvailableName destination:dest departsAt:[NSDate dateWithTimeIntervalSince1970:(arrivalAndDeparture.bestDepartureTime / 1000)] statusText:[arrivalAndDeparture statusText] departureStatus:[arrivalAndDeparture departureStatus] action:nil];
-
-    return departureRow;
-}
-
 + (nullable OBATableSection*)createServiceAlertsSection:(OBAArrivalAndDepartureV2*)arrivalAndDeparture navigationController:(UINavigationController*)navigationController {
     OBAServiceAlertsModel* serviceAlerts = [[OBAApplication sharedApplication].modelDao getServiceAlertsModelForSituations:arrivalAndDeparture.situations];
 
@@ -192,7 +186,7 @@ static NSTimeInterval const kRefreshTimeInterval = 30;
 - (OBAClassicDepartureView*)buildTableHeaderViewWithArrivalAndDeparture:(OBAArrivalAndDepartureV2*)arrivalAndDeparture {
     OBAClassicDepartureView *tableHeaderView = [[OBAClassicDepartureView alloc] initWithFrame:CGRectZero];
     tableHeaderView.autoresizingMask = UIViewAutoresizingFlexibleHeight|UIViewAutoresizingFlexibleWidth;
-    tableHeaderView.classicDepartureRow = [self.class createDepartureRow:arrivalAndDeparture];
+    tableHeaderView.classicDepartureRow = [OBAArrivalAndDepartureSectionBuilder createDepartureRow:arrivalAndDeparture];
 
     return tableHeaderView;
 }

--- a/ui/trip_details/OBATripScheduleMapViewController.m
+++ b/ui/trip_details/OBATripScheduleMapViewController.m
@@ -125,7 +125,7 @@ static const NSString *kShapeContext = @"ShapeContext";
     if ([annotation isKindOfClass:[OBATripStopTimeMapAnnotation class] ]) {
         OBATripStopTimeMapAnnotation *an = (OBATripStopTimeMapAnnotation *)annotation;
         OBATripStopTimeV2 *stopTime = an.stopTime;
-        UIViewController *vc = [OBAStopViewController stopControllerWithStopID:stopTime.stopId];
+        OBAStopViewController *vc = [[OBAStopViewController alloc] initWithStopID:stopTime.stopId];
         [self.navigationController pushViewController:vc animated:YES];
     }
     else if ([annotation isKindOfClass:[OBATripContinuationMapAnnotation class]]) {

--- a/ui/trip_details/OBATripScheduleSectionBuilder.m
+++ b/ui/trip_details/OBATripScheduleSectionBuilder.m
@@ -23,7 +23,7 @@
 
         [stopsSection addRow:^OBABaseRow *{
             OBATableRow *row = [[OBATableRow alloc] initWithTitle:stop.name action:^{
-                UIViewController *vc = [OBAStopViewController stopControllerWithStopID:stopTime.stopId];
+                OBAStopViewController *vc = [[OBAStopViewController alloc] initWithStopID:stopTime.stopId];
                 [navigationController pushViewController:vc animated:YES];
             }];
             row.subtitle = [self formattedStopTime:stopTime tripDetails:tripDetails];


### PR DESCRIPTION
Issues Fixed:

* Fixes #159 - show next bus times on bookmarks tab
* Fixes #457 - Bookmark individual routes at stops instead of the entire stop
* Fixes #593 - Can no longer reorder bookmarks in v2.5.0

Static Table Views:

* Add ability to set contextual actions on a per-table row basis.

Stop View Controller:

* Extract classic departure row construction into a separate method
* Add/Delete bookmark contextual item
* Remove a now-unnecessary class method for initialization from OBAStopViewController
* Plumb in an accessor for OBAModelDAO into OBAStopViewController to allow easier testing later on.
* Implement -hasBookmarkForArrivalAndDeparture: on OBAStopViewController
* Dump the parallax code in the stops controller; it doesn't work properly and needs reimplementation
* first stab at disambiguation UI
* Never show the text "edit bookmark" at the stop level, since it no longer makes any sense.

Bookmarks Controller:

* Add a new cell: OBABookmarkedRouteCell
* Lazy accessor for OBAModelService on OBABookmarksViewController
* Show bookmarked routes on OBABookmarksViewController

Bookmarks:

* Bookmark versioning
* * Make OBABookmarkV2 conform to NSCopying
* Add ability to bookmark a single route of a stop.
* add sortOrder property to bookmarks.
* Get bookmark reordering working again.
* Persist routeShortName in bookmarks
* Create a method to determine if a bookmark is congruent to an arrival and departure object
* Clarify which bookmark properties are new in 2.6.0

General/Misc:

* Upgrade to a first-party SVProgressHUD pod, as the version is now parseable by iTC.
* Add -oba_description:-based description method to OBARouteV2
* Add San Diego GPX file
* UUID cleanup
* Start adapting Podfile and project to work on Xcode 7 and 8
* Add OCMock 3 as the mocking library for OBA
* fix -copyWithZone: bug in OBATableRow