### PR TITLE
Better verification of custom API server URLs

### DIFF
--- a/OBAKit/Helpers/OBAUser.h
+++ b/OBAKit/Helpers/OBAUser.h
@@ -1,0 +1,13 @@
+//
+//  OBAUser.h
+//  org.onebusaway.iphone
+//
+//  Created by Aaron Brethorst on 8/13/16.
+//  Copyright © 2016 OneBusAway. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface OBAUser : NSObject
++ (NSString *)userIdFromDefaults;
+@end

--- a/OBAKit/Helpers/OBAUser.m
+++ b/OBAKit/Helpers/OBAUser.m
@@ -1,0 +1,27 @@
+//
+//  OBAUser.m
+//  org.onebusaway.iphone
+//
+//  Created by Aaron Brethorst on 8/13/16.
+//  Copyright © 2016 OneBusAway. All rights reserved.
+//
+
+#import "OBAUser.h"
+
+static NSString * const kOBAHiddenPreferenceUserId = @"OBAApplicationUserId";
+
+@implementation OBAUser
+
++ (NSString *)userIdFromDefaults {
+    NSString *userId = [[NSUserDefaults standardUserDefaults] stringForKey:kOBAHiddenPreferenceUserId];
+
+    if (!userId) {
+        userId = [[NSUUID UUID] UUIDString];
+        [[NSUserDefaults standardUserDefaults] setObject:userId forKey:kOBAHiddenPreferenceUserId];
+        [[NSUserDefaults standardUserDefaults] synchronize];
+    }
+
+    return userId;
+}
+
+@end

--- a/OBAKit/Services/OBADataSourceConfig.h
+++ b/OBAKit/Services/OBADataSourceConfig.h
@@ -19,6 +19,8 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface OBADataSourceConfig : NSObject
++ (instancetype)dataSourceConfigWithBaseURL:(NSURL*)URL userID:(NSString*)userID;
+
 - (instancetype)initWithURL:(NSURL*)baseURL args:(nullable NSDictionary*)args;
 - (NSURL*)constructURL:(NSString*)path withArgs:(nullable NSDictionary*)args;
 @end

--- a/OBAKit/Services/OBADataSourceConfig.m
+++ b/OBAKit/Services/OBADataSourceConfig.m
@@ -34,6 +34,17 @@
     return self;
 }
 
