### PR TITLE
Don't crash if the arrival and departure object lacks a headsign

### DIFF
--- a/OBAKit/Models/unmanaged/OBAArrivalAndDepartureV2.m
+++ b/OBAKit/Models/unmanaged/OBAArrivalAndDepartureV2.m
@@ -39,7 +39,10 @@
     OBATripV2 *trip = self.trip;
     OBARouteV2 *route = trip.route;
 
-    if (_tripHeadsign.length > 0) {
+    // TODO: figure out how an NSNull is slipping through the
+    // model layer :( Maybe this is an indication that we
+    // need to move to a more modern modeling framework.
+    if (![_tripHeadsign isEqual:NSNull.null] && _tripHeadsign.length > 0) {
         headsign = _tripHeadsign;
     }
     else if (trip.tripHeadsign) {
@@ -52,7 +55,7 @@
         headsign = route.shortName;
     }
 
-    if (!headsign) {
+    if (!headsign || [headsign isEqual:NSNull.null]) {
         return nil;
     }
 

--- a/ui/static_table/cells/OBATableViewCellValue1.m
+++ b/ui/static_table/cells/OBATableViewCellValue1.m
@@ -15,9 +15,6 @@
 @property(nonatomic,strong) UILabel *obaTextLabel;
 @property(nonatomic,strong) UILabel *obaDetailTextLabel;
 @property(nonatomic,strong) UIStackView *stackView;
-
-// stack views seem to require spacing views for some scenarios, like ours. Lame.
-@property(nonatomic,strong) UIView *stupidSpacingView;
 @end
 
 @implementation OBATableViewCellValue1
@@ -36,9 +33,10 @@
         _obaDetailTextLabel.textColor = [UIColor darkGrayColor];
         [_obaDetailTextLabel setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
 
-        _stupidSpacingView = [[UIView alloc] initWithFrame:CGRectZero];
+        // stack views seem to require spacing views for some scenarios, like ours. Lame.
+        UIView *stupidSpacingView = [[UIView alloc] initWithFrame:CGRectZero];
 
-        _stackView = [[UIStackView alloc] initWithArrangedSubviews:@[_obaTextLabel, _stupidSpacingView, _obaDetailTextLabel]];
+        _stackView = [[UIStackView alloc] initWithArrangedSubviews:@[_obaTextLabel, stupidSpacingView, _obaDetailTextLabel]];
         _stackView.axis = UILayoutConstraintAxisHorizontal;
         _stackView.alignment = UIStackViewAlignmentFill;
         _stackView.spacing = [OBATheme defaultPadding];

--- a/ui/stops/OBAClassicDepartureRow.m
+++ b/ui/stops/OBAClassicDepartureRow.m
@@ -12,7 +12,7 @@
 
 @implementation OBAClassicDepartureRow
 
-- (instancetype)initWithRouteName:(NSString*)routeName destination:(NSString*)destination departsAt:(NSDate*)departsAt statusText:(NSString*)statusText departureStatus:(OBADepartureStatus)departureStatus action:(void(^)(OBABaseRow *row))action {
+- (instancetype)initWithRouteName:(NSString*)routeName destination:(nullable NSString*)destination departsAt:(NSDate*)departsAt statusText:(NSString*)statusText departureStatus:(OBADepartureStatus)departureStatus action:(void(^)(OBABaseRow *row))action {
     self = [super initWithDestination:destination departsAt:departsAt statusText:statusText departureStatus:departureStatus action:action];
 
     if (self) {

--- a/ui/stops/OBAClassicDepartureView.m
+++ b/ui/stops/OBAClassicDepartureView.m
@@ -103,7 +103,14 @@
 
 - (void)renderRouteLabel {
     // TODO: clean me up once we've verified that users aren't losing their minds over the change.
-    NSString *firstLineText = [NSString stringWithFormat:NSLocalizedString(@"%@ to %@\r\n", @"Route formatting string. e.g. 10 to Downtown Seattle<NEWLINE>"), [self classicDepartureRow].routeName, [self classicDepartureRow].destination];
+    NSString *firstLineText = nil;
+
+    if ([self classicDepartureRow].destination) {
+        firstLineText = [NSString stringWithFormat:NSLocalizedString(@"%@ to %@\r\n", @"Route formatting string. e.g. 10 to Downtown Seattle<NEWLINE>"), [self classicDepartureRow].routeName, [self classicDepartureRow].destination];
+    }
+    else {
+        firstLineText = [NSString stringWithFormat:@"%@\r\n", [self classicDepartureRow].routeName];
+    }
 
     NSMutableAttributedString *routeText = [[NSMutableAttributedString alloc] initWithString:firstLineText attributes:@{NSFontAttributeName: [OBATheme bodyFont]}];
 

--- a/ui/stops/OBADepartureRow.h
+++ b/ui/stops/OBADepartureRow.h
@@ -9,8 +9,10 @@
 #import "OBABaseRow.h"
 #import <OBAKit/OBAKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface OBADepartureRow : OBABaseRow
-@property(nonatomic,copy) NSString *destination;
+@property(nonatomic,copy,nullable) NSString *destination;
 @property(nonatomic,copy) NSDate *departsAt;
 @property(nonatomic,copy) NSString *statusText;
 @property(nonatomic,assign) OBADepartureStatus departureStatus;
@@ -20,6 +22,8 @@
 
 - (NSString *)formattedNextDepartureTime;
 
-- (instancetype)initWithAction:(void (^)(OBABaseRow *row))action NS_UNAVAILABLE;
-- (instancetype)initWithDestination:(NSString*)destination departsAt:(NSDate*)departsAt statusText:(NSString*)statusText departureStatus:(OBADepartureStatus)departureStatus action:(void(^)(OBABaseRow *row))action NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithAction:(void (^ _Nullable)(OBABaseRow *row))action NS_UNAVAILABLE;
+- (instancetype)initWithDestination:(nullable NSString*)destination departsAt:(NSDate*)departsAt statusText:(NSString*)statusText departureStatus:(OBADepartureStatus)departureStatus action:(void(^)(OBABaseRow *row))action NS_DESIGNATED_INITIALIZER;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ui/stops/OBADepartureRow.m
+++ b/ui/stops/OBADepartureRow.m
@@ -17,7 +17,7 @@
     [OBAViewModelRegistry registerClass:self.class];
 }
 
-- (instancetype)initWithDestination:(NSString*)destination departsAt:(NSDate*)departsAt statusText:(NSString*)statusText departureStatus:(OBADepartureStatus)departureStatus action:(void(^)(OBABaseRow *row))action {
+- (instancetype)initWithDestination:(nullable NSString*)destination departsAt:(NSDate*)departsAt statusText:(NSString*)statusText departureStatus:(OBADepartureStatus)departureStatus action:(void(^)(OBABaseRow *row))action {
     self = [super initWithAction:action];
     
     if (self) {


### PR DESCRIPTION
Fixes #723

---

Also, remove an unnecessary property from a view and turn it into a local variable instead.