### PR TITLE
Make long stop names wrap properly on the Arrival and Departure view

### DIFF
--- a/org.onebusaway.iphone.xcodeproj/project.pbxproj
+++ b/org.onebusaway.iphone.xcodeproj/project.pbxproj
@@ -321,6 +321,7 @@
 		939C23B11D36228A002A4145 /* OBABookmarkedRouteRow.m in Sources */ = {isa = PBXBuildFile; fileRef = 939C23B01D36228A002A4145 /* OBABookmarkedRouteRow.m */; };
 		939C23B91D371DE8002A4145 /* OBABookmarkedRouteCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 939C23B81D371DE8002A4145 /* OBABookmarkedRouteCell.m */; };
 		939E8E5B1C7B815E008FCA4C /* OBABaseRow.m in Sources */ = {isa = PBXBuildFile; fileRef = 939E8E5A1C7B815E008FCA4C /* OBABaseRow.m */; };
+		93A41C7F1D7C90770080500F /* OBATableViewCellValue1.m in Sources */ = {isa = PBXBuildFile; fileRef = 93A41C7E1D7C90770080500F /* OBATableViewCellValue1.m */; };
 		93A923A21C21DCD600A657C8 /* SafariServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 93A923A11C21DCD600A657C8 /* SafariServices.framework */; };
 		93AD36431603FE7E00BDF03F /* OBAArrivalEntryTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 93AD363A1603FE7E00BDF03F /* OBAArrivalEntryTableViewCell.m */; };
 		93AD36441603FE7E00BDF03F /* OBAArrivalEntryTableViewCellFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 93AD363C1603FE7E00BDF03F /* OBAArrivalEntryTableViewCellFactory.m */; };
@@ -785,6 +786,8 @@
 		939E8E4C1C78DCB1008FCA4C /* Pods.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Pods.framework; path = "Pods/../build/Debug-iphoneos/Pods.framework"; sourceTree = "<group>"; };
 		939E8E591C7B815E008FCA4C /* OBABaseRow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBABaseRow.h; sourceTree = "<group>"; };
 		939E8E5A1C7B815E008FCA4C /* OBABaseRow.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBABaseRow.m; sourceTree = "<group>"; };
+		93A41C7D1D7C90770080500F /* OBATableViewCellValue1.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBATableViewCellValue1.h; sourceTree = "<group>"; };
+		93A41C7E1D7C90770080500F /* OBATableViewCellValue1.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBATableViewCellValue1.m; sourceTree = "<group>"; };
 		93A923A11C21DCD600A657C8 /* SafariServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SafariServices.framework; path = System/Library/Frameworks/SafariServices.framework; sourceTree = SDKROOT; };
 		93AD36391603FE7E00BDF03F /* OBAArrivalEntryTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAArrivalEntryTableViewCell.h; sourceTree = "<group>"; };
 		93AD363A1603FE7E00BDF03F /* OBAArrivalEntryTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAArrivalEntryTableViewCell.m; sourceTree = "<group>"; };
@@ -1602,6 +1605,8 @@
 				938EAC7E1D6A9BB400B174B9 /* OBASwitchCell.m */,
 				93FF25EA1D6E342B00A58E72 /* OBATextFieldCell.h */,
 				93FF25EB1D6E342B00A58E72 /* OBATextFieldCell.m */,
+				93A41C7D1D7C90770080500F /* OBATableViewCellValue1.h */,
+				93A41C7E1D7C90770080500F /* OBATableViewCellValue1.m */,
 			);
 			path = cells;
 			sourceTree = "<group>";
@@ -2214,6 +2219,7 @@
 				932BE4CF1AB66D710011F2FB /* OBATripDetailsViewController.m in Sources */,
 				93AD36431603FE7E00BDF03F /* OBAArrivalEntryTableViewCell.m in Sources */,
 				934446D91AB12C5D005B3333 /* OBAModalActivityIndicator.m in Sources */,
+				93A41C7F1D7C90770080500F /* OBATableViewCellValue1.m in Sources */,
 				93AD36441603FE7E00BDF03F /* OBAArrivalEntryTableViewCellFactory.m in Sources */,
 				93B8BA291C9C646E0079A3DA /* OBAArrivalAndDepartureViewController.m in Sources */,
 				932BE4D01AB66D710011F2FB /* OBATripScheduleListViewController.m in Sources */,

--- a/ui/static_table/cells/OBATableViewCell.h
+++ b/ui/static_table/cells/OBATableViewCell.h
@@ -12,9 +12,6 @@
 @interface OBATableViewCell : UITableViewCell<OBATableCell>
 @end
 
-@interface OBATableViewCellValue1 : OBATableViewCell
-@end
-
 @interface OBATableViewCellValue2 : OBATableViewCell
 @end
 

--- a/ui/static_table/cells/OBATableViewCell.m
+++ b/ui/static_table/cells/OBATableViewCell.m
@@ -45,13 +45,6 @@
 }
 @end
 
