### PR TITLE
Only allow the user to see vehicle details if a vehicle exists

### DIFF
--- a/categories/UITableViewCell+oba_Additions.h
+++ b/categories/UITableViewCell+oba_Additions.h
@@ -16,8 +16,6 @@ NS_ASSUME_NONNULL_BEGIN
 + (UITableViewCell*)getOrCreateCellForTableView:(UITableView*)tableView cellId:(NSString*)cellId;
 + (UITableViewCell*)getOrCreateCellForTableView:(UITableView*)tableView;
 + (UITableViewCell*)getOrCreateCellForTableView:(UITableView*)tableView style:(UITableViewCellStyle)style;
-+ (UITableViewCell*)getOrCreateCellForTableView:(UITableView*)tableView style:(UITableViewCellStyle)style cellId:(NSString*)cellId;
-+ (UITableViewCell*)getOrCreateCellForTableView:(UITableView*)tableView fromResource:(NSString*)resourceName;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/categories/UITableViewCell+oba_Additions.m
+++ b/categories/UITableViewCell+oba_Additions.m
@@ -31,10 +31,6 @@
 
 + (UITableViewCell*) getOrCreateCellForTableView:(UITableView*)tableView style:(UITableViewCellStyle)style {
     NSString * cellId = [NSString stringWithFormat:@"DefaultIdentifier-%@",@(style)];
-    return [self getOrCreateCellForTableView:tableView style:style cellId:cellId];
-}
-
-+ (UITableViewCell*) getOrCreateCellForTableView:(UITableView*)tableView style:(UITableViewCellStyle)style cellId:(NSString*)cellId {
 
     // Try to retrieve from the table view a now-unused cell with the given identifier
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:cellId];
@@ -42,18 +38,6 @@
     // If no cell is available, create a new one using the given identifier
     if (cell == nil)
         cell = [[UITableViewCell alloc] initWithStyle:style reuseIdentifier:cellId];
-
-    return cell;
-}
-
-+ (UITableViewCell*) getOrCreateCellForTableView:(UITableView*)tableView fromResource:(NSString*)resourceName {
-
-    UITableViewCell * cell = (UITableViewCell*) [tableView dequeueReusableCellWithIdentifier:resourceName];
-
-    if (cell == nil) {
-        NSArray * nib = [[NSBundle mainBundle] loadNibNamed:resourceName owner:self options:nil];
-        cell = nib[0];
-    }
 
     return cell;
 }

--- a/org.onebusaway.iphone.xcodeproj/xcshareddata/xcschemes/OneBusAway.xcscheme
+++ b/org.onebusaway.iphone.xcodeproj/xcshareddata/xcschemes/OneBusAway.xcscheme
@@ -77,7 +77,7 @@
       <AdditionalOptions>
       </AdditionalOptions>
       <LocationScenarioReference
-         identifier = "../gpx_files/capitolhill.gpx"
+         identifier = "../../gpx_files/capitolhill.gpx"
          referenceType = "0">
       </LocationScenarioReference>
    </LaunchAction>

--- a/ui/trip_details/OBAArrivalAndDepartureViewController.m
+++ b/ui/trip_details/OBAArrivalAndDepartureViewController.m
@@ -226,10 +226,21 @@ static NSTimeInterval const kRefreshTimeInterval = 30;
     }];
 
     [actionsSection addRowWithBlock:^OBABaseRow * {
-        OBATableRow *tableRow = [[OBATableRow alloc] initWithTitle:NSLocalizedString(@"Vehicle Info", @"") action:^{
-            OBAVehicleDetailsController *vc = [[OBAVehicleDetailsController alloc] initWithVehicleId:arrivalAndDeparture.tripStatus.vehicleId];
-            [navigationController pushViewController:vc animated:YES];
-        }];
+
+        OBATableRow *tableRow = nil;
+
+        if (arrivalAndDeparture.tripStatus.vehicleId.length > 0) {
+            tableRow = [[OBATableRow alloc] initWithTitle:NSLocalizedString(@"Vehicle Info", @"") action:^{
+                OBAVehicleDetailsController *vc = [[OBAVehicleDetailsController alloc] initWithVehicleId:arrivalAndDeparture.tripStatus.vehicleId];
+                [navigationController pushViewController:vc animated:YES];
+            }];
+        }
+        else {
+            tableRow = [[OBATableRow alloc] initWithTitle:NSLocalizedString(@"No Vehicle Info Available", @"") action:nil];
+            tableRow.selectionStyle = UITableViewCellSelectionStyleNone;
+            tableRow.titleColor = [OBATheme darkDisabledColor];
+        }
+
         return tableRow;
     }];
 


### PR DESCRIPTION
Fixes #735 - Attempting to view vehicle info on a scheduled route shows "Error connecting"

* If the vehicle ID attached to the trip status that the user is looking at is blank, then show a "No vehicle info available" message
* Delete a couple unused methods that I noticed