### PR TITLE
Fix a few bugs

### DIFF
--- a/OBAApplicationDelegate.h
+++ b/OBAApplicationDelegate.h
@@ -25,6 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class OBAInfoViewController;
 
 @interface OBAApplicationDelegate : UIResponder <UIApplicationDelegate>
+@property (nullable, nonatomic, strong) UIWindow *window;
 - (void)navigateToTarget:(OBANavigationTarget*)navigationTarget;
 - (void)regionSelected;
 @end

--- a/ui/bookmarks/OBABookmarkGroupsViewController.m
+++ b/ui/bookmarks/OBABookmarkGroupsViewController.m
@@ -85,6 +85,7 @@
     for (OBABookmarkGroup *group in self.modelDAO.bookmarkGroups) {
         OBATableRow *tableRow = [[OBATableRow alloc] initWithTitle:group.name action:nil];
         tableRow.model = group;
+
         [tableRow setEditAction:^(OBABaseRow *row) {
             UIAlertController *alert = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"Edit Group Name", @"") message:nil preferredStyle:UIAlertControllerStyleAlert];
             [alert addTextFieldWithConfigurationHandler:^(UITextField * textField) {
@@ -98,6 +99,11 @@
             }]];
             [self presentViewController:alert animated:YES completion:nil];
         }];
+
+        [tableRow setDeleteModel:^(OBABaseRow *row){
+            [self.modelDAO removeBookmarkGroup:row.model];
+        }];
+
         [rows addObject:tableRow];
     }
 
@@ -116,7 +122,7 @@
 
 - (void)tableView:(UITableView *)tableView commitEditingStyle:(UITableViewCellEditingStyle)editingStyle forRowAtIndexPath:(NSIndexPath *)indexPath {
     if (editingStyle == UITableViewCellEditingStyleDelete) {
-        [self deleteRowAtIndexPath:indexPath tableView:tableView];
+        [self deleteRowAtIndexPath:indexPath];
     }
 }
 

--- a/ui/bookmarks/OBABookmarksViewController.m
+++ b/ui/bookmarks/OBABookmarksViewController.m
@@ -203,7 +203,7 @@ static NSTimeInterval const kRefreshTimerInterval = 30.0;
 
 - (void)tableView:(UITableView *)tableView commitEditingStyle:(UITableViewCellEditingStyle)editingStyle forRowAtIndexPath:(NSIndexPath *)indexPath {
     if (editingStyle == UITableViewCellEditingStyleDelete) {
-        [self deleteRowAtIndexPath:indexPath tableView:tableView];
+        [self deleteRowAtIndexPath:indexPath];
     }
 }
 
@@ -221,7 +221,7 @@ static NSTimeInterval const kRefreshTimerInterval = 30.0;
     NSMutableArray<UITableViewRowAction *> *actions = [NSMutableArray array];
 
     UITableViewRowAction *delete = [UITableViewRowAction rowActionWithStyle:UITableViewRowActionStyleDestructive title:NSLocalizedString(@"Delete", @"Title of delete bookmark row action.") handler:^(UITableViewRowAction *action, NSIndexPath *indexPath) {
-        [self deleteRowAtIndexPath:indexPath tableView:tableView];
+        [self deleteRowAtIndexPath:indexPath];
     }];
     [actions addObject:delete];
 
@@ -266,29 +266,6 @@ static NSTimeInterval const kRefreshTimerInterval = 30.0;
     destinationSection.rows = [NSArray arrayWithArray:destinationRows];
 
     [tableView endUpdates];
-}
-
-#pragma mark - Table Row Deletion
-
-// TODO: get rid of this and use the newly built-in feature on OBAStaticTableViewController
-// to handle row deletion instead!
-- (void)deleteRowAtIndexPath:(NSIndexPath*)indexPath tableView:(UITableView*)tableView {
-    OBATableSection *tableSection = self.sections[indexPath.section];
-    OBATableRow *tableRow = tableSection.rows[indexPath.row];
-
-    NSMutableArray *deletedRows = [NSMutableArray new];
-
-    NSMutableArray *rows = [NSMutableArray arrayWithArray:tableSection.rows];
-    [rows removeObjectAtIndex:indexPath.row];
-    tableSection.rows = rows;
-
-    [deletedRows addObject:indexPath];
-
-    if (tableRow.deleteModel) {
-        tableRow.deleteModel();
-    }
-
-    [tableView deleteRowsAtIndexPaths:deletedRows withRowAnimation:UITableViewRowAnimationAutomatic];
 }
 
 #pragma mark - Accessors
@@ -430,8 +407,8 @@ static NSTimeInterval const kRefreshTimerInterval = 30.0;
         [self presentViewController:nav animated:YES completion:nil];
     }];
 
-    [row setDeleteModel:^{
-        [self.modelDAO removeBookmark:bookmark];
+    [row setDeleteModel:^(OBABaseRow *row){
+        [self.modelDAO removeBookmark:row.model];
     }];
 }
 

--- a/ui/regions/RegionListViewController.swift
+++ b/ui/regions/RegionListViewController.swift
@@ -209,7 +209,7 @@ class RegionListViewController: OBAStaticTableViewController, RegionBuilderDeleg
             let row: OBATableRow = OBATableRow.init(title: region.regionName, action: action)
 
             row.model = region
-            row.deleteModel = {
+            row.deleteModel = { row in
                 let alert = UIAlertController.init(title: NSLocalizedString("Are you sure you want to delete this region?", comment: ""), message: nil, preferredStyle: .Alert)
                 alert.addAction(UIAlertAction.init(title: OBAStrings.cancel(), style: .Cancel, handler: nil))
                 alert.addAction(UIAlertAction.init(title: OBAStrings.delete(), style: .Destructive, handler: { action in

--- a/ui/static_table/OBAStaticTableViewController.m
+++ b/ui/static_table/OBAStaticTableViewController.m
@@ -165,7 +165,7 @@
     OBATableSection *section = self.sections[indexPath.section];
     [section removeRowAtIndex:indexPath.row];
 
-    tableRow.deleteModel();
+    tableRow.deleteModel(tableRow);
 
     [self.tableView deleteRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
 }

--- a/ui/static_table/viewmodels/OBABaseRow.h
+++ b/ui/static_table/viewmodels/OBABaseRow.h
@@ -46,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
  to associate your row with a model (due to sorting differences or whatever), this block provides an easy way
  to get back to—and delete—the underlying data.
  */
-@property(nonatomic,copy) void (^deleteModel)();
+@property(nonatomic,copy) void (^deleteModel)(OBABaseRow *row);
 
 @property(nonatomic,assign) NSUInteger indentationLevel;
 


### PR DESCRIPTION
* Oops, turns out you do need that window property after all. My bad.
* Add a `row` parameter to the `OBABaseRow.deleteModel` block property.
* Use the OBAStaticTableViewController-provided deletion method for all row deletions across the app.