### PR TITLE
Remove (most) hardcoded dependencies on -[OBAApplication sharedApplication]

### DIFF
--- a/OBAKit/Models/annotations/OBATripStopTimeMapAnnotation.h
+++ b/OBAKit/Models/annotations/OBATripStopTimeMapAnnotation.h
@@ -25,7 +25,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (id) initWithTripDetails:(OBATripDetailsV2*)tripDetails stopTime:(OBATripStopTimeV2*)stopTime;
 
-@property (nonatomic,strong) NSDateFormatter * timeFormatter;
 @property (nonatomic,strong) OBATripStopTimeV2 * stopTime;
 
 @end

--- a/OBAKit/Models/annotations/OBATripStopTimeMapAnnotation.m
+++ b/OBAKit/Models/annotations/OBATripStopTimeMapAnnotation.m
@@ -15,6 +15,7 @@
  */
 
 #import <OBAKit/OBATripStopTimeMapAnnotation.h>
+#import <OBAKit/OBADateHelpers.h>
 
 @implementation OBATripStopTimeMapAnnotation
 
@@ -54,7 +55,7 @@
     NSInteger stopTime = _stopTime.arrivalTime;
     
     NSDate * date = [NSDate dateWithTimeIntervalSince1970:(serviceDate/1000 + stopTime + scheduleDeviation)];
