### PR TITLE
Decouple downloading the latest arrival and departure data from rendering bookmarks

### DIFF
--- a/OBAKit/Models/dao/OBAModelDAO.h
+++ b/OBAKit/Models/dao/OBAModelDAO.h
@@ -39,6 +39,7 @@ extern NSString * const OBAUngroupedBookmarksIdentifier;
 
 - (instancetype)initWithModelPersistenceLayer:(id<OBAModelPersistenceLayer>)persistenceLayer;
 
+- (NSArray<OBABookmarkV2*>*)bookmarksMatchingPredicate:(NSPredicate*)predicate;
 - (OBABookmarkV2*)bookmarkForArrivalAndDeparture:(OBAArrivalAndDepartureV2*)arrival;
 - (void)saveBookmark:(OBABookmarkV2*)bookmark;
 - (void)moveBookmark:(NSUInteger)startIndex to:(NSUInteger)endIndex;

--- a/OBAKit/Models/dao/OBAModelDAO.m
+++ b/OBAKit/Models/dao/OBAModelDAO.m
@@ -89,6 +89,16 @@ const NSInteger kMaxEntriesInMostRecentList = 10;
 
 #pragma mark - Bookmarks
 
+- (NSArray<OBABookmarkV2*>*)bookmarksMatchingPredicate:(NSPredicate*)predicate {
+    OBAGuard(predicate) else {
+        return @[];
+    }
+
+    NSArray<OBABookmarkV2*> *allBookmarks = [self allBookmarks];
+
+    return [allBookmarks filteredArrayUsingPredicate:predicate];
+}
+
 - (OBABookmarkV2*)bookmarkForArrivalAndDeparture:(OBAArrivalAndDepartureV2*)arrival {
     for (OBABookmarkV2 *bm in self.ungroupedBookmarks) {
         if ([bm matchesArrivalAndDeparture:arrival]) {

--- a/OBAKit/Models/unmanaged/OBABookmarkV2.m
+++ b/OBAKit/Models/unmanaged/OBABookmarkV2.m
@@ -158,7 +158,10 @@ static NSString * const kBookmarkVersion = @"bookmarkVersion";
         return NO;
     }
 
-    if (![self.tripHeadsign isEqual:arrivalAndDeparture.tripHeadsign]) {
+    // because of the trip headsign munging that sometimes takes place elsewhere in the codebase,
+    // we need to do a case insensitive comparison to ensure that these headsigns match. Ideally,
+    // we wouldn't have to do such a fragile comparison in the first place...
+    if ([self.tripHeadsign compare:arrivalAndDeparture.tripHeadsign options:NSCaseInsensitiveSearch] != NSOrderedSame) {
         return NO;
     }
 
@@ -168,10 +171,6 @@ static NSString * const kBookmarkVersion = @"bookmarkVersion";
 #pragma mark - Equality
 
 - (BOOL)isEqual:(id)object {
-    if (![super isEqual:object]) {
-        return NO;
-    }
-
     if (![object isKindOfClass:self.class]) {
         return NO;
     }
@@ -204,7 +203,7 @@ static NSString * const kBookmarkVersion = @"bookmarkVersion";
 }
 
 - (NSUInteger)hash {
-    return [[NSString stringWithFormat:@"%@_%@_%@", NSStringFromClass(self.class), @(self.regionIdentifier), self.stopId] hash];
+    return [[NSString stringWithFormat:@"%@_%@_%@_%@_%@_%@", NSStringFromClass(self.class), @(self.regionIdentifier), self.stopId, self.routeShortName, self.tripHeadsign, self.routeID] hash];
 }
 
 #pragma mark - NSObject

--- a/OneBusAwayTests/OBAKitTests/models/OBAModelDAO_Tests.m
+++ b/OneBusAwayTests/OBAKitTests/models/OBAModelDAO_Tests.m
@@ -38,6 +38,26 @@
     XCTAssertTrue(self.modelDAO.hideFutureLocationWarnings);
 }
 
+#pragma mark - Bookmark Searching w/ Predicate
+
+- (void)testANilPredicateReturnsEmptyArray {
+    NSPredicate *blah = nil;
+    NSArray *output = [self.modelDAO bookmarksMatchingPredicate:blah];
+    XCTAssertEqualObjects([NSArray array], output);
+}
+
+- (void)testBasicPredicatesWork {
+    OBABookmarkV2 *bookmark = [self generateBookmarkWithName:@"hello"];
+    NSArray *bookmarkArray = @[bookmark];
+    [self.modelDAO saveBookmark:bookmark];
+
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"name == %@", bookmark.name];
+
+    NSArray *matches = [self.modelDAO bookmarksMatchingPredicate:predicate];
+
+    XCTAssertEqualObjects(matches, bookmarkArray);
+}
+
 #pragma mark - Bookmarks
 
 - (void)testTransientBookmarksDontTouchPersistenceLayer {


### PR DESCRIPTION
* Retrieve bookmarks based on a predicate
* I noticed an issue on higher latency connections/slower devices where bookmark rendering (with departures) was having serious issues. By decoupling these two processes, the overall rendering quality should increase significantly.