### PR TITLE
Rebuild the map activity indicator on top of a visual effect view

### DIFF
--- a/controls/containers/OBAVibrantBlurContainerView.h
+++ b/controls/containers/OBAVibrantBlurContainerView.h
@@ -1,0 +1,14 @@
+//
+//  OBAVibrantBlurContainerView.h
+//  org.onebusaway.iphone
+//
+//  Created by Aaron Brethorst on 8/6/16.
+//  Copyright © 2016 OneBusAway. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface OBAVibrantBlurContainerView : UIView
+@property(nonatomic,assign) UIBlurEffectStyle blurEffectStyle;
+@property(nonatomic,strong,readonly) UIVisualEffectView *vibrancyEffectView;
+@end

--- a/controls/containers/OBAVibrantBlurContainerView.m
+++ b/controls/containers/OBAVibrantBlurContainerView.m
@@ -1,0 +1,45 @@
+//
+//  OBAVibrantBlurContainerView.m
+//  org.onebusaway.iphone
+//
+//  Created by Aaron Brethorst on 8/6/16.
+//  Copyright © 2016 OneBusAway. All rights reserved.
+//
+
+#import "OBAVibrantBlurContainerView.h"
+
+@interface OBAVibrantBlurContainerView ()
+@property(nonatomic,strong,readwrite) UIVisualEffectView *vibrancyEffectView;
+@end
+
+@implementation OBAVibrantBlurContainerView
+
+- (instancetype)initWithFrame:(CGRect)frame {
+    self = [super initWithFrame:frame];
+
+    if (self) {
+        _blurEffectStyle = UIBlurEffectStyleLight;
+    }
+    return self;
+}
+
+- (UIVisualEffectView*)vibrancyEffectView {
+    if (!_vibrancyEffectView) {
+        // Blur effect
+        UIBlurEffect *blurEffect = [UIBlurEffect effectWithStyle:self.blurEffectStyle];
+        UIVisualEffectView *blurEffectView = [[UIVisualEffectView alloc] initWithEffect:blurEffect];
+        blurEffectView.autoresizingMask = UIViewAutoresizingFlexibleHeight|UIViewAutoresizingFlexibleWidth;
+        blurEffectView.frame = self.bounds;
+        [self addSubview:blurEffectView];
+
+        // Vibrancy effect
+        UIVibrancyEffect *vibrancyEffect = [UIVibrancyEffect effectForBlurEffect:blurEffect];
+        _vibrancyEffectView = [[UIVisualEffectView alloc] initWithEffect:vibrancyEffect];
+        _vibrancyEffectView.frame = blurEffectView.contentView.bounds;
+        _vibrancyEffectView.autoresizingMask = UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleHeight;
+        [blurEffectView.contentView addSubview:_vibrancyEffectView];
+    }
+    return _vibrancyEffectView;
+}
+
+@end

--- a/controls/progress/OBAMapActivityIndicatorView.h
+++ b/controls/progress/OBAMapActivityIndicatorView.h
@@ -9,6 +9,5 @@
 #import <UIKit/UIKit.h>
 
 @interface OBAMapActivityIndicatorView : UIView
-- (void)startAnimating;
-- (void)stopAnimating;
+@property(nonatomic,assign) BOOL animating;
 @end

--- a/controls/progress/OBAMapActivityIndicatorView.m
+++ b/controls/progress/OBAMapActivityIndicatorView.m
@@ -7,36 +7,49 @@
 //
 
 #import "OBAMapActivityIndicatorView.h"
+#import "OBAVibrantBlurContainerView.h"
+#import "OBATheme.h"
 
 @interface OBAMapActivityIndicatorView ()
+@property(nonatomic,strong) OBAVibrantBlurContainerView *blurContainer;
 @property(nonatomic,strong) UIActivityIndicatorView *activityIndicatorView;
 @end
 
 @implementation OBAMapActivityIndicatorView
+@dynamic animating;
 
 - (instancetype)initWithFrame:(CGRect)frame {
     self = [super initWithFrame:frame];
 
     if (self) {
+        self.layer.masksToBounds = YES;
+        self.layer.cornerRadius = [OBATheme defaultCornerRadius];
 
-        self.backgroundColor = OBARGBACOLOR(0, 0, 0, 0.5);
-        self.layer.cornerRadius = 4.f;
-        self.layer.shouldRasterize = YES;
-        self.layer.rasterizationScale = [UIScreen mainScreen].scale;
+        _blurContainer = [[OBAVibrantBlurContainerView alloc] initWithFrame:self.bounds];
+        _blurContainer.blurEffectStyle = UIBlurEffectStyleDark;
+        _blurContainer.autoresizingMask = UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleHeight;
+        [self addSubview:_blurContainer];
 
-        _activityIndicatorView = [[UIActivityIndicatorView alloc] initWithFrame:CGRectInset(self.bounds, 4, 4)];
+        _activityIndicatorView = [[UIActivityIndicatorView alloc] initWithFrame:CGRectInset(self.bounds, [OBATheme compactPadding], [OBATheme compactPadding])];
         _activityIndicatorView.activityIndicatorViewStyle = UIActivityIndicatorViewStyleWhite;
-        [self addSubview:_activityIndicatorView];
+        [_blurContainer.vibrancyEffectView.contentView addSubview:_activityIndicatorView];
     }
     return self;
 }
 
