### PR TITLE
Make it possible to clear the Recent Stops list

### DIFF
--- a/OBAKit/Models/dao/OBAModelDAO.h
+++ b/OBAKit/Models/dao/OBAModelDAO.h
@@ -67,14 +67,19 @@ extern NSString * const OBAMostRecentStopsChangedNotification;
 - (BOOL) readSetRegionAutomatically;
 - (void) writeSetRegionAutomatically:(BOOL)setRegionAutomatically;
 
+// Recent Stops
+
+- (void)clearMostRecentStops;
+- (void)viewedArrivalsAndDeparturesForStop:(OBAStopV2*)stop;
+
+// Custom API
+
 - (NSString*) readCustomApiUrl;
 - (void) writeCustomApiUrl:(NSString*)customApiUrl;
 
 - (void) addCustomApiUrl:(NSString*)customApiUrl;
 
 - (NSString*)normalizedAPIServerURL;
-
-- (void)viewedArrivalsAndDeparturesForStop:(OBAStopV2*)stop;
 
 @end
 

--- a/OBAKit/Models/dao/OBAModelDAO.m
+++ b/OBAKit/Models/dao/OBAModelDAO.m
@@ -379,20 +379,26 @@ const NSInteger kMaxEntriesInMostRecentList = 10;
 
 #pragma mark - Stop Viewing
 
+- (void)clearMostRecentStops {
+    [_mostRecentStops removeAllObjects];
+    [_preferencesDao writeMostRecentStops:_mostRecentStops];
+    [[NSNotificationCenter defaultCenter] postNotificationName:OBAMostRecentStopsChangedNotification object:nil];
+}
+
 - (void)addStopAccessEvent:(OBAStopAccessEventV2*)event {
 
     OBAStopAccessEventV2 * existingEvent = nil;
 
     NSArray * stopIds = event.stopIds;
 
-    for( OBAStopAccessEventV2 * stopEvent in _mostRecentStops ) {
-        if( [stopEvent.stopIds isEqual:stopIds] ) {
+    for (OBAStopAccessEventV2 * stopEvent in _mostRecentStops) {
+        if ([stopEvent.stopIds isEqual:stopIds]) {
             existingEvent = stopEvent;
             break;
         }
     }
 
-    if( existingEvent ) {
+    if (existingEvent) {
         [_mostRecentStops removeObject:existingEvent];
         [_mostRecentStops insertObject:existingEvent atIndex:0];
     }
@@ -406,14 +412,19 @@ const NSInteger kMaxEntriesInMostRecentList = 10;
     existingEvent.subtitle = event.subtitle;
 
     NSInteger over = [_mostRecentStops count] - kMaxEntriesInMostRecentList;
-    for( int i=0; i<over; i++)
+    for (int i=0; i<over; i++) {
         [_mostRecentStops removeObjectAtIndex:([_mostRecentStops count]-1)];
+    }
 
     [_preferencesDao writeMostRecentStops:_mostRecentStops];
     [[NSNotificationCenter defaultCenter] postNotificationName:OBAMostRecentStopsChangedNotification object:nil];
 }
 
 - (void)viewedArrivalsAndDeparturesForStop:(OBAStopV2*)stop {
+    OBAGuard(stop) else {
+        return;
+    }
+
     OBAStopAccessEventV2 * event = [[OBAStopAccessEventV2 alloc] init];
     event.stopIds = @[stop.stopId];
     event.title = stop.title;

--- a/OBAKit/OBAKit.h
+++ b/OBAKit/OBAKit.h
@@ -99,5 +99,5 @@ FOUNDATION_EXPORT const unsigned char OBAKitVersionString[];
 #import <OBAKit/OBARouteFilter.h>
 
 // Explicitly UI classes - Maybe part of an eventual OBAUIKit vs OBAFoundation?
-#import <OBAKit/OBATableFooterLabelView.h>
 #import <OBAKit/OBATheme.h>
+#import <OBAKit/OBATableFooterLabelView.h>

--- a/OneBusAwayTests/OBAKitTests/models/OBAModelDAO_Tests.m
+++ b/OneBusAwayTests/OBAKitTests/models/OBAModelDAO_Tests.m
@@ -7,12 +7,9 @@
 //
 
 #import <XCTest/XCTest.h>
-#import "OBAModelDAO.h"
+#import <OBAKit/OBAKit.h>
 #import "OBATestHelpers.h"
 #import "OBATestHarnessPersistenceLayer.h"
-#import "OBABookmarkGroup.h"
-#import "OBABookmarkV2.h"
-#import "OBAArrivalAndDepartureV2.h"
 
 @interface OBAModelDAO_Tests : XCTestCase
 @property(nonatomic,strong) OBATestHarnessPersistenceLayer *persistenceLayer;
@@ -569,6 +566,35 @@
 - (void)testNullRegionReturnsEmptyArray {
     self.modelDAO.region = nil;
     XCTAssertEqualObjects(self.modelDAO.bookmarksForCurrentRegion, @[]);
+}
+
+#pragma mark - Most Recent Stops
+
+- (void)testViewingStopAffectsMostRecentStops {
+    OBAStopV2 *stop = [self.class generateStop];
+    [self.modelDAO viewedArrivalsAndDeparturesForStop:stop];
+
+    XCTAssertEqual(1, self.modelDAO.mostRecentStops.count);
+
+}
+
+- (void)testClearingMostRecentStops {
+    OBAStopV2 *stop = [self.class generateStop];
+    [self.modelDAO viewedArrivalsAndDeparturesForStop:stop];
+    [self.modelDAO clearMostRecentStops];
+
+    XCTAssertEqual(0, self.modelDAO.mostRecentStops.count);
+}
+
+- (void)testClearingMostRecentStopsTriggersNotification {
+    OBAStopV2 *stop = [self.class generateStop];
+    [self.modelDAO viewedArrivalsAndDeparturesForStop:stop];
+
+    [self expectationForNotification:OBAMostRecentStopsChangedNotification object:nil handler:nil];
+
+    [self.modelDAO clearMostRecentStops];
+
+    [self waitForExpectationsWithTimeout:5 handler:nil];
 }
 
 #pragma mark - Location

--- a/ui/recent_stops/OBARecentStopsViewController.m
+++ b/ui/recent_stops/OBARecentStopsViewController.m
@@ -41,10 +41,33 @@
     return self;
 }
 
+#pragma mark - UIViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+    self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Clear Stops", @"") style:UIBarButtonItemStylePlain target:self action:@selector(clearRecentList)];
+}
+
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
+
     [self reloadData];
 }
+
+#pragma mark - Actions
+
+- (void)clearRecentList {
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"Clear Recent Stops", @"") message:NSLocalizedString(@"Are you sure you want to clear your recent stops?", @"") preferredStyle:UIAlertControllerStyleAlert];
+    [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", @"") style:UIAlertActionStyleCancel handler:nil]];
+    [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Clear Stops", @"") style:UIAlertActionStyleDestructive handler:^(UIAlertAction *action) {
+        [[OBAApplication sharedApplication].modelDao clearMostRecentStops];
+        [self reloadData];
+    }]];
+    [self presentViewController:alert animated:YES completion:nil];
+}
+
+#pragma mark - Data Loading
 
 - (void)reloadData {
 


### PR DESCRIPTION
Fixes #663

* Add a `clearMostRecentStops` method to OBAModelDAO
* Ensure that the 3D Touch Quick Actions recent stops list is also cleared
* Add tests validating that the feature works