### PR TITLE
Be less cavalier about replacing table rows inside of blocks on Bookmarks

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>20160814.22</string>
+	<string>20160905.10</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>
@@ -48,7 +48,7 @@
 		<true/>
 		<key>NSExceptionDomains</key>
 		<dict>
-			<key>onebusaway.org</key>
+			<key>194.89.230.196</key>
 			<dict>
 				<key>NSIncludesSubdomains</key>
 				<true/>
@@ -69,21 +69,14 @@
 				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
 				<true/>
 			</dict>
-			<key>wmata.com</key>
+			<key>obartd.com</key>
 			<dict>
 				<key>NSIncludesSubdomains</key>
 				<true/>
 				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
 				<true/>
 			</dict>
-			<key>yrt.ca</key>
-			<dict>
-				<key>NSIncludesSubdomains</key>
-				<true/>
-				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
-			<key>v-a.io</key>
+			<key>onebusaway.org</key>
 			<dict>
 				<key>NSIncludesSubdomains</key>
 				<true/>
@@ -97,13 +90,6 @@
 				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
 				<true/>
 			</dict>
-			<key>obartd.com</key>
-			<dict>
-				<key>NSIncludesSubdomains</key>
-				<true/>
-				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
 			<key>sdmts.com</key>
 			<dict>
 				<key>NSIncludesSubdomains</key>
@@ -111,7 +97,21 @@
 				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
 				<true/>
 			</dict>
-			<key>194.89.230.196</key>
+			<key>v-a.io</key>
+			<dict>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
+			<key>wmata.com</key>
+			<dict>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
+			<key>yrt.ca</key>
 			<dict>
 				<key>NSIncludesSubdomains</key>
 				<true/>

--- a/OBAKit/Info.plist
+++ b/OBAKit/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>20160814.22</string>
+	<string>20160905.10</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/ui/bookmarks/OBABookmarksViewController.m
+++ b/ui/bookmarks/OBABookmarksViewController.m
@@ -135,8 +135,16 @@ static NSTimeInterval const kRefreshTimerInterval = 30.0;
                 OBATableSection *section = self.sections[indexPath.section];
 
                 if (section.rows.count > indexPath.row) {
-                    [self replaceRowAtIndexPath:indexPath withRow:row];
-                    [self.tableView reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationNone];
+
+                    // if our expectation of what's in the table is in sync with reality,
+                    // then we will reload just the row at indexPath. Otherwise, we will
+                    // reload the entire table.
+                    if ([self replaceRowAtIndexPath:indexPath withRow:row]) {
+                        [self.tableView reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationNone];
+                    }
+                    else {
+                        [self.tableView reloadData];
+                    }
                 }
             }
         });

--- a/ui/static_table/OBAStaticTableViewController.h
+++ b/ui/static_table/OBAStaticTableViewController.h
@@ -56,7 +56,7 @@ typedef NS_ENUM(NSUInteger, OBARootViewStyle) {
  */
 - (nullable NSIndexPath*)indexPathForModel:(id)model;
 
-- (void)replaceRowAtIndexPath:(NSIndexPath*)indexPath withRow:(OBABaseRow*)row;
+- (BOOL)replaceRowAtIndexPath:(NSIndexPath*)indexPath withRow:(OBABaseRow*)row;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ui/static_table/OBAStaticTableViewController.m
+++ b/ui/static_table/OBAStaticTableViewController.m
@@ -134,14 +134,14 @@
     return nil;
 }
 
-- (void)replaceRowAtIndexPath:(NSIndexPath*)indexPath withRow:(OBABaseRow*)row {
-    OBAGuard(indexPath && row) else {
-        return;
+- (BOOL)replaceRowAtIndexPath:(NSIndexPath*)indexPath withRow:(OBABaseRow*)row {
+    if (!indexPath || !row) {
+        return NO;
     }
 
     OBATableSection *section = self.sections[indexPath.section];
     if (!section) {
-        return;
+        return NO;
     }
 
     NSMutableArray *rows = [NSMutableArray arrayWithArray:section.rows];
@@ -153,6 +153,8 @@
         [rows addObject:row];
     }
     section.rows = [NSArray arrayWithArray:rows];
+
+    return YES;
 }
 
 - (void)deleteRowAtIndexPath:(NSIndexPath*)indexPath {


### PR DESCRIPTION
Fixes #689 - Occasional crash when reloading the bookmarks page

Instead of simply replacing and reloading an index path that may no longer exist on the bookmark controller's table view (because the user toggled a group), check to see if the row exists, and then reload it. If it doesn't exist, then reload the whole table.