### PR TITLE
Remove unnecessary properties from the app delegate

### DIFF
--- a/OBAApplicationDelegate.h
+++ b/OBAApplicationDelegate.h
@@ -25,10 +25,6 @@ NS_ASSUME_NONNULL_BEGIN
 @class OBAInfoViewController;
 
 @interface OBAApplicationDelegate : UIResponder <UIApplicationDelegate>
-@property(nonatomic,strong) UIWindow *window;
-@property(nonatomic,readonly) BOOL active;
-@property(nonatomic, strong) id<GAITracker> tracker;
-
 - (void)navigateToTarget:(OBANavigationTarget*)navigationTarget;
 - (void)regionSelected;
 @end

--- a/OBAApplicationDelegate.m
+++ b/OBAApplicationDelegate.m
@@ -34,13 +34,11 @@
 
 static NSString *const kTrackingId = @"UA-2423527-17";
 static NSString *const kOptOutOfTracking = @"OptOutOfTracking";
-
 static NSString *const kApptentiveKey = @"3363af9a6661c98dec30fedea451a06dd7d7bc9f70ef38378a9d5a15ac7d4926";
 
 @interface OBAApplicationDelegate () <OBABackgroundTaskExecutor, OBARegionHelperDelegate, RegionListDelegate>
 @property (nonatomic, strong) UINavigationController *regionNavigationController;
 @property (nonatomic, strong) RegionListViewController *regionListViewController;
-@property (nonatomic, readwrite) BOOL active;
 @property (nonatomic, strong) id regionObserver;
 @property (nonatomic, strong) id recentStopsObserver;
 @property(nonatomic,strong) id<OBAApplicationUI> applicationUI;
@@ -52,8 +50,6 @@ static NSString *const kApptentiveKey = @"3363af9a6661c98dec30fedea451a06dd7d7bc
     self = [super init];
 
     if (self) {
-        _active = NO;
-
         self.regionObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kOBAApplicationSettingsRegionRefreshNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *note) {
             [OBAApplication sharedApplication].modelDao.automaticallySelectRegion = YES;
             [[OBAApplication sharedApplication].regionHelper updateNearestRegion];
@@ -131,16 +127,13 @@ static NSString *const kApptentiveKey = @"3363af9a6661c98dec30fedea451a06dd7d7bc
 
     // User must be able to opt out of tracking
     [GAI sharedInstance].optOut = ![[NSUserDefaults standardUserDefaults] boolForKey:kOptOutOfTracking];
-
     [GAI sharedInstance].trackUncaughtExceptions = YES;
-    [[[GAI sharedInstance] logger] setLogLevel:kGAILogLevelWarning];
+    [GAI sharedInstance].logger.logLevel = kGAILogLevelWarning;
 
     //don't report to Google Analytics when developing
 #ifdef DEBUG
     [[GAI sharedInstance] setDryRun:YES];
 #endif
-
-    self.tracker = [[GAI sharedInstance] trackerWithTrackingId:kTrackingId];
 
     [[GAI sharedInstance].defaultTracker set:[GAIFields customDimensionForIndex:1] value:[OBAApplication sharedApplication].modelDao.currentRegion.regionName];
 
@@ -160,8 +153,6 @@ static NSString *const kApptentiveKey = @"3363af9a6661c98dec30fedea451a06dd7d7bc
 }
 
 - (void)applicationDidBecomeActive:(UIApplication *)application {
-    self.active = YES;
-
     [[OBAApplication sharedApplication].reachability startNotifier];
 
     [self.applicationUI applicationDidBecomeActive];
@@ -176,7 +167,6 @@ static NSString *const kApptentiveKey = @"3363af9a6661c98dec30fedea451a06dd7d7bc
 }
 
 - (void)applicationWillResignActive:(UIApplication *)application {
-    self.active = NO;
     [[OBAApplication sharedApplication].reachability stopNotifier];
 }
 

--- a/ui/search/OBASearchResultsMapViewController.m
+++ b/ui/search/OBASearchResultsMapViewController.m
@@ -33,6 +33,8 @@
 #define kAddressSegmentIndex        1
 #define kStopNumberSegmentIndex     2
 
+#define kDefaultTitle NSLocalizedString(@"Map", @"Map tab title")
+
 static const NSUInteger kShowNClosestStops = 4;
 static const double kStopsInRegionRefreshDelayOnDrag = 0.1;
 
@@ -72,7 +74,7 @@ static const double kStopsInRegionRefreshDelayOnDrag = 0.1;
     self = [super initWithNibName:@"OBASearchResultsMapViewController" bundle:nil];
 
     if (self) {
-        self.title = NSLocalizedString(@"Map", @"Map tab title");
+        self.title = kDefaultTitle;
         self.tabBarItem.image = [UIImage imageNamed:@"CrossHairs"];
     }
 
@@ -1144,7 +1146,7 @@ static const double kStopsInRegionRefreshDelayOnDrag = 0.1;
 }
 
 - (void)cancelPressed {
-    self.navigationItem.title = NSLocalizedString(@"Map", @"Map tab title");
+    self.navigationItem.title = kDefaultTitle;
     self.navigationItem.titleView = self.titleView;
 
     [self.searchController searchWithTarget:[OBASearch getNavigationTargetForSearchNone]];
@@ -1153,13 +1155,13 @@ static const double kStopsInRegionRefreshDelayOnDrag = 0.1;
 }
 
 - (BOOL)controllerIsVisibleAndActive {
-    if (!APP_DELEGATE.active) {
-        // Ignore errors if our app isn't currently active
-        return NO;
-    }
-    else {
+    if ([UIApplication sharedApplication].applicationState == UIApplicationStateActive) {
         // Ignore errors if our view isn't currently on top
         return self == self.navigationController.visibleViewController;
+    }
+    else {
+        // Ignore errors if our app isn't currently active
+        return NO;
     }
 }
 


### PR DESCRIPTION
* Remove the `window` property from the app delegate. This has been defined on the protocol since iOS 5.
* Remove the `active` property. This can be retrieved from the `UIApplication` singleton.
* Remove the `tracker` property and use the GA singleton directly.
* On the map, replace two identical `NSLocalizedString` calls with a macro. This way, we can ensure that if/when the title of this view controller is changed, it won't show an old title under some scenarios.