-    return [self.timeFormatter stringFromDate:date];
+    return [OBADateHelpers formatShortTimeNoDate:date];
 }
 
 - (CLLocationCoordinate2D) coordinate {

--- a/ui/bookmark_groups/OBAEditBookmarkGroupViewController.h
+++ b/ui/bookmark_groups/OBAEditBookmarkGroupViewController.h
@@ -7,8 +7,7 @@
 //
 
 #import <UIKit/UIKit.h>
-
-@class OBABookmarkGroup;
+#import <OBAKit/OBAKit.h>
 
 typedef NS_ENUM(NSInteger, OBABookmarkGroupEditType) {
     OBABookmarkGroupEditNew=0,
@@ -18,8 +17,9 @@ typedef NS_ENUM(NSInteger, OBABookmarkGroupEditType) {
 NS_ASSUME_NONNULL_BEGIN
 
 @interface OBAEditBookmarkGroupViewController : UITableViewController
+@property(nonatomic,strong) OBAModelDAO *modelDAO;
 
-- (id) initWithBookmarkGroup:(OBABookmarkGroup*)bookmarkGroup editType:(OBABookmarkGroupEditType)editType;
+- (instancetype)initWithBookmarkGroup:(OBABookmarkGroup*)bookmarkGroup editType:(OBABookmarkGroupEditType)editType;
 
 @end
 

--- a/ui/bookmark_groups/OBAEditBookmarkGroupViewController.m
+++ b/ui/bookmark_groups/OBAEditBookmarkGroupViewController.m
@@ -51,8 +51,17 @@
 - (void)onSaveButton:(id)sender {
     _bookmarkGroup.name = _textField.text;
     [OBAAnalytics reportEventWithCategory:OBAAnalyticsCategoryUIAction action:@"edit_field" label:@"Edited Bookmark" value:nil];
-    [[OBAApplication sharedApplication].modelDao saveBookmarkGroup:_bookmarkGroup];
+    [self.modelDAO saveBookmarkGroup:_bookmarkGroup];
     [self.navigationController popViewControllerAnimated:YES];
+}
+
+#pragma mark - Lazy Loading
+
+- (OBAModelDAO*)modelDAO {
+    if (!_modelDAO) {
+        _modelDAO = [OBAApplication sharedApplication].modelDao;
+    }
+    return _modelDAO;
 }
 
 #pragma mark - Table view data source

--- a/ui/bookmark_groups/OBAEditStopBookmarkGroupViewController.h
+++ b/ui/bookmark_groups/OBAEditStopBookmarkGroupViewController.h
@@ -18,11 +18,11 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @interface OBAEditStopBookmarkGroupViewController : UITableViewController <UITextFieldDelegate>
-@property (nonatomic,strong) NSArray *groups;
-@property (nonatomic,strong,nullable) OBABookmarkGroup *selectedGroup;
-@property (nonatomic,strong) id <OBABookmarkGroupVCDelegate> delegate;
+@property(nonatomic,strong) OBAModelDAO *modelDAO;
+@property(nonatomic,strong,nullable) OBABookmarkGroup *selectedGroup;
+@property(nonatomic,strong) id <OBABookmarkGroupVCDelegate> delegate;
 
-- (id)initWithSelectedBookmarkGroup:(OBABookmarkGroup*)group;
+- (instancetype)initWithModelDAO:(OBAModelDAO*)modelDAO selectedBookmarkGroup:(OBABookmarkGroup*)group;
 
 @end
 

--- a/ui/bookmark_groups/OBAEditStopBookmarkGroupViewController.m
+++ b/ui/bookmark_groups/OBAEditStopBookmarkGroupViewController.m
@@ -15,9 +15,9 @@
 
 @implementation OBAEditStopBookmarkGroupViewController
 
-- (id)initWithSelectedBookmarkGroup:(OBABookmarkGroup *)group {
+- (instancetype)initWithModelDAO:(OBAModelDAO*)modelDAO selectedBookmarkGroup:(OBABookmarkGroup*)group {
     if (self = [super initWithStyle:UITableViewStylePlain]) {
-        _groups = [[OBAApplication sharedApplication].modelDao bookmarkGroups];
+        _modelDAO = modelDAO;
         _selectedGroup = group;
 
         UIBarButtonItem *doneButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(onDoneButton:)];
@@ -43,7 +43,7 @@
 #pragma mark - Table view data source
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
-    return self.groups.count + 2;
+    return self.modelDAO.bookmarkGroups.count + 2;
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
@@ -62,7 +62,7 @@
         }
     }
     else {
-        OBABookmarkGroup *group = self.groups[indexPath.row - 2];
+        OBABookmarkGroup *group = self.modelDAO.bookmarkGroups[indexPath.row - 2];
 
         if (group == self.selectedGroup) {
             cell.accessoryType = UITableViewCellAccessoryCheckmark;
@@ -87,7 +87,7 @@
         [self.navigationController pushViewController:editBookmarkGroupVC animated:YES];
     }
     else if (indexPath.row == 1) {
-        NSInteger oldGroupRow = self.selectedGroup ? ([self.groups indexOfObject:self.selectedGroup] + 2) : -1;
+        NSInteger oldGroupRow = self.selectedGroup ? ([self.modelDAO.bookmarkGroups indexOfObject:self.selectedGroup] + 2) : -1;
         self.selectedGroup = nil;
         [self.delegate didSetBookmarkGroup:nil];
         [self.tableView reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
@@ -98,14 +98,14 @@
     }
     else {
         if (self.editing) {
-            OBAEditBookmarkGroupViewController *editBookmarkGroupVC = [[OBAEditBookmarkGroupViewController alloc] initWithBookmarkGroup:self.groups[indexPath.row - 2] editType:OBABookmarkGroupEditExisting];
+            OBAEditBookmarkGroupViewController *editBookmarkGroupVC = [[OBAEditBookmarkGroupViewController alloc] initWithBookmarkGroup:self.modelDAO.bookmarkGroups[indexPath.row - 2] editType:OBABookmarkGroupEditExisting];
             [OBAAnalytics reportEventWithCategory:OBAAnalyticsCategoryUIAction action:@"edit_field" label:@"Edited Bookmark Group" value:nil];
             [self.navigationController pushViewController:editBookmarkGroupVC animated:YES];
         }
         else {
-            NSInteger oldGroupRow = self.selectedGroup ? ([self.groups indexOfObject:self.selectedGroup] + 2) : 1;
+            NSInteger oldGroupRow = self.selectedGroup ? ([self.modelDAO.bookmarkGroups indexOfObject:self.selectedGroup] + 2) : 1;
             NSIndexPath *oldIndexPath = [NSIndexPath indexPathForRow:oldGroupRow inSection:0];
-            self.selectedGroup = self.groups[indexPath.row - 2];
+            self.selectedGroup = self.modelDAO.bookmarkGroups[indexPath.row - 2];
             [self.delegate didSetBookmarkGroup:self.selectedGroup];
 
             if ([indexPath isEqual:oldIndexPath]) {
@@ -124,7 +124,7 @@
 
 - (void)tableView:(UITableView *)tableView commitEditingStyle:(UITableViewCellEditingStyle)editingStyle forRowAtIndexPath:(NSIndexPath *)indexPath {
     if (editingStyle == UITableViewCellEditingStyleDelete) {
-        OBABookmarkGroup *group = self.groups[indexPath.row - 2];
+        OBABookmarkGroup *group = self.modelDAO.bookmarkGroups[indexPath.row - 2];
 
         if (self.selectedGroup == group) {
             self.selectedGroup = nil;
@@ -132,7 +132,7 @@
             [self.tableView reloadRowsAtIndexPaths:@[[NSIndexPath indexPathForRow:1 inSection:0]] withRowAnimation:UITableViewRowAnimationAutomatic];
         }
 
-        [[OBAApplication sharedApplication].modelDao removeBookmarkGroup:group];
+        [self.modelDAO removeBookmarkGroup:group];
         [self _refreshGroups];
         [tableView deleteRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
     }
@@ -141,8 +141,7 @@
 #pragma mark - Private
 
 - (void)_refreshGroups {
-    self.groups = [[OBAApplication sharedApplication].modelDao bookmarkGroups];
-    self.editButtonItem.enabled = (self.groups.count > 0);
+    self.editButtonItem.enabled = (self.modelDAO.bookmarkGroups.count > 0);
 }
 
 @end

--- a/ui/bookmarks/OBAEditStopBookmarkViewController.h
+++ b/ui/bookmarks/OBAEditStopBookmarkViewController.h
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-#import <OBAKit/OBABookmarkV2.h>
+#import <OBAKit/OBAKit.h>
 #import "OBAEditStopBookmarkGroupViewController.h"
-
-@class OBAArrivalAndDepartureV2;
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface OBAEditStopBookmarkViewController : UITableViewController <OBABookmarkGroupVCDelegate>
+@property(nonatomic,strong) OBAModelDAO *modelDAO;
+@property(nonatomic,strong) OBAModelService *modelService;
 - (instancetype)initWithBookmark:(OBABookmarkV2 *)bookmark;
 @end
 

--- a/ui/bookmarks/OBAEditStopBookmarkViewController.m
+++ b/ui/bookmarks/OBAEditStopBookmarkViewController.m
@@ -66,7 +66,7 @@
     [self.tableView reloadData];
 
     NSString *stopId = _bookmark.stopId;
-    [[OBAApplication sharedApplication].modelService requestStopForId:stopId completionBlock:^(id responseData, NSUInteger responseCode, NSError *error) {
+    [self.modelService requestStopForId:stopId completionBlock:^(id responseData, NSUInteger responseCode, NSError *error) {
         OBAEntryWithReferencesV2 *entry = responseData;
         OBAStopV2 *stop = entry.entry;
 
@@ -77,6 +77,22 @@
             [self.tableView reloadRowsAtIndexPaths:indexPaths withRowAnimation:UITableViewRowAnimationFade];
         }
     }];
+}
+
+#pragma mark - Lazy Loading
+
+- (OBAModelDAO*)modelDAO {
+    if (!_modelDAO) {
+        _modelDAO = [OBAApplication sharedApplication].modelDao;
+    }
+    return _modelDAO;
+}
+
+- (OBAModelService*)modelService {
+    if (!_modelService) {
+        _modelService = [OBAApplication sharedApplication].modelService;
+    }
+    return _modelService;
 }
 
 #pragma mark - UITableView
@@ -129,7 +145,7 @@
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
     if (indexPath.row == 2) {
-        OBAEditStopBookmarkGroupViewController *groupVC = [[OBAEditStopBookmarkGroupViewController alloc] initWithSelectedBookmarkGroup:self.selectedGroup];
+        OBAEditStopBookmarkGroupViewController *groupVC = [[OBAEditStopBookmarkGroupViewController alloc] initWithModelDAO:self.modelDAO selectedBookmarkGroup:self.selectedGroup];
         groupVC.delegate = self;
         [self.navigationController pushViewController:groupVC animated:YES];
     }
@@ -149,8 +165,6 @@
 - (void)save:(id)sender {
     [self.view endEditing:YES];
 
-    OBAModelDAO *dao = [OBAApplication sharedApplication].modelDao;
-
     self.bookmark.name = self.textField.text;
 
     if (![self.bookmark isValidModel]) {
@@ -159,10 +173,10 @@
     }
 
     if (!self.bookmark.group && !self.selectedGroup) {
-        [dao saveBookmark:self.bookmark];
+        [self.modelDAO saveBookmark:self.bookmark];
     }
     else {
-        [dao moveBookmark:self.bookmark toGroup:self.selectedGroup];
+        [self.modelDAO moveBookmark:self.bookmark toGroup:self.selectedGroup];
     }
 
     [self dismissViewControllerAnimated:YES completion:nil];

--- a/ui/info/OBAAgenciesListViewController.h
+++ b/ui/info/OBAAgenciesListViewController.h
@@ -20,7 +20,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface OBAAgenciesListViewController : OBARequestDrivenTableViewController 
+@interface OBAAgenciesListViewController : OBARequestDrivenTableViewController
+@property(nonatomic,strong) OBAModelService *modelService;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ui/info/OBAAgenciesListViewController.m
+++ b/ui/info/OBAAgenciesListViewController.m
@@ -67,7 +67,7 @@ typedef NS_ENUM (NSInteger, OBASectionType) {
 
 - (id<OBAModelServiceRequest>)handleRefresh {
     @weakify(self);
-    return [[OBAApplication sharedApplication].modelService requestAgenciesWithCoverage:^(id jsonData, NSUInteger responseCode, NSError *error) {
+    return [self.modelService requestAgenciesWithCoverage:^(id jsonData, NSUInteger responseCode, NSError *error) {
         @strongify(self);
         
         if (error) {
@@ -81,6 +81,15 @@ typedef NS_ENUM (NSInteger, OBASectionType) {
             [self refreshCompleteWithCode:responseCode];
         }
     }];
+}
+
+#pragma mark - Lazy Loading
+
+- (OBAModelService*)modelService {
+    if (!_modelService) {
+        _modelService = [OBAApplication sharedApplication].modelService;
+    }
+    return _modelService;
 }
 
 #pragma mark Table view methods

--- a/ui/info/OBAInfoViewController.h
+++ b/ui/info/OBAInfoViewController.h
@@ -7,14 +7,14 @@
 //
 
 #import <UIKit/UIKit.h>
+#import <OBAKit/OBAKit.h>
 #import "OBAStaticTableViewController.h"
 #import "OBANavigationTargetAware.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class OBAApplicationDelegate;
-
 @interface OBAInfoViewController : OBAStaticTableViewController<OBANavigationTargetAware>
+@property(nonatomic,strong) OBAModelDAO *modelDAO;
 - (void)openAgencies;
 @end
 

--- a/ui/info/OBAInfoViewController.m
+++ b/ui/info/OBAInfoViewController.m
@@ -63,6 +63,15 @@ static NSString * const kPrivacyURLString = @"http://onebusaway.org/privacy/";
     [self reloadData];
 }
 
+#pragma mark - Lazy Loading
+
+- (OBAModelDAO*)modelDAO {
+    if (!_modelDAO) {
+        _modelDAO = [OBAApplication sharedApplication].modelDao;
+    }
+    return _modelDAO;
+}
+
 #pragma mark - Table Data
 
 - (void)reloadData {
@@ -81,7 +90,7 @@ static NSString * const kPrivacyURLString = @"http://onebusaway.org/privacy/";
     }];
     region.style = UITableViewCellStyleValue1;
     region.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
-    region.subtitle = [OBAApplication sharedApplication].modelDao.currentRegion.regionName;
+    region.subtitle = self.modelDAO.currentRegion.regionName;
 
     OBATableRow *agencies = [[OBATableRow alloc] initWithTitle:NSLocalizedString(@"Agencies", @"Info Page Agencies Row Title") action:^{
         [self openAgencies];
@@ -165,7 +174,7 @@ static NSString * const kPrivacyURLString = @"http://onebusaway.org/privacy/";
 - (void)openContactUs {
     [OBAAnalytics reportEventWithCategory:OBAAnalyticsCategoryUIAction action:@"button_press" label:@"Clicked Email Link" value:nil];
 
-    MFMailComposeViewController *composer = [OBAEmailHelper mailComposeViewControllerForModelDAO:[OBAApplication sharedApplication].modelDao
+    MFMailComposeViewController *composer = [OBAEmailHelper mailComposeViewControllerForModelDAO:self.modelDAO
                                                                                  currentLocation:[OBAApplication sharedApplication].locationManager.currentLocation];
 
     if (composer) {

--- a/ui/recent_stops/OBARecentStopsViewController.h
+++ b/ui/recent_stops/OBARecentStopsViewController.h
@@ -14,12 +14,16 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+#import <OBAKit/OBAKit.h>
 #import "OBANavigationTargetAware.h"
 #import "OBAStaticTableViewController.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface OBARecentStopsViewController : OBAStaticTableViewController <OBANavigationTargetAware>
+@property(nonatomic,strong) OBAModelDAO *modelDAO;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ui/recent_stops/OBARecentStopsViewController.m
+++ b/ui/recent_stops/OBARecentStopsViewController.m
@@ -59,10 +59,19 @@
     UIAlertController *alert = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"Clear Recent Stops", @"") message:NSLocalizedString(@"Are you sure you want to clear your recent stops?", @"") preferredStyle:UIAlertControllerStyleAlert];
     [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", @"") style:UIAlertActionStyleCancel handler:nil]];
     [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Clear Stops", @"") style:UIAlertActionStyleDestructive handler:^(UIAlertAction *action) {
-        [[OBAApplication sharedApplication].modelDao clearMostRecentStops];
+        [self.modelDAO clearMostRecentStops];
         [self reloadData];
     }]];
     [self presentViewController:alert animated:YES completion:nil];
+}
+
+#pragma mark - Lazy Loading
+
+- (OBAModelDAO*)modelDAO {
+    if (!_modelDAO) {
+        _modelDAO = [OBAApplication sharedApplication].modelDao;
+    }
+    return _modelDAO;
 }
 
 #pragma mark - Data Loading
@@ -71,8 +80,7 @@
 
     OBATableSection *section = [[OBATableSection alloc] init];
 
-    for (OBAStopAccessEventV2* stop in [OBAApplication sharedApplication].modelDao.mostRecentStops) {
-
+    for (OBAStopAccessEventV2* stop in self.modelDAO.mostRecentStops) {
         [section addRowWithBlock:^OBABaseRow*{
             OBATableRow *tableRow = [[OBATableRow alloc] initWithTitle:stop.title action:^{
                 OBAStopViewController *vc = [[OBAStopViewController alloc] initWithStopID:stop.stopIds[0]];
@@ -89,7 +97,7 @@
     [self.tableView reloadData];
 }
 
-#pragma mark OBANavigationTargetAware
+#pragma mark - OBANavigationTargetAware
 
 - (OBANavigationTarget *)navigationTarget {
     return [OBANavigationTarget target:OBANavigationTargetTypeRecentStops];

--- a/ui/search/OBASearchController.h
+++ b/ui/search/OBASearchController.h
@@ -47,6 +47,8 @@ extern NSString * const OBASearchControllerUserInfoDataKey;
 @property (nonatomic,strong) NSObject<OBAProgressIndicatorSource>* progress;
 @property (nonatomic,strong) NSError * error;
 
+- (instancetype)initWithModelService:(OBAModelService*)modelService;
+
 - (BOOL)unfilteredSearch;
 - (void)searchWithTarget:(OBANavigationTarget*)target;
 - (void)searchPending;

--- a/ui/search/OBASearchController.m
+++ b/ui/search/OBASearchController.m
@@ -37,9 +37,9 @@ NSString * const OBASearchControllerUserInfoDataKey = @"OBASearchControllerUserI
 
 @implementation OBASearchController
 
-- (id)init {
+- (instancetype)initWithModelService:(OBAModelService*)modelService {
     if (self = [super init]) {
-        _modelService = [OBAApplication sharedApplication].modelService;
+        _modelService = modelService;
         _searchType = OBASearchTypeNone;
         _progress = [[OBAProgressIndicatorImpl alloc] init];
     }

--- a/ui/search/OBASearchResultsMapViewController.h
+++ b/ui/search/OBASearchResultsMapViewController.h
@@ -23,6 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class OBAModelDAO;
 
 @interface OBASearchResultsMapViewController : UIViewController <OBANavigationTargetAware, OBASearchControllerDelegate, OBAProgressIndicatorDelegate>
+@property(nonatomic,strong) OBAModelService *modelService;
 - (IBAction)updateLocation:(id)sender;
 - (IBAction)showListView:(id)sender;
 - (void)recenterMap;

--- a/ui/search/OBASearchResultsMapViewController.m
+++ b/ui/search/OBASearchResultsMapViewController.m
@@ -101,7 +101,7 @@ static const double kStopsInRegionRefreshDelayOnDrag = 0.1;
 
     self.hideFutureNetworkErrors = NO;
 
-    self.searchController = [[OBASearchController alloc] init];
+    self.searchController = [[OBASearchController alloc] initWithModelService:self.modelService];
     self.searchController.delegate = self;
     self.searchController.progress.delegate = self;
 
@@ -266,6 +266,15 @@ static const double kStopsInRegionRefreshDelayOnDrag = 0.1;
     } completion:^(BOOL finished) {
         [self.scopeView removeFromSuperview];
     }];
+}
+
+#pragma mark - Lazily Loaded Properties
+
+- (OBAModelService*)modelService {
+    if (!_modelService) {
+        _modelService = [OBAApplication sharedApplication].modelService;
+    }
+    return _modelService;
 }
 
 #pragma mark - OBANavigationTargetAware

--- a/ui/situations/OBADiversionViewController.h
+++ b/ui/situations/OBADiversionViewController.h
@@ -24,6 +24,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 +(OBADiversionViewController*) loadFromNibWithappDelegate:(OBAApplicationDelegate*)context;
 
+@property(nonatomic,strong) OBAModelService *modelService;
+
 @property (nonatomic,strong) NSString * diversionPath;
 @property (nonatomic,strong) NSDictionary * args;
 

--- a/ui/situations/OBADiversionViewController.m
+++ b/ui/situations/OBADiversionViewController.m
@@ -19,8 +19,6 @@
 #import "EXTScope.h"
 
 @interface OBADiversionViewController ()
-
-
 @property (nonatomic, strong) NSString *tripEncodedPolyline;
 
 @property (nonatomic, strong) MKPolyline *routePolyline;
@@ -30,10 +28,6 @@
 @property (nonatomic, strong) MKPolylineRenderer *reroutePolylineRenderer;
 
 @property (nonatomic, strong) id<OBAModelServiceRequest> request;
-
-- (MKMapView *)mapView;
-
-
 @end
 
 @implementation OBADiversionViewController
@@ -71,11 +65,20 @@
     }
 }
 
-- (void)requestShapeForID:(NSString *)shapeId {
-    OBAModelService *service = [OBAApplication sharedApplication].modelService;
+#pragma mark - Lazy Loading
 
+- (OBAModelService*)modelService {
+    if (!_modelService) {
+        _modelService = [OBAApplication sharedApplication].modelService;
+    }
+    return _modelService;
+}
+
+#pragma mark - Data Loading
+
+- (void)requestShapeForID:(NSString *)shapeId {
     @weakify(self);
-    self.request = [service requestShapeForId:shapeId completionBlock:^(id jsonData, NSUInteger responseCode, NSError *error) {
+    self.request = [self.modelService requestShapeForId:shapeId completionBlock:^(id jsonData, NSUInteger responseCode, NSError *error) {
         @strongify(self);
 
         if (!jsonData) {

--- a/ui/situations/OBASituationViewController.h
+++ b/ui/situations/OBASituationViewController.h
@@ -16,19 +16,15 @@
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
-#import <OBAKit/OBASituationV2.h>
+#import <OBAKit/OBAKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface OBASituationViewController : UITableViewController {
-    OBASituationV2 * _situation;
-    NSString * _diversionPath;
-}
-
-- (id) initWithSituation:(OBASituationV2*)situation;
-
+@interface OBASituationViewController : UITableViewController
+@property(nonatomic,strong) OBAModelDAO *modelDAO;
 @property (nonatomic,strong) NSDictionary * args;
 
+- (instancetype)initWithSituation:(OBASituationV2*)situation;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ui/situations/OBASituationViewController.m
+++ b/ui/situations/OBASituationViewController.m
@@ -21,24 +21,10 @@ typedef NS_ENUM (NSInteger, OBASectionType) {
     OBASectionTypeMarkAsRead
 };
 
-
-@interface OBASituationViewController (Private)
-
-- (OBASectionType)sectionTypeForSection:(NSUInteger)section;
-
-- (UITableViewCell *)tableView:(UITableView *)tableView titleCellForRowAtIndexPath:(NSIndexPath *)indexPath;
-- (UITableViewCell *)tableView:(UITableView *)tableView detailsCellForRowAtIndexPath:(NSIndexPath *)indexPath;
-- (UITableViewCell *)tableView:(UITableView *)tableView markAsReadCellForRowAtIndexPath:(NSIndexPath *)indexPath;
-
-- (void)didSelectDetailsRowAtIndexPath:(NSIndexPath *)indexPath tableView:(UITableView *)tableView;
-- (void)didSelectMarkAsReadRowAtIndexPath:(NSIndexPath *)indexPath tableView:(UITableView *)tableView;
-
-- (NSString *)getDetails:(BOOL)htmlify;
-
-@end
-
-
-@implementation OBASituationViewController
+@implementation OBASituationViewController {
+    OBASituationV2 * _situation;
+    NSString * _diversionPath;
+}
 
 #pragma mark - Initialization
 
@@ -51,14 +37,14 @@ typedef NS_ENUM (NSInteger, OBASectionType) {
         NSArray *consequences = _situation.consequences;
 
         for (OBASituationConsequenceV2 *consequence in consequences) {
-            if (consequence.diversionPath) diversionPath = consequence.diversionPath;
+            if (consequence.diversionPath) {
+                diversionPath = consequence.diversionPath;
+            }
         }
 
-        if (diversionPath) _diversionPath = diversionPath;
-
-        // Mark the situation as visited
-        OBAModelDAO *modelDao = [OBAApplication sharedApplication].modelDao;
-        [modelDao setVisited:YES forSituationWithId:_situation.situationId];
+        if (diversionPath) {
+            _diversionPath = diversionPath;
+        }
     }
 
     return self;
@@ -66,8 +52,21 @@ typedef NS_ENUM (NSInteger, OBASectionType) {
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+
+    // Mark the situation as visited
+    [self.modelDAO setVisited:YES forSituationWithId:_situation.situationId];
+
     self.tableView.backgroundView = nil;
     self.tableView.backgroundColor = [UIColor whiteColor];
+}
+
+#pragma mark - Lazy Loading
+
+- (OBAModelDAO*)modelDAO {
+    if (!_modelDAO) {
+        _modelDAO = [OBAApplication sharedApplication].modelDao;
+    }
+    return _modelDAO;
 }
 
 #pragma mark - Table view data source
@@ -153,10 +152,7 @@ typedef NS_ENUM (NSInteger, OBASectionType) {
     }
 }
 
-@end
-
-
-@implementation OBASituationViewController (Private)
+#pragma mark - Private
 
 - (OBASectionType)sectionTypeForSection:(NSUInteger)section {
     int offset = 0;
@@ -204,8 +200,7 @@ typedef NS_ENUM (NSInteger, OBASectionType) {
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView markAsReadCellForRowAtIndexPath:(NSIndexPath *)indexPath {
-    OBAModelDAO *modelDao = [OBAApplication sharedApplication].modelDao;
-    BOOL isRead = [modelDao isVisitedSituationWithId:_situation.situationId];
+    BOOL isRead = [self.modelDAO isVisitedSituationWithId:_situation.situationId];
 
     UITableViewCell *cell = [UITableViewCell getOrCreateCellForTableView:tableView];
 
@@ -229,10 +224,9 @@ typedef NS_ENUM (NSInteger, OBASectionType) {
 }
 
 - (void)didSelectMarkAsReadRowAtIndexPath:(NSIndexPath *)indexPath tableView:(UITableView *)tableView {
-    OBAModelDAO *modelDao = [OBAApplication sharedApplication].modelDao;
-    BOOL isRead = ![modelDao isVisitedSituationWithId:_situation.situationId];
+    BOOL isRead = ![self.modelDAO isVisitedSituationWithId:_situation.situationId];
 
-    [modelDao setVisited:isRead forSituationWithId:_situation.situationId];
+    [self.modelDAO setVisited:isRead forSituationWithId:_situation.situationId];
 
     UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
     cell.textLabel.text = isRead ? NSLocalizedString(@"Mark as Unread", @"isRead") : NSLocalizedString(@"Mark as Read", @"!isRead");
@@ -255,7 +249,7 @@ typedef NS_ENUM (NSInteger, OBASectionType) {
     }
 
     /**
-     * Is this a terrible hack?  Probably yes.
+     * Is this a terrible hack? Definitely yes. Remove please.
      */
     if (htmlify) {
         NSError *error = nil;

--- a/ui/static_table/categories/OBAStaticTableViewController+Builders.h
+++ b/ui/static_table/categories/OBAStaticTableViewController+Builders.h
@@ -10,5 +10,5 @@
 #import <OBAKit/OBAKit.h>
 
 @interface OBAStaticTableViewController (Builders)
-+ (OBATableSection*)createServiceAlertsSection:(id<OBAHasServiceAlerts>)result serviceAlerts:(OBAServiceAlertsModel*)serviceAlerts navigationController:(UINavigationController*)navigationController;
+- (OBATableSection*)createServiceAlertsSection:(id<OBAHasServiceAlerts>)result serviceAlerts:(OBAServiceAlertsModel*)serviceAlerts;
 @end

--- a/ui/static_table/categories/OBAStaticTableViewController+Builders.m
+++ b/ui/static_table/categories/OBAStaticTableViewController+Builders.m
@@ -11,9 +11,9 @@
 
 @implementation OBAStaticTableViewController (Builders)
 
-+ (OBATableSection*)createServiceAlertsSection:(id<OBAHasServiceAlerts>)result serviceAlerts:(OBAServiceAlertsModel*)serviceAlerts navigationController:(UINavigationController*)navigationController {
+- (OBATableSection*)createServiceAlertsSection:(id<OBAHasServiceAlerts>)result serviceAlerts:(OBAServiceAlertsModel*)serviceAlerts {
     OBATableRow *serviceAlertsRow = [[OBATableRow alloc] initWithTitle:NSLocalizedString(@"View Service Alerts", @"") action:^{
-        [OBASituationsViewController showSituations:result.situations navigationController:navigationController args:nil];
+        [OBASituationsViewController showSituations:result.situations navigationController:self.navigationController args:nil];
     }];
 
     serviceAlertsRow.image = [self.class iconForServiceAlerts:serviceAlerts];

--- a/ui/stop_details/OBAEditStopPreferencesViewController.h
+++ b/ui/stop_details/OBAEditStopPreferencesViewController.h
@@ -19,7 +19,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface OBAEditStopPreferencesViewController : UITableViewController
-- (instancetype)initWithStop:(OBAStopV2*)stop;
+- (instancetype)initWithModelDAO:(OBAModelDAO*)modelDAO stop:(OBAStopV2*)stop;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ui/stop_details/OBAEditStopPreferencesViewController.m
+++ b/ui/stop_details/OBAEditStopPreferencesViewController.m
@@ -15,13 +15,13 @@
  */
 
 #import "OBAEditStopPreferencesViewController.h"
-#import <OBAKit/OBAKit.h>
 #import "OBAStopViewController.h"
 #import "UITableViewController+oba_Additions.h"
 #import "UITableViewCell+oba_Additions.h"
 #import "OBAAnalytics.h"
 
 @interface OBAEditStopPreferencesViewController ()
+@property(nonatomic,strong) OBAModelDAO *modelDAO;
 @property(nonatomic,strong) OBAStopV2 *stop;
 @property(nonatomic,strong) NSArray *routes;
 @property(nonatomic,strong) OBAStopPreferencesV2 *preferences;
@@ -29,9 +29,12 @@
 
 @implementation OBAEditStopPreferencesViewController
 
-- (instancetype)initWithStop:(OBAStopV2 *)stop {
+- (instancetype)initWithModelDAO:(OBAModelDAO*)modelDAO stop:(OBAStopV2 *)stop {
     if (self = [super initWithStyle:UITableViewStylePlain]) {
         _stop = stop;
+        _modelDAO = modelDAO;
+        _preferences = [_modelDAO stopPreferencesForStopWithId:_stop.stopId];
+        _routes = [_stop.routes sortedArrayUsingSelector:@selector(compareUsingName:)];
 
         UIBarButtonItem *cancelButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancel:)];
         self.navigationItem.leftBarButtonItem = cancelButton;
@@ -40,10 +43,6 @@
         self.navigationItem.rightBarButtonItem = saveButton;
 
         self.navigationItem.title = NSLocalizedString(@"Filter & Sort", @"self.navigationItem.title");
-
-        _routes = [_stop.routes sortedArrayUsingSelector:@selector(compareUsingName:)];
-
-        _preferences = [[OBAApplication sharedApplication].modelDao stopPreferencesForStopWithId:stop.stopId];
     }
 
     return self;
@@ -205,7 +204,7 @@
 }
 
 - (void)save:(id)sender {
-    [[OBAApplication sharedApplication].modelDao setStopPreferences:_preferences forStopWithId:_stop.stopId];
+    [self.modelDAO setStopPreferences:self.preferences forStopWithId:self.stop.stopId];
     [self dismissViewControllerAnimated:YES completion:nil];
 }
 

--- a/ui/stop_details/OBAReportProblemWithRecentTripsViewController.h
+++ b/ui/stop_details/OBAReportProblemWithRecentTripsViewController.h
@@ -14,11 +14,14 @@
  * limitations under the License.
  */
 
+#import <OBAKit/OBAKit.h>
 #import "OBAStaticTableViewController.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface OBAReportProblemWithRecentTripsViewController : OBAStaticTableViewController
+@property(nonatomic,strong) OBAModelService *modelService;
+
 - (instancetype)initWithStopID:(NSString*)stopID;
 @end
 

--- a/ui/stop_details/OBAReportProblemWithRecentTripsViewController.m
+++ b/ui/stop_details/OBAReportProblemWithRecentTripsViewController.m
@@ -16,7 +16,6 @@
 
 #import "OBAReportProblemWithRecentTripsViewController.h"
 #import "OBAReportProblemWithTripViewController.h"
-#import <OBAKit/OBAKit.h>
 #import "OBAClassicDepartureRow.h"
 
 @interface OBAReportProblemWithRecentTripsViewController ()
@@ -38,8 +37,7 @@
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
 
-    [[OBAApplication sharedApplication].modelService requestStopForID:self.stopID minutesBefore:30 minutesAfter:30].then(^(OBAArrivalsAndDeparturesForStopV2 *response) {
-
+    [self.modelService requestStopForID:self.stopID minutesBefore:30 minutesAfter:30].then(^(OBAArrivalsAndDeparturesForStopV2 *response) {
         [self populateTableFromArrivalsAndDeparturesModel:response];
     }).catch(^(NSError *error) {
         self.title = error.localizedDescription ?: NSLocalizedString(@"Error connecting", @"requestDidFail");
@@ -63,8 +61,7 @@
 }
 
 - (void)reportProblemWithTrip:(OBATripInstanceRef*)tripInstance {
-
-    [[OBAApplication sharedApplication].modelService requestTripDetailsForTripInstance:tripInstance].then(^(OBATripDetailsV2 *tripDetails) {
+    [self.modelService requestTripDetailsForTripInstance:tripInstance].then(^(OBATripDetailsV2 *tripDetails) {
         OBAReportProblemWithTripViewController *vc = [[OBAReportProblemWithTripViewController alloc] initWithTripInstance:tripInstance trip:tripDetails.trip];
         vc.currentStopId = self.stopID;
         [self.navigationController pushViewController:vc animated:YES];
@@ -72,6 +69,15 @@
         UIAlertController *alert = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"Error Connecting", @"") message:error.localizedDescription preferredStyle:UIAlertControllerStyleAlert];
         [self presentViewController:alert animated:YES completion:nil];
     });
+}
+
+#pragma mark - Lazy Loading
+
+- (OBAModelService*)modelService {
+    if (!_modelService) {
+        _modelService = [OBAApplication sharedApplication].modelService;
+    }
+    return _modelService;
 }
 
 @end

--- a/ui/stop_details/OBAReportProblemWithStopViewController.h
+++ b/ui/stop_details/OBAReportProblemWithStopViewController.h
@@ -14,23 +14,18 @@
  * limitations under the License.
  */
 
-#import <OBAKit/OBAStopV2.h>
+#import <OBAKit/OBAKit.h>
 #import "OBAModalActivityIndicator.h"
 #import "OBATextEditViewController.h"
 #import "OBAListSelectionViewController.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface OBAReportProblemWithStopViewController : UITableViewController <UITextFieldDelegate, OBATextEditViewControllerDelegate, OBAListSelectionViewControllerDelegate> {
-    OBAStopV2 * _stop;
-    NSMutableArray * _problemIds;
-    NSMutableArray * _problemNames;
-    NSUInteger _problemIndex;
-    NSString * _comment;
-}
+@interface OBAReportProblemWithStopViewController : UITableViewController <UITextFieldDelegate, OBATextEditViewControllerDelegate, OBAListSelectionViewControllerDelegate> 
+@property(nonatomic,strong) OBAModelService *modelService;
+@property(nonatomic,strong) OBALocationManager *locationManager;
 
-- (id) initWithStop:(OBAStopV2*)stop;
-
+- (instancetype)initWithStop:(OBAStopV2*)stop;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ui/stop_details/OBAReportProblemWithStopViewController.m
+++ b/ui/stop_details/OBAReportProblemWithStopViewController.m
@@ -33,7 +33,13 @@ typedef NS_ENUM (NSInteger, OBASectionType) {
 @property(nonatomic,strong) OBAModalActivityIndicator * activityIndicatorView;
 @end
 
-@implementation OBAReportProblemWithStopViewController
+@implementation OBAReportProblemWithStopViewController{
+    OBAStopV2 * _stop;
+    NSMutableArray * _problemIds;
+    NSMutableArray * _problemNames;
+    NSUInteger _problemIndex;
+    NSString * _comment;
+}
 
 #pragma mark - Initialization
 
@@ -317,10 +323,10 @@ typedef NS_ENUM (NSInteger, OBASectionType) {
     problem.stopId = _stop.stopId;
     problem.code = _problemIds[_problemIndex];
     problem.userComment = _comment;
-    problem.userLocation = [OBAApplication sharedApplication].locationManager.currentLocation;
+    problem.userLocation = self.locationManager.currentLocation;
 
     [self.activityIndicatorView show:self.view];
-    [[OBAApplication sharedApplication].modelService reportProblemWithStop:problem completionBlock:^(id responseData, NSUInteger responseCode, NSError *error) {
+    [self.modelService reportProblemWithStop:problem completionBlock:^(id responseData, NSUInteger responseCode, NSError *error) {
         if (error || !responseData) {
             [self showErrorAlert];
             [self.activityIndicatorView hide];
@@ -353,6 +359,22 @@ typedef NS_ENUM (NSInteger, OBASectionType) {
         [APP_DELEGATE navigateToTarget:[OBANavigationTarget target:OBANavigationTargetTypeContactUs]];
     }]];
     [self presentViewController:alert animated:YES completion:nil];
+}
+
+#pragma mark - Lazy Loading
+
+- (OBAModelService*)modelService {
+    if (!_modelService) {
+        _modelService = [OBAApplication sharedApplication].modelService;
+    }
+    return _modelService;
+}
+
+- (OBALocationManager*)locationManager {
+    if (!_locationManager) {
+        _locationManager = [OBAApplication sharedApplication].locationManager;
+    }
+    return _locationManager;
 }
 
 @end

--- a/ui/stops/OBADepartureRow.m
+++ b/ui/stops/OBADepartureRow.m
@@ -62,16 +62,7 @@
 }
 
 - (NSString *)formattedNextDepartureTime {
-    
-    static NSDateFormatter *formatter = nil;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        formatter = [[NSDateFormatter alloc] init];
-        formatter.dateStyle = NSDateFormatterNoStyle;
-        formatter.timeStyle = NSDateFormatterShortStyle;
-    });
-
-    return [formatter stringFromDate:self.departsAt];
+    return [OBADateHelpers formatShortTimeNoDate:self.departsAt];
 }
 
 @end

--- a/ui/stops/OBAStopViewController.h
+++ b/ui/stops/OBAStopViewController.h
@@ -6,15 +6,15 @@
 //  Copyright © 2016 OneBusAway. All rights reserved.
 //
 
+#import <OBAKit/OBAKit.h>
 #import "OBAStaticTableViewController.h"
 #import "OBANavigationTargetAware.h"
-
-@class OBAModelDAO;
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface OBAStopViewController : OBAStaticTableViewController<OBANavigationTargetAware>
 @property(nonatomic,strong) OBAModelDAO *modelDAO;
+@property(nonatomic,strong) OBAModelService *modelService;
 @property(nonatomic,copy,readonly) NSString *stopID;
 @property(nonatomic,assign) NSUInteger minutesBefore;
 @property(nonatomic,assign) NSUInteger minutesAfter;

--- a/ui/stops/OBAStopViewController.m
+++ b/ui/stops/OBAStopViewController.m
@@ -121,6 +121,13 @@ static CGFloat const kTableHeaderHeight = 150.f;
     return _modelDAO;
 }
 
+- (OBAModelService*)modelService {
+    if (!_modelService) {
+        _modelService = [OBAApplication sharedApplication].modelService;
+    }
+    return _modelService;
+}
+
 - (OBAStopPreferencesV2*)stopPreferences {
     if (!_stopPreferences) {
         _stopPreferences = [self.modelDAO stopPreferencesForStopWithId:self.stopID];
@@ -153,7 +160,7 @@ static CGFloat const kTableHeaderHeight = 150.f;
 
     self.navigationItem.title = NSLocalizedString(@"Updating...", @"Title of the Stop UI Controller while it is updating its content.");
 
-    [[OBAApplication sharedApplication].modelService requestStopForID:self.stopID minutesBefore:self.minutesBefore minutesAfter:self.minutesAfter].then(^(OBAArrivalsAndDeparturesForStopV2 *response) {
+    [self.modelService requestStopForID:self.stopID minutesBefore:self.minutesBefore minutesAfter:self.minutesAfter].then(^(OBAArrivalsAndDeparturesForStopV2 *response) {
         self.navigationItem.title = [NSString stringWithFormat:@"%@: %@", NSLocalizedString(@"Updated", @"message"), [OBACommon getTimeAsString]];
         [self.modelDAO viewedArrivalsAndDeparturesForStop:response.stop];
 
@@ -193,7 +200,7 @@ static CGFloat const kTableHeaderHeight = 150.f;
     // Service Alerts
     OBAServiceAlertsModel *serviceAlerts = [self.modelDAO getServiceAlertsModelForSituations:result.situations];
     if (serviceAlerts.totalCount > 0) {
-        [sections addObject:[self.class createServiceAlertsSection:result serviceAlerts:serviceAlerts navigationController:self.navigationController]];
+        [sections addObject:[self createServiceAlertsSection:result serviceAlerts:serviceAlerts]];
     }
 
     // Departures
@@ -370,7 +377,7 @@ static CGFloat const kTableHeaderHeight = 150.f;
 
     // Filter/Sort Arrivals
     OBATableRow *filter = [[OBATableRow alloc] initWithTitle:NSLocalizedString(@"Filter & Sort Routes", @"") action:^{
-        OBAEditStopPreferencesViewController *vc = [[OBAEditStopPreferencesViewController alloc] initWithStop:stop];
+        OBAEditStopPreferencesViewController *vc = [[OBAEditStopPreferencesViewController alloc] initWithModelDAO:modelDAO stop:stop];
         UINavigationController *nav = [[UINavigationController alloc] initWithRootViewController:vc];
         [self presentViewController:nav animated:YES completion:nil];
     }];
@@ -408,7 +415,7 @@ static CGFloat const kTableHeaderHeight = 150.f;
 
 - (void)createTableHeaderView {
     self.parallaxHeaderView = [[OBAParallaxTableHeaderView alloc] initWithFrame:CGRectMake(0, 0, CGRectGetWidth(self.tableView.frame), kTableHeaderHeight)];
-    self.parallaxHeaderView.highContrastMode = [[OBAApplication sharedApplication] useHighContrastUI];
+    self.parallaxHeaderView.highContrastMode = [OBAApplication sharedApplication].useHighContrastUI;
 
     self.tableView.tableHeaderView = self.parallaxHeaderView;
 }

--- a/ui/trip_details/OBAArrivalAndDepartureViewController.h
+++ b/ui/trip_details/OBAArrivalAndDepartureViewController.h
@@ -6,11 +6,13 @@
 //  Copyright © 2016 OneBusAway. All rights reserved.
 //
 
+#import <OBAKit/OBAKit.h>
 #import "OBAStaticTableViewController.h"
 
-@class OBAArrivalAndDepartureV2;
-
 @interface OBAArrivalAndDepartureViewController : OBAStaticTableViewController
+@property(nonatomic,strong) OBAModelDAO *modelDAO;
+@property(nonatomic,strong) OBAModelService *modelService;
 @property(nonatomic,strong) OBAArrivalAndDepartureV2* arrivalAndDeparture;
+
 - (instancetype)initWithArrivalAndDeparture:(OBAArrivalAndDepartureV2*)arrivalAndDeparture;
 @end

--- a/ui/trip_details/OBAReportProblemWithTripViewController.h
+++ b/ui/trip_details/OBAReportProblemWithTripViewController.h
@@ -21,23 +21,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface OBAReportProblemWithTripViewController : UITableViewController <UITextFieldDelegate, OBATextEditViewControllerDelegate, OBAListSelectionViewControllerDelegate> {
-    OBATripInstanceRef *_tripInstance;
-    OBATripV2 *_trip;
-    NSMutableArray *_problemIds;
-    NSMutableArray *_problemNames;
-    NSUInteger _problemIndex;
-    NSString *_comment;
-    BOOL _onVehicle;
-    NSString *_vehicleNumber;
-    NSString *_vehicleType;
+@interface OBAReportProblemWithTripViewController : UITableViewController <UITextFieldDelegate, OBATextEditViewControllerDelegate, OBAListSelectionViewControllerDelegate>
+@property(nonatomic,strong) OBALocationManager *locationManager;
+@property(nonatomic,strong) OBAModelService *modelService;
+@property(nonatomic,copy) NSString *currentStopId;
 
-    OBAModalActivityIndicator *_activityIndicatorView;
-}
-
-- (id)initWithTripInstance:(OBATripInstanceRef *)tripInstance trip:(OBATripV2 *)trip;
-
-@property (nonatomic, strong) NSString *currentStopId;
+- (instancetype)initWithTripInstance:(OBATripInstanceRef *)tripInstance trip:(OBATripV2 *)trip;
 
 @end
 

--- a/ui/trip_details/OBAReportProblemWithTripViewController.m
+++ b/ui/trip_details/OBAReportProblemWithTripViewController.m
@@ -34,16 +34,23 @@ typedef NS_ENUM (NSInteger, OBASectionType) {
     OBASectionTypeNotes
 };
 
+@implementation OBAReportProblemWithTripViewController {
+    OBATripInstanceRef *_tripInstance;
+    OBATripV2 *_trip;
+    NSMutableArray *_problemIds;
+    NSMutableArray *_problemNames;
+    NSUInteger _problemIndex;
+    NSString *_comment;
+    BOOL _onVehicle;
+    NSString *_vehicleNumber;
+    NSString *_vehicleType;
 
-@interface OBAReportProblemWithTripViewController ()
-@end
-
-
-@implementation OBAReportProblemWithTripViewController
+    OBAModalActivityIndicator *_activityIndicatorView;
+}
 
 #pragma mark - Initialization
 
-- (id)initWithTripInstance:(OBATripInstanceRef *)tripInstance trip:(OBATripV2 *)trip {
+- (instancetype)initWithTripInstance:(OBATripInstanceRef *)tripInstance trip:(OBATripV2 *)trip {
     if (self = [super initWithStyle:UITableViewStylePlain]) {
         _tripInstance = tripInstance;
         _trip = trip;
@@ -83,6 +90,22 @@ typedef NS_ENUM (NSInteger, OBASectionType) {
     self.tableView.backgroundView = nil;
     self.tableView.backgroundColor = [UIColor whiteColor];
     [self hideEmptySeparators];
+}
+
+#pragma mark - Lazily Loaded Properties
+
+- (OBALocationManager*)locationManager {
+    if (!_locationManager) {
+        _locationManager = [OBAApplication sharedApplication].locationManager;
+    }
+    return _locationManager;
+}
+
+- (OBAModelService*)modelService {
+    if (!_modelService) {
+        _modelService = [OBAApplication sharedApplication].modelService;
+    }
+    return _modelService;
 }
 
 #pragma mark - Table view methods
@@ -418,10 +441,10 @@ typedef NS_ENUM (NSInteger, OBASectionType) {
     problem.userComment = _comment;
     problem.userOnVehicle = _onVehicle;
     problem.userVehicleNumber = _vehicleNumber;
-    problem.userLocation = [OBAApplication sharedApplication].locationManager.currentLocation;
+    problem.userLocation = self.locationManager.currentLocation;
 
     [SVProgressHUD show];
-    [[OBAApplication sharedApplication].modelService reportProblemWithTrip:problem completionBlock:^(id jsonData, NSUInteger responseCode, NSError *error) {
+    [self.modelService reportProblemWithTrip:problem completionBlock:^(id jsonData, NSUInteger responseCode, NSError *error) {
         [SVProgressHUD dismiss];
 
         if (error || !jsonData) {

--- a/ui/trip_details/OBATripDetailsViewController.h
+++ b/ui/trip_details/OBATripDetailsViewController.h
@@ -21,18 +21,15 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface OBATripDetailsViewController : OBARequestDrivenTableViewController {
-    OBATripInstanceRef *_tripInstance;
-    OBATripDetailsV2 *_tripDetails;
-    OBAServiceAlertsModel *_serviceAlerts;
-}
+@interface OBATripDetailsViewController : OBARequestDrivenTableViewController
+@property(nonatomic,strong) OBAModelDAO *modelDAO;
+@property(nonatomic,strong) OBAModelService *modelService;
+@property(nonatomic,strong) OBATripInstanceRef *tripInstance;
+@property(nonatomic,strong) OBATripDetailsV2 *tripDetails;
+@property(nonatomic,strong) OBAServiceAlertsModel *serviceAlerts;
+@property(nonatomic,copy) NSString *currentStopId;
 
-- (id)initWithTripInstance:(OBATripInstanceRef *)tripInstance;
-
-@property (nonatomic, strong) OBATripInstanceRef *tripInstance;
-@property (nonatomic, strong) OBATripDetailsV2 *tripDetails;
-@property (nonatomic, strong) OBAServiceAlertsModel *serviceAlerts;
-@property (nonatomic, strong) NSString *currentStopId;
+- (instancetype)initWithTripInstance:(OBATripInstanceRef *)tripInstance;
 
 @end
 

--- a/ui/trip_details/OBATripScheduleListViewController.h
+++ b/ui/trip_details/OBATripScheduleListViewController.h
@@ -15,14 +15,13 @@
  */
 
 #import <UIKit/UIKit.h>
+#import <OBAKit/OBAKit.h>
 #import "OBAStaticTableViewController.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class OBATripDetailsV2;
-@class OBATripInstanceRef;
-
 @interface OBATripScheduleListViewController : OBAStaticTableViewController
+@property(nonatomic,strong) OBAModelService *modelService;
 @property(nonatomic,strong) OBATripDetailsV2 *tripDetails;
 @property(nonatomic,copy) NSString *currentStopId;
 

--- a/ui/trip_details/OBATripScheduleListViewController.m
+++ b/ui/trip_details/OBATripScheduleListViewController.m
@@ -69,10 +69,12 @@ typedef NS_ENUM(NSUInteger, OBASectionType) {
         return;
     }
 
-    [[OBAApplication sharedApplication].modelService requestTripDetailsForTripInstance:self.tripInstance].then(^(OBATripDetailsV2 *tripDetails) {
+    [self.modelService requestTripDetailsForTripInstance:self.tripInstance].then(^(OBATripDetailsV2 *tripDetails) {
         self.tripDetails = tripDetails;
         [self buildUI];
     }).catch(^(NSError *error) {
+
+        // TODO: replace this with an AlertPresenter.
         if (error.code == 404) {
             [self.progressView setMessage:NSLocalizedString(@"Trip not found", @"message") inProgress:NO progress:0];
         }
@@ -84,6 +86,15 @@ typedef NS_ENUM(NSUInteger, OBASectionType) {
             [self.progressView setMessage:NSLocalizedString(@"Error connecting", @"message") inProgress:NO progress:0];
         }
     });
+}
+
+#pragma mark - Lazily Loaded Properties
+
+- (OBAModelService*)modelService {
+    if (!_modelService) {
+        _modelService = [OBAApplication sharedApplication].modelService;
+    }
+    return _modelService;
 }
 
 #pragma mark - Static tables

--- a/ui/trip_details/OBATripScheduleMapViewController.h
+++ b/ui/trip_details/OBATripScheduleMapViewController.h
@@ -21,8 +21,9 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface OBATripScheduleMapViewController : UIViewController <MKMapViewDelegate>
-@property(nonatomic,strong) MKMapView *mapView;
+@property(nonatomic,strong) OBAModelService *modelService;
 
+@property(nonatomic,strong) MKMapView *mapView;
 @property(nonatomic,strong) OBAProgressIndicatorView *progressView;
 @property(nonatomic,strong) OBATripInstanceRef *tripInstance;
 @property(nonatomic,strong) OBATripDetailsV2 *tripDetails;

--- a/ui/trip_details/OBAVehicleDetailsController.h
+++ b/ui/trip_details/OBAVehicleDetailsController.h
@@ -20,7 +20,9 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface OBAVehicleDetailsController : OBARequestDrivenTableViewController
-- (id) initWithVehicleId:(NSString*)vehicleId;
+@property(nonatomic,strong) OBAModelService *modelService;
+
+- (instancetype)initWithVehicleId:(NSString*)vehicleId;
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Fixes #742 - Remove hardcoded dependencies on -[OBAApplication sharedApplication]

I've replaced almost all of the hardcoded references to singleton objects like [OBAApplication sharedApplication].modelService with lazily loaded properties across the app. I've been doing this in order to make it easier to test our objects in isolation without the overhead or churn associated with going full-on Java-esque dependency injection.