++ (instancetype)dataSourceConfigWithBaseURL:(NSURL*)URL userID:(NSString*)userID {
+    NSDictionary *obaArgs = @{ @"key":     @"org.onebusaway.iphone",
+                               @"app_uid": userID,
+                               @"app_ver": [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"],
+                               @"version": @"2"};
+
+    return [[OBADataSourceConfig alloc] initWithURL:URL args:obaArgs];
+}
+
+#pragma mark - Public Methods
+
 - (NSURL*)constructURL:(NSString*)path withArgs:(NSDictionary*)args {
     NSMutableString *constructedURL = [NSMutableString string];
     

--- a/OBAKit/Services/OBAJsonDataSource.h
+++ b/OBAKit/Services/OBAJsonDataSource.h
@@ -23,6 +23,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface OBAJsonDataSource : NSObject
 
++ (instancetype)JSONDataSourceWithBaseURL:(NSURL*)URL userID:(NSString*)userID;
++ (instancetype)googleMapsJSONDataSource;
+
 - (id)initWithConfig:(OBADataSourceConfig*)config;
 
 - (id<OBADataSourceConnection>)requestWithPath:(NSString*)path

--- a/OBAKit/Services/OBAJsonDataSource.m
+++ b/OBAKit/Services/OBAJsonDataSource.m
@@ -38,6 +38,20 @@
     [self cancelOpenConnections];
 }
 
+#pragma mark - Factory Helpers
+
++ (instancetype)JSONDataSourceWithBaseURL:(NSURL*)URL userID:(NSString*)userID {
+    OBADataSourceConfig *obaDataSourceConfig = [OBADataSourceConfig dataSourceConfigWithBaseURL:URL userID:userID];
+    return [[OBAJsonDataSource alloc] initWithConfig:obaDataSourceConfig];
+}
+
++ (instancetype)googleMapsJSONDataSource {
+    OBADataSourceConfig *googleMapsDataSourceConfig = [[OBADataSourceConfig alloc] initWithURL:[NSURL URLWithString:@"https://maps.googleapis.com"] args:@{@"sensor": @"true"}];
+    return [[OBAJsonDataSource alloc] initWithConfig:googleMapsDataSourceConfig];
+}
+
+#pragma mark - Public Methods
+
 - (id<OBADataSourceConnection>)requestWithPath:(NSString *)path withArgs:(NSDictionary *)args completionBlock:(OBADataSourceCompletion)completion progressBlock:(OBADataSourceProgress)progress {
 
     NSURL *feedURL = [self.config constructURL:path withArgs:args];

--- a/OBAKit/Services/OBAModelFactory.m
+++ b/OBAKit/Services/OBAModelFactory.m
@@ -101,7 +101,6 @@ static NSString * const kReferences = @"references";
     return self;
 }
 
-
 - (OBAEntryWithReferencesV2*) getStopFromJSON:(NSDictionary*)jsonDictionary error:(NSError**)error {
     
     OBAEntryWithReferencesV2 * entry = [[OBAEntryWithReferencesV2 alloc] initWithReferences:_references];

--- a/OBAKit/Services/OBAModelService.h
+++ b/OBAKit/Services/OBAModelService.h
@@ -63,6 +63,22 @@ NS_ASSUME_NONNULL_BEGIN
 - (AnyPromise*)requestArrivalAndDeparture:(OBAArrivalAndDepartureInstanceRef*)instanceRef;
 
 /**
+ Retrieves the current server time as an NSNumber representing the number of milliseconds since January 1, 1970.
+
+ @return A promise that resolves to an NSNumber object.
+ */
+- (AnyPromise*)requestCurrentTime;
+
+/**
+ *  Makes an asynchronous request to fetch the current server time.
+ *
+ *  @param completion The block to be called once the request completes, this is always executed on the main thread.
+ *
+ *  @return The OBAModelServiceRequest object that allows request cancellation
+ */
+- (id<OBAModelServiceRequest>)requestCurrentTimeWithCompletionBlock:(OBADataSourceCompletion)completion;
+
+/**
  *  Makes an asynchronous request to fetch a stop object.
  *
  *  @param stopId     The string identifier of the stop to be fetched

--- a/OBAKit/Services/OBAModelService.m
+++ b/OBAKit/Services/OBAModelService.m
@@ -9,6 +9,8 @@ static const CLLocationAccuracy kBigSearchRadius = 15000;
 
 @implementation OBAModelService
 
+#pragma mark - Promise-based Requests
+
 - (AnyPromise*)requestStopForID:(NSString*)stopID minutesBefore:(NSUInteger)minutesBefore minutesAfter:(NSUInteger)minutesAfter {
 
     OBAGuard(stopID) else {
@@ -68,6 +70,30 @@ static const CLLocationAccuracy kBigSearchRadius = 15000;
             }
         }];
     }];
+}
+
+- (AnyPromise*)requestCurrentTime {
+    return [AnyPromise promiseWithResolverBlock:^(PMKResolver resolve) {
+        [self requestCurrentTimeWithCompletionBlock:^(id responseData, NSUInteger responseCode, NSError *error) {
+            if (error) {
+                resolve(error);
+            }
+            else {
+                resolve(responseData[@"entry"][@"time"]);
+            }
+        }];
+    }];
+}
+
+#pragma mark - Old School Requests
+
+- (id<OBAModelServiceRequest>)requestCurrentTimeWithCompletionBlock:(OBADataSourceCompletion)completion {
+    return [self request:self.obaJsonDataSource
+                     url:@"/api/where/current-time.json"
+                    args:nil
+                selector:nil
+         completionBlock:completion
+           progressBlock:nil];
 }
 
 - (id<OBAModelServiceRequest>)requestStopForId:(NSString *)stopId completionBlock:(OBADataSourceCompletion)completion {

--- a/org.onebusaway.iphone.xcodeproj/project.pbxproj
+++ b/org.onebusaway.iphone.xcodeproj/project.pbxproj
@@ -316,6 +316,8 @@
 		93AD369D1604027E00BDF03F /* OBAProgressIndicatorImpl.m in Sources */ = {isa = PBXBuildFile; fileRef = 93AD369B1604027E00BDF03F /* OBAProgressIndicatorImpl.m */; };
 		93B32FF31AC4912F001DC177 /* UIViewController+OBAAnalytics.m in Sources */ = {isa = PBXBuildFile; fileRef = 93B32FF21AC4912F001DC177 /* UIViewController+OBAAnalytics.m */; };
 		93B35AA11D5EFF440025DA4D /* OBATableFooterLabelView.m in Sources */ = {isa = PBXBuildFile; fileRef = 93B35AA01D5EFF440025DA4D /* OBATableFooterLabelView.m */; };
+		93B35AA41D5FCCA70025DA4D /* OBAUser.h in Headers */ = {isa = PBXBuildFile; fileRef = 93B35AA21D5FCCA70025DA4D /* OBAUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		93B35AA51D5FCCA70025DA4D /* OBAUser.m in Sources */ = {isa = PBXBuildFile; fileRef = 93B35AA31D5FCCA70025DA4D /* OBAUser.m */; };
 		93B8BA291C9C646E0079A3DA /* OBAArrivalAndDepartureViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 93B8BA281C9C646E0079A3DA /* OBAArrivalAndDepartureViewController.m */; };
 		93C921461D59289E00CA8868 /* OBADrawerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 93C921451D59289E00CA8868 /* OBADrawerViewController.m */; };
 		93DEE5831D45207700042803 /* stop_with_obj_lat_long.plist in Resources */ = {isa = PBXBuildFile; fileRef = 93DEE5821D45207700042803 /* stop_with_obj_lat_long.plist */; };
@@ -771,6 +773,8 @@
 		93B32FF21AC4912F001DC177 /* UIViewController+OBAAnalytics.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+OBAAnalytics.m"; sourceTree = "<group>"; };
 		93B35A9F1D5EFF440025DA4D /* OBATableFooterLabelView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBATableFooterLabelView.h; sourceTree = "<group>"; };
 		93B35AA01D5EFF440025DA4D /* OBATableFooterLabelView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBATableFooterLabelView.m; sourceTree = "<group>"; };
+		93B35AA21D5FCCA70025DA4D /* OBAUser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAUser.h; sourceTree = "<group>"; };
+		93B35AA31D5FCCA70025DA4D /* OBAUser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAUser.m; sourceTree = "<group>"; };
 		93B8BA271C9C646E0079A3DA /* OBAArrivalAndDepartureViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAArrivalAndDepartureViewController.h; sourceTree = "<group>"; };
 		93B8BA281C9C646E0079A3DA /* OBAArrivalAndDepartureViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAArrivalAndDepartureViewController.m; sourceTree = "<group>"; };
 		93C921441D59289E00CA8868 /* OBADrawerViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBADrawerViewController.h; sourceTree = "<group>"; };
@@ -1330,6 +1334,8 @@
 				934D00271C83924400A76A90 /* OBAURLHelpers.m */,
 				9337D6C61D32A85F00D237D6 /* OBAEmailHelper.h */,
 				9337D6C71D32A85F00D237D6 /* OBAEmailHelper.m */,
+				93B35AA21D5FCCA70025DA4D /* OBAUser.h */,
+				93B35AA31D5FCCA70025DA4D /* OBAUser.m */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -1840,6 +1846,7 @@
 				93392E271CB23F5C00A46B61 /* OBAModelPersistenceLayer.h in Headers */,
 				934B62A21CFBA5FA00D8FA85 /* NSObject+OBADescription.h in Headers */,
 				9302B6081CA4CCDA002B6AC7 /* NSArray+OBAAdditions.h in Headers */,
+				93B35AA41D5FCCA70025DA4D /* OBAUser.h in Headers */,
 				9337D6C81D32A85F00D237D6 /* OBAEmailHelper.h in Headers */,
 				9320771A1C993A4D005F7D4A /* OBARouteType.h in Headers */,
 			);