-- (void)startAnimating {
-    [self.activityIndicatorView startAnimating];
+- (void)setAnimating:(BOOL)animating {
+    self.hidden = !animating;
+
+    if (animating) {
+        [self.activityIndicatorView startAnimating];
+    }
+    else {
+        [self.activityIndicatorView stopAnimating];
+    }
 }
 
-- (void)stopAnimating {
-    [self.activityIndicatorView stopAnimating];
+- (BOOL)animating {
+    return self.activityIndicatorView.isAnimating;
 }
 
 @end

--- a/org.onebusaway.iphone.xcodeproj/project.pbxproj
+++ b/org.onebusaway.iphone.xcodeproj/project.pbxproj
@@ -316,6 +316,7 @@
 		93E0D19F1D569E7B00D9AA63 /* UIViewController+OBAContainment.m in Sources */ = {isa = PBXBuildFile; fileRef = 93E0D19E1D569E7B00D9AA63 /* UIViewController+OBAContainment.m */; };
 		93E0D1A21D579CA300D9AA63 /* OBAApplicationUI.m in Sources */ = {isa = PBXBuildFile; fileRef = 93E0D1A11D579CA300D9AA63 /* OBAApplicationUI.m */; };
 		93E0D1A51D57D34E00D9AA63 /* OBAMapActivityIndicatorView.m in Sources */ = {isa = PBXBuildFile; fileRef = 93E0D1A41D57D34E00D9AA63 /* OBAMapActivityIndicatorView.m */; };
+		93E0D1AB1D57EAAD00D9AA63 /* OBAVibrantBlurContainerView.m in Sources */ = {isa = PBXBuildFile; fileRef = 93E0D1AA1D57EAAD00D9AA63 /* OBAVibrantBlurContainerView.m */; };
 		93E4A3011CF7D42300EF9595 /* OBAClassicDepartureView.m in Sources */ = {isa = PBXBuildFile; fileRef = 93E4A3001CF7D42300EF9595 /* OBAClassicDepartureView.m */; };
 		93E4A7621CE65B2100E769B0 /* atlanta.gpx in Resources */ = {isa = PBXBuildFile; fileRef = 93E4A7611CE65B2100E769B0 /* atlanta.gpx */; };
 		93F05A631C8E080000BF36B1 /* OBAAnimation.m in Sources */ = {isa = PBXBuildFile; fileRef = 93F05A621C8E080000BF36B1 /* OBAAnimation.m */; };
@@ -761,6 +762,8 @@
 		93E0D1A11D579CA300D9AA63 /* OBAApplicationUI.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAApplicationUI.m; sourceTree = "<group>"; };
 		93E0D1A31D57D34E00D9AA63 /* OBAMapActivityIndicatorView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAMapActivityIndicatorView.h; sourceTree = "<group>"; };
 		93E0D1A41D57D34E00D9AA63 /* OBAMapActivityIndicatorView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAMapActivityIndicatorView.m; sourceTree = "<group>"; };
+		93E0D1A91D57EAAD00D9AA63 /* OBAVibrantBlurContainerView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAVibrantBlurContainerView.h; sourceTree = "<group>"; };
+		93E0D1AA1D57EAAD00D9AA63 /* OBAVibrantBlurContainerView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAVibrantBlurContainerView.m; sourceTree = "<group>"; };
 		93E4A2FF1CF7D42300EF9595 /* OBAClassicDepartureView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAClassicDepartureView.h; sourceTree = "<group>"; };
 		93E4A3001CF7D42300EF9595 /* OBAClassicDepartureView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAClassicDepartureView.m; sourceTree = "<group>"; };
 		93E4A7611CE65B2100E769B0 /* atlanta.gpx */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = atlanta.gpx; sourceTree = "<group>"; };
@@ -1194,6 +1197,8 @@
 		9330DF251606404100E14AF4 /* containers */ = {
 			isa = PBXGroup;
 			children = (
+				93E0D1A91D57EAAD00D9AA63 /* OBAVibrantBlurContainerView.h */,
+				93E0D1AA1D57EAAD00D9AA63 /* OBAVibrantBlurContainerView.m */,
 				9330DF261606405100E14AF4 /* OBAScopeView.h */,
 				9330DF271606405100E14AF4 /* OBAScopeView.m */,
 			);
@@ -2134,6 +2139,7 @@
 				932BE4DB1AB66D890011F2FB /* OBASituationViewController.m in Sources */,
 				936D3EC01C14E94A00091DC9 /* OBAStaticTableViewController.m in Sources */,
 				93E4A3011CF7D42300EF9595 /* OBAClassicDepartureView.m in Sources */,
+				93E0D1AB1D57EAAD00D9AA63 /* OBAVibrantBlurContainerView.m in Sources */,
 				939E8E5B1C7B815E008FCA4C /* OBABaseRow.m in Sources */,
 				934446CF1AB12B29005B3333 /* OBARequestDrivenTableViewController.m in Sources */,
 				939C23B91D371DE8002A4145 /* OBABookmarkedRouteCell.m in Sources */,

--- a/ui/search/OBASearchResultsMapViewController.m
+++ b/ui/search/OBASearchResultsMapViewController.m
@@ -349,15 +349,7 @@ static const double kStopsInRegionRefreshDelayOnDrag = 0.1;
 
 - (void)progressUpdated {
     id<OBAProgressIndicatorSource> progress = self.searchController.progress;
-
-    if (progress.inProgress) {
-        self.mapActivityIndicatorView.hidden = NO;
-        [self.mapActivityIndicatorView startAnimating];
-    }
-    else {
-        self.mapActivityIndicatorView.hidden = YES;
-        [self.mapActivityIndicatorView stopAnimating];
-    }
+    [self.mapActivityIndicatorView setAnimating:progress.inProgress];
 }
 
 #pragma mark - MKMapViewDelegate Methods
@@ -643,8 +635,6 @@ static const double kStopsInRegionRefreshDelayOnDrag = 0.1;
     CLLocation *location = lm.currentLocation;
 
     if (location) {
-        //OBALogDebug(@"refreshCurrentLocation: auto center on current location: %d", self.mapRegionManager.lastRegionChangeWasprogrammatic);
-        
         if (self.mapRegionManager.lastRegionChangeWasProgrammatic) {
             double radius = MAX(location.horizontalAccuracy, OBAMinMapRadiusInMeters);
             MKCoordinateRegion region = [OBASphericalGeometryLibrary createRegionWithCenter:location.coordinate latRadius:radius lonRadius:radius];
@@ -1157,15 +1147,6 @@ static const double kStopsInRegionRefreshDelayOnDrag = 0.1;
     if (self.searchBar.isFirstResponder) {
         [self searchBarCancelButtonClicked:self.searchBar];
     }
-}
-
-- (void)touchesCancelled:(NSSet *)touches withEvent:(UIEvent *)event {
-}
-
-- (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event {
-}
-
-- (void)touchesMoved:(NSSet *)touches withEvent:(UIEvent *)event {
 }
 
 - (BOOL)outOfServiceArea {

--- a/ui/themes/OBATheme.h
+++ b/ui/themes/OBATheme.h
@@ -126,12 +126,17 @@
 /**
  Half of the default padding. Used in situations where a tighter fit is necessary.
  */
-+ (CGFloat)halfDefaultPadding;
++ (CGFloat)compactPadding;
 
 /**
  * The default vertical and horizontal padding in px.
  */
 + (CGFloat)defaultPadding;
+
+/**
+ The default corner radius to apply to views that require rounded edges.
+ */
++ (CGFloat)defaultCornerRadius;
 
 /**
  The value of +[OBATheme defaultPadding] in the form of UIEdgeInsets.

--- a/ui/themes/OBATheme.m
+++ b/ui/themes/OBATheme.m
@@ -135,12 +135,16 @@ static UIFont *_boldFootnoteFont = nil;
 
 #pragma mark - Pixels, err points
 
-+ (CGFloat)halfDefaultPadding {
++ (CGFloat)compactPadding {
     return self.defaultPadding / 2.f;
 }
 
 + (CGFloat)defaultPadding {
     return 8.f;
+}
+
++ (CGFloat)defaultCornerRadius {
+    return [self compactPadding];
 }
 
 + (UIEdgeInsets)defaultEdgeInsets {


### PR DESCRIPTION
* Rename the OBATheme method `halfDefaultPadding` to the more semantically meaningful `compactPadding`
* Add a visual effect view container that takes away the confusing parts of building vibrant visual effect views
* Simplify the map activity indicator view's API