### PR TITLE
Only load bookmarks once when app opens to the bookmarks tab

### DIFF
--- a/ui/bookmarks/OBABookmarksViewController.m
+++ b/ui/bookmarks/OBABookmarksViewController.m
@@ -93,8 +93,12 @@ static NSTimeInterval const kRefreshTimerInterval = 30.0;
 }
 
 - (void)startTimer {
-    self.refreshBookmarksTimer = [NSTimer scheduledTimerWithTimeInterval:kRefreshTimerInterval target:self selector:@selector(refreshBookmarkDepartures:) userInfo:nil repeats:YES];
-    [self refreshBookmarkDepartures:nil];
+    @synchronized (self) {
+        if (!self.refreshBookmarksTimer) {
+            self.refreshBookmarksTimer = [NSTimer scheduledTimerWithTimeInterval:kRefreshTimerInterval target:self selector:@selector(refreshBookmarkDepartures:) userInfo:nil repeats:YES];
+            [self refreshBookmarkDepartures:nil];
+        }
+    }
 }
 
 - (void)refreshBookmarkDepartures:(NSTimer*)timer {


### PR DESCRIPTION
Fixes #693 - Bookmarks are being downloaded twice on each refresh

Turns out they weren't really being downloaded twice on every refresh. They were downloading twice when the app's reachability status changed, like when it launched.