-@implementation OBATableViewCellValue1
-- (instancetype)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier {
-    self = [super initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:reuseIdentifier];
-    return self;
-}
-@end
-
 @implementation OBATableViewCellValue2
 - (instancetype)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier {
     self = [super initWithStyle:UITableViewCellStyleValue2 reuseIdentifier:reuseIdentifier];

--- a/ui/static_table/cells/OBATableViewCellValue1.h
+++ b/ui/static_table/cells/OBATableViewCellValue1.h
@@ -1,0 +1,13 @@
+//
+//  OBATableViewCellValue1.h
+//  org.onebusaway.iphone
+//
+//  Created by Aaron Brethorst on 9/4/16.
+//  Copyright © 2016 OneBusAway. All rights reserved.
+//
+
+#import "OBATableViewCell.h"
+
+@interface OBATableViewCellValue1 : OBATableViewCell
+
+@end

--- a/ui/static_table/cells/OBATableViewCellValue1.m
+++ b/ui/static_table/cells/OBATableViewCellValue1.m
@@ -1,0 +1,90 @@
+//
+//  OBATableViewCellValue1.m
+//  org.onebusaway.iphone
+//
+//  Created by Aaron Brethorst on 9/4/16.
+//  Copyright © 2016 OneBusAway. All rights reserved.
+//
+
+#import "OBATableViewCellValue1.h"
+#import "OBATableRow.h"
+#import "OBATheme.h"
+#import <Masonry/Masonry.h>
+
+@interface OBATableViewCellValue1 ()
+@property(nonatomic,strong) UILabel *obaTextLabel;
+@property(nonatomic,strong) UILabel *obaDetailTextLabel;
+@property(nonatomic,strong) UIStackView *stackView;
+
+// stack views seem to require spacing views for some scenarios, like ours. Lame.
+@property(nonatomic,strong) UIView *stupidSpacingView;
+@end
+
+@implementation OBATableViewCellValue1
+@synthesize tableRow = _tableRow;
+
+- (instancetype)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier {
+    self = [super initWithStyle:UITableViewCellStyleDefault reuseIdentifier:reuseIdentifier];
+
+    if (self) {
+        _obaTextLabel = [[UILabel alloc] initWithFrame:CGRectZero];
+        _obaTextLabel.numberOfLines = 0;
+        [_obaTextLabel setContentHuggingPriority:UILayoutPriorityDefaultLow forAxis:UILayoutConstraintAxisHorizontal];
+        [_obaTextLabel setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
+
+        _obaDetailTextLabel = [[UILabel alloc] initWithFrame:CGRectZero];
+        _obaDetailTextLabel.textColor = [UIColor darkGrayColor];
+        [_obaDetailTextLabel setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
+
+        _stupidSpacingView = [[UIView alloc] initWithFrame:CGRectZero];
+
+        _stackView = [[UIStackView alloc] initWithArrangedSubviews:@[_obaTextLabel, _stupidSpacingView, _obaDetailTextLabel]];
+        _stackView.axis = UILayoutConstraintAxisHorizontal;
+        _stackView.alignment = UIStackViewAlignmentFill;
+        _stackView.spacing = [OBATheme defaultPadding];
+        _stackView.layoutMargins = self.layoutMargins;
+        _stackView.layoutMarginsRelativeArrangement = YES;
+        [self.contentView addSubview:_stackView];
+        [_stackView mas_makeConstraints:^(MASConstraintMaker *make) {
+            make.edges.equalTo(self.contentView);
+            make.height.greaterThanOrEqualTo(@44);
+        }];
+    }
+
+    return self;
+}
+
+- (void)prepareForReuse {
+    [super prepareForReuse];
+
+    self.textLabel.text = nil;
+    self.textLabel.textColor = nil;
+    self.detailTextLabel.text = nil;
+    self.accessoryType = UITableViewCellAccessoryNone;
+    self.imageView.image = nil;
+    self.selectionStyle = UITableViewCellSelectionStyleDefault;
+}
+
+- (void)setTableRow:(OBATableRow *)tableRow {
+    // this method very intentionally doesn't call super.
+
+    OBAGuardClass(tableRow, OBATableRow) else {
+        return;
+    }
+
+    _tableRow = [tableRow copy];
+
+    self.obaTextLabel.text = [self tableDataRow].title;
+    self.obaTextLabel.textColor = [self tableDataRow].titleColor;
+    self.obaTextLabel.textAlignment = [self tableDataRow].textAlignment;
+    self.obaDetailTextLabel.text = [self tableDataRow].subtitle;
+    self.accessoryType = [self tableDataRow].accessoryType;
+    self.imageView.image = [self tableDataRow].image;
+    self.selectionStyle = [self tableDataRow].selectionStyle;
+}
+
+- (OBATableRow*)tableDataRow {
+    return (OBATableRow*)self.tableRow;
+}
+
+@end

--- a/ui/static_table/viewmodels/OBATableRow.m
+++ b/ui/static_table/viewmodels/OBATableRow.m
@@ -9,6 +9,7 @@
 #import "OBATableRow.h"
 #import "OBAViewModelRegistry.h"
 #import "OBATableViewCell.h"
+#import "OBATableViewCellValue1.h"
 
 static NSString * const OBACellStyleDefaultReuseIdentifier = @"OBAUITableViewCellStyleDefaultCellIdentifier";
 static NSString * const OBACellStyleValue1ReuseIdentifier = @"OBACellStyleValue1ReuseIdentifier";


### PR DESCRIPTION
Fixes #691 - Arrival and Departure UI needs polishing

It turns out that there are bugs with handling long text in a table cell with the Value1 style. By using our own custom cell and wrapping replacement labels in that cell with a stack view, we can properly handle displaying long strings.