### PR TITLE
Stop tearing down the reachability object on region changes

### DIFF
--- a/OBAApplicationDelegate.m
+++ b/OBAApplicationDelegate.m
@@ -213,11 +213,7 @@ static NSString *const kApptentiveKey = @"3363af9a6661c98dec30fedea451a06dd7d7bc
     OBAReachability *reachability = note.object;
 
     if (!reachability.isReachable) {
-
-        NSString *host = [OBAApplication sharedApplication].modelDao.currentRegion.baseURL.host;
-        NSString *body = [NSString stringWithFormat:NSLocalizedString(@"Cannot connect to %@", @"Global reachablity alert body format string"), host];
-
-        [AlertPresenter showWarning:NSLocalizedString(@"Lost Connection", @"Global reachability alert title") body:body];
+        [AlertPresenter showWarning:NSLocalizedString(@"Cannot connect to the Internet", @"Reachability alert title") body:NSLocalizedString(@"Please check your Internet connection and try again.", @"Reachability alert body")];
     }
 }
 

--- a/OBAKit/OBAApplication.m
+++ b/OBAKit/OBAApplication.m
@@ -65,8 +65,6 @@ NSString *const kOBAApplicationSettingsRegionRefreshNotification = @"kOBAApplica
 
     self.modelService.locationManager = self.locationManager;
 
-    [self restartReachability];
-
     self.regionHelper = [[OBARegionHelper alloc] initWithLocationManager:self.locationManager];
 
     [self refreshSettings];
@@ -86,21 +84,16 @@ NSString *const kOBAApplicationSettingsRegionRefreshNotification = @"kOBAApplica
     return self.reachability.isReachable;
 }
 
-- (void)restartReachability {
-    [self.reachability stopNotifier];
-    self.reachability = nil;
-
-    NSURL *apiURL = self.modelDao.currentRegion.baseURL;
-    NSString *hostname = apiURL ? apiURL.host : @"api.onebusaway.org";
-
-    self.reachability = [OBAReachability reachabilityWithHostname:hostname];
-    [self.reachability startNotifier];
+- (OBAReachability*)reachability {
+    if (!_reachability) {
+        _reachability = [OBAReachability reachabilityForInternetConnection];
+    }
+    return _reachability;
 }
 
 #pragma mark - Region
 
 - (void)regionUpdated:(NSNotification*)note {
-    [self restartReachability];
     [self refreshSettings];
 }
 


### PR DESCRIPTION
Fixes #767 - Reachability causing crashes (https://github.com/OneBusAway/onebusaway-iphone/issues/767)

The only crashes we've seen thus far in OBA 2.6.0 are happening deep within the bowels of the Reachability object. My supposition on what's happening is that when the reachability object is torn down in -[OBAApplication restartReachability] it is not releasing all of its resources/callbacks/whatever. And when one of these finally calls back after the reachability object has been torn down, the app crashes.

So, we will drop the reachability check for the user's current region server and, instead, just make sure that the Internet is accessible. 99% as good, and hopefully 100% fewer crashes.