### PR TITLE
Improve the rendering of the "No departure scheduled" label

### DIFF
--- a/OBAKit/UI/OBATheme.m
+++ b/OBAKit/UI/OBATheme.m
@@ -62,14 +62,14 @@ static UIFont *_boldFootnoteFont = nil;
 
 + (UIFont*)titleFont {
     if (!_titleFont) {
-        _titleFont = [self fontWithTextStyle:UIFontTextStyleTitle1];
+        _titleFont = [self fontWithTextStyle:UIFontTextStyleTitle2];
     }
     return _titleFont;
 }
 
 + (UIFont*)subtitleFont {
     if (!_subtitleFont) {
-        _subtitleFont = [self fontWithTextStyle:UIFontTextStyleTitle2];
+        _subtitleFont = [self fontWithTextStyle:UIFontTextStyleTitle3];
     }
     return _subtitleFont;
 }

--- a/controls/progress/OBALabelActivityIndicatorView.m
+++ b/controls/progress/OBALabelActivityIndicatorView.m
@@ -21,7 +21,9 @@
     self = [super initWithFrame:frame];
 
     if (self) {
+        self.clipsToBounds = YES;
         _textLabel = [[UILabel alloc] initWithFrame:CGRectZero];
+        _textLabel.numberOfLines = 0;
         _textLabel.text = NSLocalizedString(@"Loading", @"");
 
         _activity = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleGray];
@@ -30,7 +32,9 @@
         [self addSubview:_activity];
 
         [_textLabel mas_makeConstraints:^(MASConstraintMaker *make) {
-            make.center.equalTo(self);
+            make.centerX.equalTo(self);
+            make.top.and.bottom.equalTo(self);
+            make.width.lessThanOrEqualTo(self);
         }];
 
         [_activity mas_makeConstraints:^(MASConstraintMaker *make) {
@@ -41,6 +45,8 @@
 
     return self;
 }
+
+#pragma mark - Public Methods
 
 - (void)startAnimating {
     [self.activity startAnimating];

--- a/ui/bookmarks/OBABookmarksViewController.m
+++ b/ui/bookmarks/OBABookmarksViewController.m
@@ -114,7 +114,7 @@ static NSTimeInterval const kRefreshTimerInterval = 30.0;
                 row.supplementaryMessage = nil;
             }
             else {
-                row.supplementaryMessage = [NSString stringWithFormat:@"No departure scheduled for the next %@ minutes", @(minutes)];
+                row.supplementaryMessage = [NSString stringWithFormat:NSLocalizedString(@"%@: No departure scheduled for the next %@ minutes", @""), bookmark.routeShortName, @(minutes)];
             }
 
             row.nextDeparture = departure;

--- a/ui/bookmarks/tableview/OBABookmarkedRouteCell.m
+++ b/ui/bookmarks/tableview/OBABookmarkedRouteCell.m
@@ -35,6 +35,7 @@
         self.contentView.autoresizingMask = UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleHeight;
 
         _titleLabel = [OBAUIBuilder label];
+        _titleLabel.font = [OBATheme subtitleFont];
         _titleLabel.numberOfLines = 0;
         [self.contentView addSubview:_titleLabel];
 
@@ -55,15 +56,14 @@
         make.left.top.and.right.equalTo(self.contentView).insets(self.layoutMargins);
     }];
 
-    [self.departureView mas_makeConstraints:^(MASConstraintMaker *make) {
+    void (^constraintBlock)(MASConstraintMaker *make) = ^(MASConstraintMaker *make) {
         make.top.equalTo(self.titleLabel.mas_bottom);
         make.left.right.and.bottom.equalTo(self.contentView).insets(self.layoutMargins);
         make.height.greaterThanOrEqualTo(@40);
-    }];
+    };
 
-    [self.activityIndicatorView mas_makeConstraints:^(MASConstraintMaker *make) {
-        make.edges.equalTo(self.departureView).insets(self.layoutMargins);
-    }];
+    [self.departureView mas_makeConstraints:constraintBlock];
+    [self.activityIndicatorView mas_makeConstraints:constraintBlock];
 }
 
 - (void)prepareForReuse {

--- a/ui/trip_details/OBAVehicleDetailsController.m
+++ b/ui/trip_details/OBAVehicleDetailsController.m
@@ -1,5 +1,4 @@
 #import "OBAVehicleDetailsController.h"
-#import "OBATripScheduleMapViewController.h"
 #import "OBAReportProblemWithTripViewController.h"
 #import "OBASituationsViewController.h"
 #import "OBAAnalytics.h"


### PR DESCRIPTION
Fixes #690 - "No departure scheduled" margins are wonky

* Fix a couple funky issues with the OBALabelActivityIndicatorView label layout
* Decrease font size of the titleFont and subtitleFont
* Use subtitleFont on the bookmarks controller for the bookmark title
* Add the short route name to the bookmark cell's "no departure scheduled" message so that you know which route it refers to.