### PR TITLE
Prospective fix for another user-discovered crashing bug

### DIFF
--- a/OBAKit/Models/unmanaged/OBAStopV2.m
+++ b/OBAKit/Models/unmanaged/OBAStopV2.m
@@ -69,17 +69,19 @@
 
 - (NSArray<OBARouteV2*>*)routes {
 
-    if (!_routes) {
-        NSMutableArray *routes = [NSMutableArray array];
+    @synchronized (self) {
+        if (!_routes) {
+            NSMutableArray *routes = [NSMutableArray array];
 
-        for (NSString *routeId in _routeIds) {
-            OBARouteV2 *route = [self.references getRouteForId:routeId];
-            [routes addObject:route];
+            for (NSString *routeId in _routeIds) {
+                OBARouteV2 *route = [self.references getRouteForId:routeId];
+                [routes addObject:route];
+            }
+
+            [routes sortUsingSelector:@selector(compareUsingName:)];
+
+            _routes = [[NSArray alloc] initWithArray:routes copyItems:YES];
         }
-
-        [routes sortUsingSelector:@selector(compareUsingName:)];
-
-        _routes = [[NSArray alloc] initWithArray:routes copyItems:YES];
     }
 
     return _routes;


### PR DESCRIPTION
Wrap a `@synchronized` section around the code used to generate a stop's routes in order to prevent what seems to be simultaneous access of the `routes` variable.