### PR TITLE
Ensure that bookmarks have titles before allowing them to be created

### DIFF
--- a/OBAKit/Models/unmanaged/OBABookmarkV2.h
+++ b/OBAKit/Models/unmanaged/OBABookmarkV2.h
@@ -39,6 +39,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithStop:(OBAStopV2*)stop region:(OBARegionV2*)region;
 
 /**
+ Tests whether this is a valid bookmark model.
+
+ @return True if it is valid and false if it is invalid.
+ */
+- (BOOL)isValidModel;
+
+/**
  Basically, an -isEqual: for comparing bookmarks to OBAArrivalAndDepartureV2 objects.
  */
 - (BOOL)matchesArrivalAndDeparture:(OBAArrivalAndDepartureV2*)arrivalAndDeparture;

--- a/OBAKit/Models/unmanaged/OBABookmarkV2.m
+++ b/OBAKit/Models/unmanaged/OBABookmarkV2.m
@@ -139,6 +139,14 @@ static NSString * const kBookmarkVersion = @"bookmarkVersion";
 
 #pragma mark - Misc
 
+- (BOOL)isValidModel {
+    // TODO: this should really be smarter and check for a variety of
+    // properties depending on whether it is a 252 or 260-style bookmark.
+    // However, for the purposes of fixing https://github.com/OneBusAway/onebusaway-iphone/issues/711,
+    // the check for the name is sufficient.
+    return self.name.length > 0;
+}
+
 - (NSArray<OBAArrivalAndDepartureV2*>*)matchingArrivalsAndDeparturesForStop:(OBAArrivalsAndDeparturesForStopV2*)dep {
     NSMutableArray *matches = [NSMutableArray array];
 

--- a/OBAKit/Models/unmanaged/OBARegionV2.h
+++ b/OBAKit/Models/unmanaged/OBARegionV2.h
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Tests whether this is a valid region object.
  */
-- (BOOL)validateModel;
+- (BOOL)isValidModel;
 
 /**
  obaBaseUrl converted into an NSURL

--- a/OBAKit/Models/unmanaged/OBARegionV2.m
+++ b/OBAKit/Models/unmanaged/OBARegionV2.m
@@ -87,7 +87,7 @@ static NSString * kCustom = @"custom";
 
 #pragma mark - Other Public Methods
 
-- (BOOL)validateModel {
+- (BOOL)isValidModel {
     return [NSURL URLWithString:self.obaBaseUrl] && self.regionName.length > 0;
 }
 

--- a/OneBusAwayTests/OBAKitTests/models/OBABookmarkV2_Tests.m
+++ b/OneBusAwayTests/OBAKitTests/models/OBABookmarkV2_Tests.m
@@ -56,4 +56,15 @@
     XCTAssertEqual(bm.regionIdentifier, 1);
 }
 
+- (void)testValidateModelPassing {
+    OBABookmarkV2 *bm = [OBATestHelpers unarchiveBundledTestFile:@"bookmark_with_region_identifier.plist"];
+    XCTAssertTrue([bm isValidModel]);
+}
+
+- (void)testValidateModelFailing {
+    OBABookmarkV2 *bm = [OBATestHelpers unarchiveBundledTestFile:@"bookmark_with_region_identifier.plist"];
+    bm.name = @"";
+    XCTAssertFalse([bm isValidModel]);
+}
+
 @end

--- a/ui/bookmarks/OBAEditStopBookmarkViewController.m
+++ b/ui/bookmarks/OBAEditStopBookmarkViewController.m
@@ -24,6 +24,7 @@
 #import "UITableViewCell+oba_Additions.h"
 #import "OBAApplication.h"
 #import <OBAKit/OBAKit.h>
+#import "OneBusAway-Swift.h"
 
 @interface OBAEditStopBookmarkViewController ()
 @property(nonatomic,strong) OBABookmarkV2 *bookmark;
@@ -150,6 +151,11 @@
     OBAModelDAO *dao = [OBAApplication sharedApplication].modelDao;
 
     self.bookmark.name = self.textField.text;
+
+    if (![self.bookmark isValidModel]) {
+        [AlertPresenter showWarning:NSLocalizedString(@"Can't Create Bookmark", @"Title of the alert shown when a bookmark can't be created") body:NSLocalizedString(@"Bookmarks must have a name. Please add a name and then try again.", @"Body of the alert shown when a bookmark can't be created.")];
+        return;
+    }
 
     if (!self.bookmark.group && !self.selectedGroup) {
         [dao saveBookmark:self.bookmark];

--- a/ui/regions/RegionBuilderViewController.swift
+++ b/ui/regions/RegionBuilderViewController.swift
@@ -118,7 +118,7 @@ class RegionBuilderViewController: OBAStaticTableViewController {
 
         self.loadDataIntoRegion()
 
-        guard self.region.validateModel() else {
+        guard self.region.isValidModel() else {
             let alert = UIAlertController.init(title: NSLocalizedString("Invalid Region", comment: ""), message: NSLocalizedString("The region you have specified is not valid. Please specify at least a base URL and a name.", comment: ""), preferredStyle: .Alert)
             alert.addAction(UIAlertAction.init(title: OBAStrings.dismiss(), style: .Default, handler: nil))
             self.presentViewController(alert, animated: true, completion: nil)


### PR DESCRIPTION
* Add a -validateModel method to OBABookmarkV2 that checks to see if the bookmark has a name with length greater than 0
* Add tests demonstrating that -validateModel works correctly
* Show an AlertPresenter-based error message if the -validateModel check fails

Fixes #711 - Bookmarks should be validated as having non-zero length titles before being created