### PR TITLE
Show a legible alert on Stops when there is an error

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -28,6 +28,7 @@ target 'OneBusAway' do
   pod 'DZNEmptyDataSet', '1.8.1'
   pod 'apptentive-ios', '3.2.1'
   pod 'Pulley', '1.0.0'
+  pod 'SwiftMessages', '~> 1.1'
 
   pod_promise_kit
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -59,6 +59,7 @@ PODS:
     - PromiseKit/CorePromise
   - Pulley (1.0.0)
   - SVProgressHUD (2.0.3)
+  - SwiftMessages (1.1.1)
 
 DEPENDENCIES:
   - apptentive-ios (= 3.2.1)
@@ -75,6 +76,7 @@ DEPENDENCIES:
   - PromiseKit/MapKit (= 3.5.0)
   - Pulley (= 1.0.0)
   - SVProgressHUD (= 2.0.3)
+  - SwiftMessages (~> 1.1)
 
 SPEC CHECKSUMS:
   apptentive-ios: bb0b126f7d2a3bc87fac843da3a71df7f50d433e
@@ -88,7 +90,8 @@ SPEC CHECKSUMS:
   PromiseKit: 3a8a529c0571f8c2c423dba0897ff39bc060bf92
   Pulley: 4dc1d5568d18bdbf9c8cb8d4d7cd0cf76692ddfe
   SVProgressHUD: b0830714205bea1317ea1a2ebc71e5633af334d4
+  SwiftMessages: 5419699a94516ddf2af21c0e067f2e7e3c2b6b29
 
-PODFILE CHECKSUM: b6d4990abcd8045964263109521b8046800a3fe4
+PODFILE CHECKSUM: 08f1d12d31d19c0e7a0e67322e0422ecc371dbd8
 
 COCOAPODS: 1.1.0.beta.1

--- a/credits.html
+++ b/credits.html
@@ -182,6 +182,14 @@
             <p>
             A different license may apply to other resources included in this package, including Freepik Icons. Please consult their respective headers for the terms of their individual licenses.
             </p>
+            <h2 id='swiftmessages'>SwiftMessages</h2>
+            <p>Copyright (c) 2016 SwiftKick Mobile LLC</p>
+
+            <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:</p>
+
+            <p>The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.</p>
+
+            <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</p>
             <h2 id="libextobjc">
                 libextobjc
             </h2>

--- a/org.onebusaway.iphone.xcodeproj/project.pbxproj
+++ b/org.onebusaway.iphone.xcodeproj/project.pbxproj
@@ -128,6 +128,7 @@
 		934446D91AB12C5D005B3333 /* OBAModalActivityIndicator.m in Sources */ = {isa = PBXBuildFile; fileRef = 934446D61AB12C5D005B3333 /* OBAModalActivityIndicator.m */; };
 		934446DA1AB12C5D005B3333 /* OBAProgressIndicatorView.m in Sources */ = {isa = PBXBuildFile; fileRef = 934446D81AB12C5D005B3333 /* OBAProgressIndicatorView.m */; };
 		9347860E1D3453E9002A5627 /* sandiego.gpx in Resources */ = {isa = PBXBuildFile; fileRef = 9347860D1D3453E9002A5627 /* sandiego.gpx */; };
+		9347B0631D73CB5C00DFBEE0 /* AlertPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9347B0621D73CB5C00DFBEE0 /* AlertPresenter.swift */; };
 		934B62971CF825D200D8FA85 /* OBATripScheduleSectionBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 934B62961CF825D200D8FA85 /* OBATripScheduleSectionBuilder.m */; };
 		934B62A21CFBA5FA00D8FA85 /* NSObject+OBADescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 934B62A01CFBA5FA00D8FA85 /* NSObject+OBADescription.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		934B62A31CFBA5FA00D8FA85 /* NSObject+OBADescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 934B62A11CFBA5FA00D8FA85 /* NSObject+OBADescription.m */; };
@@ -554,6 +555,7 @@
 		934446D71AB12C5D005B3333 /* OBAProgressIndicatorView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAProgressIndicatorView.h; sourceTree = "<group>"; };
 		934446D81AB12C5D005B3333 /* OBAProgressIndicatorView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAProgressIndicatorView.m; sourceTree = "<group>"; };
 		9347860D1D3453E9002A5627 /* sandiego.gpx */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = sandiego.gpx; sourceTree = "<group>"; };
+		9347B0621D73CB5C00DFBEE0 /* AlertPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlertPresenter.swift; sourceTree = "<group>"; };
 		934B62951CF825D200D8FA85 /* OBATripScheduleSectionBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBATripScheduleSectionBuilder.h; sourceTree = "<group>"; };
 		934B62961CF825D200D8FA85 /* OBATripScheduleSectionBuilder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBATripScheduleSectionBuilder.m; sourceTree = "<group>"; };
 		934B62A01CFBA5FA00D8FA85 /* NSObject+OBADescription.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSObject+OBADescription.h"; sourceTree = "<group>"; };
@@ -1737,6 +1739,7 @@
 			isa = PBXGroup;
 			children = (
 				93F64E951BE5ACC300323527 /* OBAAlerts.h */,
+				9347B0621D73CB5C00DFBEE0 /* AlertPresenter.swift */,
 				93F64E961BE5ACC300323527 /* OBAAlerts.m */,
 			);
 			path = alerts;
