### PR TITLE
Animate value changes on the bookmarks page

### DIFF
--- a/OBAKit/UI/OBATheme.h
+++ b/OBAKit/UI/OBATheme.h
@@ -110,6 +110,12 @@
 + (UIColor*)textColor;
 
 /**
+ Use this when a control changes value on screen and you want to highlight
+ its changed value for the user.
+ */
++ (UIColor*)propertyChangedColor;
+
+/**
  The standard highlight color with a less-than-100% opacity. By default, this is a dark green color.
 
  @return A UIColor.

--- a/OBAKit/UI/OBATheme.m
+++ b/OBAKit/UI/OBATheme.m
@@ -119,6 +119,10 @@ static UIFont *_boldFootnoteFont = nil;
     return [UIColor blackColor];
 }
 
++ (UIColor*)propertyChangedColor {
+    return [OBATheme colorWithRed:255 green:255 blue:128 alpha:0.7];
+}
+
 + (UIColor*)nonOpaquePrimaryColor {
     return [self colorWithRed:152 green:216 blue:69 alpha:0.8f];
 }

--- a/ui/bookmarks/OBABookmarksViewController.m
+++ b/ui/bookmarks/OBABookmarksViewController.m
@@ -132,7 +132,7 @@ static NSTimeInterval const kRefreshTimerInterval = 30.0;
 
                 if (section.rows.count > indexPath.row) {
                     [self replaceRowAtIndexPath:indexPath withRow:row];
-                    [self.tableView reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
+                    [self.tableView reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationNone];
                 }
             }
         });
@@ -318,7 +318,7 @@ static NSTimeInterval const kRefreshTimerInterval = 30.0;
         }
         section.rows = open ? [self tableRowsFromBookmarks:bookmarks] : @[];
         NSIndexSet *indexSet = [NSIndexSet indexSetWithIndex:[self.sections indexOfObject:section]];
-        [self.tableView reloadSections:indexSet withRowAnimation:UITableViewRowAnimationAutomatic];
+        [self.tableView reloadSections:indexSet withRowAnimation:UITableViewRowAnimationNone];
     }];
     section.headerView = header;
 

--- a/ui/stops/OBAClassicDepartureView.m
+++ b/ui/stops/OBAClassicDepartureView.m
@@ -10,12 +10,17 @@
 #import <Masonry/Masonry.h>
 #import "OBAClassicDepartureRow.h"
 #import "OBADepartureCellHelpers.h"
+#import "OBAAnimation.h"
 
 #define kUseDebugColors 0
 
 @interface OBAClassicDepartureView ()
+@property(nonatomic,assign) BOOL firstRenderPass;
 @property(nonatomic,strong) UILabel *routeLabel;
 @property(nonatomic,strong,readwrite) UILabel *minutesLabel;
+
+@property(nonatomic,copy) NSString *previousMinutesText;
+@property(nonatomic,copy) UIColor *previousMinutesColor;
 @end
 
 @implementation OBAClassicDepartureView
@@ -28,12 +33,18 @@
     self = [super initWithFrame:frame];
 
     if (self) {
+        self.clipsToBounds = YES;
+        _firstRenderPass = YES;
+
         _routeLabel = ({
             UILabel *l = [[UILabel alloc] init];
             l.numberOfLines = 0;
             [l setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
             l;
         });
+
+        UIView *minutesWrapper = [[UIView alloc] initWithFrame:CGRectZero];
+        minutesWrapper.clipsToBounds = YES;
 
         _minutesLabel = ({
             UILabel *l = [[UILabel alloc] init];
@@ -42,15 +53,22 @@
             [l setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
             l;
         });
+        [minutesWrapper addSubview:_minutesLabel];
+        [_minutesLabel mas_makeConstraints:^(MASConstraintMaker *make) {
+            make.centerY.equalTo(minutesWrapper);
+            make.width.greaterThanOrEqualTo(@20);
+            make.right.equalTo(minutesWrapper);
+        }];
 
         if (kUseDebugColors) {
             self.backgroundColor = [UIColor purpleColor];
             _routeLabel.backgroundColor = [UIColor greenColor];
             _minutesLabel.backgroundColor = [UIColor magentaColor];
+            minutesWrapper.backgroundColor = [UIColor redColor];
         }
 
         UIStackView *horizontalStack = ({
-            UIStackView *stack = [[UIStackView alloc] initWithArrangedSubviews:@[_routeLabel, _minutesLabel]];
+            UIStackView *stack = [[UIStackView alloc] initWithArrangedSubviews:@[_routeLabel, minutesWrapper]];
             stack.axis = UILayoutConstraintAxisHorizontal;
             stack.distribution = UIStackViewDistributionFill;
             stack;
@@ -79,6 +97,11 @@
 
     _classicDepartureRow = [classicDepartureRow copy];
 
+    [self renderRouteLabel];
+    [self renderMinutesLabel];
+}
+
+- (void)renderRouteLabel {
     // TODO: clean me up once we've verified that users aren't losing their minds over the change.
     NSString *firstLineText = [NSString stringWithFormat:NSLocalizedString(@"%@ to %@\r\n", @"Route formatting string. e.g. 10 to Downtown Seattle<NEWLINE>"), [self classicDepartureRow].routeName, [self classicDepartureRow].destination];
 
@@ -93,8 +116,37 @@
     [routeText appendAttributedString:departureTime];
 
     self.routeLabel.attributedText = routeText;
-
-    self.minutesLabel.text = [self classicDepartureRow].formattedMinutesUntilNextDeparture;
-    self.minutesLabel.textColor = [OBADepartureCellHelpers colorForStatus:[self classicDepartureRow].departureStatus];
 }
+
+- (void)renderMinutesLabel {
+    NSString *formattedMinutes = [self classicDepartureRow].formattedMinutesUntilNextDeparture;
+    UIColor *formattedColor = [OBADepartureCellHelpers colorForStatus:[self classicDepartureRow].departureStatus];
+
+    BOOL textChanged = ![formattedMinutes isEqual:self.previousMinutesText];
+    BOOL colorChanged = ![formattedColor isEqual:self.previousMinutesColor];
+
+    self.previousMinutesText = formattedMinutes;
+    self.minutesLabel.text = formattedMinutes;
+
+    self.previousMinutesColor = formattedColor;
+    self.minutesLabel.textColor = formattedColor;
+
+    // don't animate the first rendering of the cell.
+    if (self.firstRenderPass) {
+        self.firstRenderPass = NO;
+        return;
+    }
+
+    if (textChanged || colorChanged) {
+        [self animateLabelChange];
+    }
+}
+
+- (void)animateLabelChange {
+    self.minutesLabel.layer.backgroundColor = [OBATheme propertyChangedColor].CGColor;
+    [UIView animateWithDuration:OBALongAnimationDuration animations:^{
+        self.minutesLabel.layer.backgroundColor = self.backgroundColor.CGColor;
+    }];
+}
+
 @end

--- a/ui/themes/OBAAnimation.h
+++ b/ui/themes/OBAAnimation.h
@@ -8,6 +8,8 @@
 
 #import <Foundation/Foundation.h>
 
+extern NSTimeInterval const OBALongAnimationDuration;
+
 @interface OBAAnimation : NSObject
 
 /**

--- a/ui/themes/OBAAnimation.m
+++ b/ui/themes/OBAAnimation.m
@@ -8,6 +8,8 @@
 
 #import "OBAAnimation.h"
 
+NSTimeInterval const OBALongAnimationDuration = 2.0;
+
 @implementation OBAAnimation
 
 + (void)performAnimations:(void (^)(void))animations {


### PR DESCRIPTION
Fixes #687 - Bookmarks on the bookmarks tab flicker when reloaded

Stop reloading the bookmarks controller with an animation, which was causing a flicker. Instead, animate changing property values in its cells.