### PR TITLE
Better differentiate information on departure views

### DIFF
--- a/ui/stops/OBAClassicDepartureView.m
+++ b/ui/stops/OBAClassicDepartureView.m
@@ -83,6 +83,9 @@
     NSString *firstLineText = [NSString stringWithFormat:NSLocalizedString(@"%@ to %@\r\n", @"Route formatting string. e.g. 10 to Downtown Seattle<NEWLINE>"), [self classicDepartureRow].routeName, [self classicDepartureRow].destination];
 
     NSMutableAttributedString *routeText = [[NSMutableAttributedString alloc] initWithString:firstLineText attributes:@{NSFontAttributeName: [OBATheme bodyFont]}];
+
+    [routeText addAttribute:NSFontAttributeName value:[OBATheme boldBodyFont] range:NSMakeRange(0, [self classicDepartureRow].routeName.length)];
+
     NSAttributedString *departureTime = [OBADepartureCellHelpers attributedDepartureTime:[self classicDepartureRow].formattedNextDepartureTime
                                                                               statusText:[self classicDepartureRow].statusText
                                                                          departureStatus:[self classicDepartureRow].departureStatus];


### PR DESCRIPTION
Fixes #685 - Hard to visually differentiate information on Bookmarks tab

Bold the route name on the departure view