### PR TITLE
Make it possible to bookmark the entire stop again

### DIFF
--- a/OBAKit/Models/unmanaged/OBABookmarkV2.h
+++ b/OBAKit/Models/unmanaged/OBABookmarkV2.h
@@ -28,7 +28,15 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic,assign) NSUInteger sortOrder;
 @property(nonatomic,assign) OBABookmarkVersion bookmarkVersion;
 
+/**
+ Used to create OBABookmarkVersion260-type bookmarks.
+ */
 - (instancetype)initWithArrivalAndDeparture:(OBAArrivalAndDepartureV2*)arrivalAndDeparture region:(OBARegionV2*)region;
+
+/**
+ Used to create OBABookmarkVersion252-type bookmarks.
+ */
+- (instancetype)initWithStop:(OBAStopV2*)stop region:(OBARegionV2*)region;
 
 /**
  Basically, an -isEqual: for comparing bookmarks to OBAArrivalAndDepartureV2 objects.

--- a/OBAKit/Models/unmanaged/OBABookmarkV2.m
+++ b/OBAKit/Models/unmanaged/OBABookmarkV2.m
@@ -25,12 +25,26 @@ static NSString * const kBookmarkVersion = @"bookmarkVersion";
         _routeShortName = [arrivalAndDeparture.routeShortName copy];
         _routeID = [arrivalAndDeparture.routeId copy];
         _tripHeadsign = [arrivalAndDeparture.tripHeadsign copy];
-        _name = stop.direction ? [NSString stringWithFormat:@"%@ [%@]", stop.name,stop.direction] : [stop.name copy];
+        _name = [stop.nameWithDirection copy];
         _stopId = [stop.stopId copy];
         _regionIdentifier = region.identifier;
         _stop = [stop copy];
         _bookmarkVersion = OBABookmarkVersion260;
     }
+    return self;
+}
+
+- (instancetype)initWithStop:(OBAStopV2*)stop region:(OBARegionV2*)region {
+    self = [super init];
+
+    if (self) {
+        _name = [stop.nameWithDirection copy];
+        _stopId = [stop.stopId copy];
+        _regionIdentifier = region.identifier;
+        _stop = [stop copy];
+        _bookmarkVersion = OBABookmarkVersion252;
+    }
+
     return self;
 }
 

--- a/OBAKit/Models/unmanaged/OBAStopV2.h
+++ b/OBAKit/Models/unmanaged/OBAStopV2.h
@@ -6,6 +6,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface OBAStopV2 : OBAHasReferencesV2 <MKAnnotation,NSCoding,NSCopying>
 
+@property(nonatomic,copy,readonly) NSString *nameWithDirection;
+
 @property (nonatomic, strong) NSString * stopId;
 @property (nonatomic, strong) NSString * name;
 

--- a/OBAKit/Models/unmanaged/OBAStopV2.m
+++ b/OBAKit/Models/unmanaged/OBAStopV2.m
@@ -111,6 +111,14 @@
     return OBARouteTypeUnknown;
 }
 
+- (NSString*)nameWithDirection {
+    if (self.direction) {
+        return [NSString stringWithFormat:@"%@ [%@]", self.name, self.direction];
+    }
+    else {
+        return [self.name copy];
+    }
+}
 
 #pragma mark - MKAnnotation
 

--- a/ui/bookmarks/OBABookmarkRouteDisambiguationViewController.m
+++ b/ui/bookmarks/OBABookmarkRouteDisambiguationViewController.m
@@ -33,21 +33,21 @@
 
     self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Cancel", @"") style:UIBarButtonItemStylePlain target:self action:@selector(cancel)];
 
-    OBATableSection *section = [[OBATableSection alloc] init];
+    OBATableSection *stopSection = [[OBATableSection alloc] initWithTitle:NSLocalizedString(@"Bookmark the Stop", @"")];
+    [stopSection addRow:^OBABaseRow *{
+        OBATableRow *row = [[OBATableRow alloc] initWithTitle:self.arrivalsAndDepartures.stop.nameWithDirection action:^{
+            OBABookmarkV2 *bookmark = [[OBABookmarkV2 alloc] initWithStop:self.arrivalsAndDepartures.stop region:self.region];
+            OBAEditStopBookmarkViewController *bookmarkViewController = [[OBAEditStopBookmarkViewController alloc] initWithBookmark:bookmark];
+            [self.navigationController pushViewController:bookmarkViewController animated:YES];
+        }];
+        row.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+        return row;
+    }];
 
-    NSMutableSet *representedItems = [NSMutableSet set];
+    OBATableSection *routeSection = [[OBATableSection alloc] initWithTitle:NSLocalizedString(@"Bookmark a Route at the Stop", @"")];
 
     for (OBAArrivalAndDepartureV2 *dep in self.arrivalsAndDepartures.arrivalsAndDepartures) {
-
-        // make sure we don't double up bookmarks :-|
-        if ([representedItems containsObject:dep.bookmarkKey]) {
-            continue;
-        }
-        else {
-            [representedItems addObject:dep.bookmarkKey];
-        }
-
-        [section addRow:^OBABaseRow *{
+        [routeSection addRow:^OBABaseRow *{
             OBATableRow *row = [[OBATableRow alloc] initWithTitle:[NSString stringWithFormat:@"%@ - %@", dep.bestAvailableName, dep.tripHeadsign] action:^{
                 OBABookmarkV2 *bookmark = [[OBABookmarkV2 alloc] initWithArrivalAndDeparture:dep region:self.region];
                 OBAEditStopBookmarkViewController *bookmarkViewController = [[OBAEditStopBookmarkViewController alloc] initWithBookmark:bookmark];
@@ -57,7 +57,7 @@
             return row;
         }];
     }
-    self.sections = @[section];
+    self.sections = @[stopSection, routeSection];
 }
 
 #pragma mark - Actions


### PR DESCRIPTION
Fixes #658: Allow users to bookmark the entire stop (sans route)

* Add a bookmark init method for creating OBA 2.5.2-style bookmarks
* Add convenience method for getting a stop's name and direction
* Add a new section to the bookmark route disambiguation view controller for bookmarking the entire route