@@ -1933,6 +1936,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = OBA;
+				LastSwiftUpdateCheck = 0730;
 				LastUpgradeCheck = 0710;
 				ORGANIZATIONNAME = OneBusAway;
 				TargetAttributes = {
@@ -2187,6 +2191,7 @@
 				932076621C940519005F7D4A /* OBASegmentedRow.m in Sources */,
 				934446B51AB10E67005B3333 /* UINavigationController+oba_Additions.m in Sources */,
 				932BE4BF1AB66D5C0011F2FB /* OBAReportProblemWithStopViewController.m in Sources */,
+				9347B0631D73CB5C00DFBEE0 /* AlertPresenter.swift in Sources */,
 				932BE4CE1AB66D710011F2FB /* OBAReportProblemWithTripViewController.m in Sources */,
 				932BE4FB1AB66EDD0011F2FB /* OBAVehicleDetailsController.m in Sources */,
 				936D2EED1C7A3BAB0060B7E1 /* OBATableViewCell.m in Sources */,
@@ -2414,6 +2419,7 @@
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				BUILD_VARIANTS = normal;
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN_ASSIGN_ENUM = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
@@ -2458,6 +2464,7 @@
 				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "";
 				SDKROOT = iphoneos;
 				STRIP_INSTALLED_PRODUCT = NO;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 2.3;
 				VALIDATE_PRODUCT = YES;
 			};
@@ -2469,6 +2476,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN_ASSIGN_ENUM = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
@@ -2950,6 +2958,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN_ASSIGN_ENUM = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
@@ -3022,6 +3031,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN_ASSIGN_ENUM = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;

--- a/ui/alerts/AlertPresenter.swift
+++ b/ui/alerts/AlertPresenter.swift
@@ -1,0 +1,34 @@
+//
+//  AlertPresenter.swift
+//  org.onebusaway.iphone
+//
+//  Created by Aaron Brethorst on 8/28/16.
+//  Copyright © 2016 OneBusAway. All rights reserved.
+//
+
+import UIKit
+import SwiftMessages
+
+@objc public class AlertPresenter: NSObject {
+
+    public class func showWarning(title: String, body: String) {
+
+        var config = SwiftMessages.Config()
+        config.presentationContext = .Window(windowLevel: UIWindowLevelStatusBar)
+        config.duration = .Seconds(seconds: 5)
+        config.dimMode = .Gray(interactive: true)
+        config.interactiveHide = true
+        config.preferredStatusBarStyle = .LightContent
+
+        // Instantiate a message view from the provided card view layout. SwiftMessages searches for nib
+        // files in the main bundle first, so you can easily copy them into your project and make changes.
+        let view = MessageView.viewFromNib(layout: .CardView)
+        view.button?.hidden = true
+        view.configureTheme(.Warning)
+        view.configureDropShadow()
+        view.configureContent(title: title, body: body)
+
+        // Show the message.
+        SwiftMessages.show(config: config, view: view)
+    }
+}

--- a/ui/stops/OBAStopViewController.m
+++ b/ui/stops/OBAStopViewController.m
@@ -10,6 +10,7 @@
 #import <OBAKit/OBAKit.h>
 #import <PromiseKit/PromiseKit.h>
 #import <DateTools/DateTools.h>
+#import "OneBusAway-Swift.h"
 #import "OBAStopSectionHeaderView.h"
 #import "OBASeparatorSectionView.h"
 #import "OBAReportProblemViewController.h"
@@ -151,8 +152,7 @@ static CGFloat const kTableHeaderHeight = 150.f;
     }
 
     self.navigationItem.title = NSLocalizedString(@"Updating...", @"Title of the Stop UI Controller while it is updating its content.");
-    
-    __block NSString *message = nil;
+
     [[OBAApplication sharedApplication].modelService requestStopForID:self.stopID minutesBefore:self.minutesBefore minutesAfter:self.minutesAfter].then(^(OBAArrivalsAndDeparturesForStopV2 *response) {
         self.navigationItem.title = [NSString stringWithFormat:@"%@: %@", NSLocalizedString(@"Updated", @"message"), [OBACommon getTimeAsString]];
         [self.modelDAO viewedArrivalsAndDeparturesForStop:response.stop];
@@ -162,8 +162,8 @@ static CGFloat const kTableHeaderHeight = 150.f;
         [self populateTableFromArrivalsAndDeparturesModel:self.arrivalsAndDepartures];
         [self.parallaxHeaderView populateTableHeaderFromArrivalsAndDeparturesModel:self.arrivalsAndDepartures];
     }).catch(^(NSError *error) {
-        message = error.localizedDescription ?: NSLocalizedString(@"Error connecting", @"requestDidFail");
-        self.navigationItem.title = message;
+        self.navigationItem.title = NSLocalizedString(@"Error", @"");
+        [AlertPresenter showWarning:NSLocalizedString(@"Error", @"") body:error.localizedDescription ?: NSLocalizedString(@"Error connecting", @"requestDidFail")];
     }).finally(^{
         if (animated) {
             [self.refreshControl endRefreshing];


### PR DESCRIPTION
Fixes #600 - Title of stop view has issues with long strings

* Add a 3rd party component for presenting non-modal alerts and wrap it with a Swift class that supports Obj-C interoperability
* Display an error message on the Stop UI when the stop data fails to load