### PR TITLE
Add Notifications to OBALocationManager

### DIFF
--- a/OBAKit/Location/OBALocationManager.h
+++ b/OBAKit/Location/OBALocationManager.h
@@ -16,28 +16,22 @@
 
 
 #import <OBAKit/OBAModelDAO.h>
+#import <CoreLocation/CoreLocation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class OBALocationManager;
+extern NSString * const OBALocationDidUpdateNotification;
+extern NSString * const OBALocationAuthorizationStatusChangedNotification;
+extern NSString * const OBALocationManagerDidFailWithErrorNotification;
 
-@protocol OBALocationManagerDelegate <NSObject>
-- (void) locationManager:(OBALocationManager *)manager didUpdateLocation:(CLLocation *)location;
-- (void) locationManager:(OBALocationManager *)manager didFailWithError:(NSError*)error;
-
-@optional
-- (void)locationManager:(OBALocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status;
-@end
-
+extern NSString * const OBALocationAuthorizationStatusUserInfoKey;
+extern NSString * const OBALocationErrorUserInfoKey;
 
 @interface OBALocationManager : NSObject <CLLocationManagerDelegate>
 @property(nonatomic,copy,readonly) CLLocation * currentLocation;
 @property(nonatomic,assign,readonly) BOOL locationServicesEnabled;
 
 - (instancetype)initWithModelDAO:(OBAModelDAO*)modelDAO;
-
-- (void)addDelegate:(id<OBALocationManagerDelegate>)delegate;
-- (void)removeDelegate:(id<OBALocationManagerDelegate>)delegate;
 
 - (void)startUpdatingLocation;
 - (void)stopUpdatingLocation;

--- a/OBAKit/Location/OBARegionHelper.h
+++ b/OBAKit/Location/OBARegionHelper.h
@@ -9,6 +9,8 @@
 #import <Foundation/Foundation.h>
 #import <OBAKit/OBAModelService.h>
 #import <OBAKit/OBARegionV2.h>
+#import <OBAKit/OBALocationManager.h>
+#import <OBAKit/OBAModelDAO.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -17,8 +19,15 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)regionHelperShowRegionListController:(OBARegionHelper*)regionHelper;
 @end
 
-@interface OBARegionHelper : NSObject <OBALocationManagerDelegate>
+@interface OBARegionHelper : NSObject
+@property(nonatomic,strong) OBALocationManager *locationManager;
+@property(nonatomic,strong) OBAModelDAO *modelDAO;
+@property(nonatomic,strong) OBAModelService *modelService;
 @property(nonatomic,weak) id<OBARegionHelperDelegate> delegate;
+
+- (instancetype)initWithLocationManager:(OBALocationManager*)locationManager NS_DESIGNATED_INITIALIZER;
+- (instancetype)init NS_UNAVAILABLE;
+
 - (void)updateNearestRegion;
 - (void)updateRegion;
 @end

--- a/OBAKit/OBAApplication.m
+++ b/OBAKit/OBAApplication.m
@@ -67,7 +67,7 @@ NSString *const kOBAApplicationSettingsRegionRefreshNotification = @"kOBAApplica
 
     [self restartReachability];
 
-    self.regionHelper = [[OBARegionHelper alloc] init];
+    self.regionHelper = [[OBARegionHelper alloc] initWithLocationManager:self.locationManager];
 
     [self refreshSettings];
 }

--- a/ui/search/OBASearchResultsMapViewController.h
+++ b/ui/search/OBASearchResultsMapViewController.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class OBAModelDAO;
 
-@interface OBASearchResultsMapViewController : UIViewController <OBANavigationTargetAware, OBASearchControllerDelegate, OBALocationManagerDelegate, OBAProgressIndicatorDelegate>
+@interface OBASearchResultsMapViewController : UIViewController <OBANavigationTargetAware, OBASearchControllerDelegate, OBAProgressIndicatorDelegate>
 - (IBAction)updateLocation:(id)sender;
 - (IBAction)showListView:(id)sender;
 - (void)recenterMap;


### PR DESCRIPTION
Fixes #676

Remove the multiple delegates pattern from OBALocationManager and replace it with notifications.