### PR TITLE
Fix 699 and 705

### DIFF
--- a/ui/stops/OBAClassicDepartureView.m
+++ b/ui/stops/OBAClassicDepartureView.m
@@ -39,7 +39,7 @@
         _routeLabel = ({
             UILabel *l = [[UILabel alloc] init];
             l.numberOfLines = 0;
-            [l setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
+            [l setContentCompressionResistancePriority:UILayoutPriorityDefaultHigh forAxis:UILayoutConstraintAxisHorizontal];
             l;
         });
 
@@ -50,14 +50,14 @@
             UILabel *l = [[UILabel alloc] init];
             l.font = [OBATheme bodyFont];
             l.textAlignment = NSTextAlignmentRight;
-            [l setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
+            [l setContentHuggingPriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
             l;
         });
         [minutesWrapper addSubview:_minutesLabel];
+
         [_minutesLabel mas_makeConstraints:^(MASConstraintMaker *make) {
             make.centerY.equalTo(minutesWrapper);
-            make.width.greaterThanOrEqualTo(@20);
-            make.right.equalTo(minutesWrapper);
+            make.left.and.right.equalTo(minutesWrapper);
         }];
 
         if (kUseDebugColors) {


### PR DESCRIPTION
Fix issue where it took bookmarks 30 seconds to load

Fixes #699 - Bookmarks aren't showing their next departure time until the next refresh

* Automatically retry loading bookmarks when their row state doesn't match where we are in the code
* Clean and simplify up the code around creating these stop requests for bookmarks by extracting a method and a constant

--------

Ensure that departure view labels properly size to fit their contents 

Fixes #705 - Clipped text on bookmarks for some stops