@@ -2284,6 +2291,7 @@
 				934D010B1C83924D00A76A90 /* OBANavigationTarget.m in Sources */,
 				934D011D1C83924D00A76A90 /* OBASearch.m in Sources */,
 				934D010F1C83924D00A76A90 /* OBAPlacemarks.m in Sources */,
+				93B35AA51D5FCCA70025DA4D /* OBAUser.m in Sources */,
 				934D00E31C83924D00A76A90 /* OBASelectorJsonDigesterRule.m in Sources */,
 				934D01441C83924D00A76A90 /* OBAJsonDataSource.m in Sources */,
 				934D00401C83924400A76A90 /* OBAStopIconFactory.m in Sources */,


### PR DESCRIPTION
Related to:

* https://github.com/OneBusAway/onebusaway-iphone/issues/548 - Improve Management and Display of Regions and Custom API Servers

Instead of manually crafting a URL that will be used to verify that the custom API server specified by the user is correct, the application now builds a new model service object around the specified custom API URL, thereby ensuring that the same code path that will be used to display data to an end user is also used to verify the correctness of the custom API server.

* Move code for building OBA JSON data sources into factory helpers in OBAJsonDataSource
* Create a new OBAKit class, OBAUser, for generating and storing the user's UUID
* Greatly simplify the creation of the model service object in OBAApplication
* Verify that the custom API server URL is correct by building a new model service object around it.