### PR TITLE
Improve departure cell text wrapping

### DIFF
--- a/ui/bookmarks/tableview/OBABookmarkedRouteCell.m
+++ b/ui/bookmarks/tableview/OBABookmarkedRouteCell.m
@@ -71,10 +71,7 @@
 
     self.titleLabel.text = nil;
 
-    self.departureView.routeNameLabel.text = nil;
-    self.departureView.destinationLabel.text = nil;
-    self.departureView.timeAndStatusLabel.text = nil;
-    self.departureView.minutesUntilDepartureLabel.text = nil;
+    [self.departureView prepareForReuse];
 
     [self.activityIndicatorView prepareForReuse];
 }

--- a/ui/stops/OBAClassicDepartureCell.m
+++ b/ui/stops/OBAClassicDepartureCell.m
@@ -39,10 +39,7 @@
 - (void)prepareForReuse {
     [super prepareForReuse];
 
-    self.departureView.routeNameLabel.text = nil;
-    self.departureView.destinationLabel.text = nil;
-    self.departureView.timeAndStatusLabel.text = nil;
-    self.departureView.minutesUntilDepartureLabel.text = nil;
+    [self.departureView prepareForReuse];
 }
 
 #pragma mark - OBATableCell

--- a/ui/stops/OBAClassicDepartureView.h
+++ b/ui/stops/OBAClassicDepartureView.h
@@ -13,12 +13,9 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface OBAClassicDepartureView : UIView
-@property(nonatomic,strong,readonly) UILabel *routeNameLabel;
-@property(nonatomic,strong,readonly) UILabel *destinationLabel;
-@property(nonatomic,strong,readonly) UILabel *timeAndStatusLabel;
-@property(nonatomic,strong,readonly) UILabel *minutesUntilDepartureLabel;
-
 @property(nonatomic,copy) OBAClassicDepartureRow *classicDepartureRow;
+
+- (void)prepareForReuse;
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Fixes #622 - Long route name causes UI readability issues

Replace the old two stack views/four labels layout of the departure cell with a new one stack/two label layout that can handle long route names. Text wraps to multiple lines quite elegantly, and nothing should be truncated again.