### PR TITLE
Prospective fix for missing map annotations

### DIFF
--- a/OBAKit/Location/OBARegionHelper.m
+++ b/OBAKit/Location/OBARegionHelper.m
@@ -89,7 +89,7 @@
 }
 
 - (void)setNearestRegion {
-    OBAGuard(self.regions.count > 0) else {
+    if (self.regions.count == 0) {
         return;
     }
 

--- a/OBAKit/Models/dao/OBAModelDAO.m
+++ b/OBAKit/Models/dao/OBAModelDAO.m
@@ -73,6 +73,10 @@ const NSInteger kMaxEntriesInMostRecentList = 10;
 #pragma mark - Regions
 
 - (void)setCurrentRegion:(OBARegionV2 *)currentRegion {
+    if ([_currentRegion isEqual:currentRegion]) {
+        return;
+    }
+
     _currentRegion = currentRegion;
     [_preferencesDao writeOBARegion:currentRegion];
 

--- a/OBAKit/Models/unmanaged/OBARegionV2.m
+++ b/OBAKit/Models/unmanaged/OBARegionV2.m
@@ -162,7 +162,71 @@ static NSString * kCustom = @"custom";
         return NO;
     }
 
-    return self.identifier == object.identifier;
+    if (![self.siriBaseUrl isEqual:object.siriBaseUrl]) {
+        return NO;
+    }
+
+    if (![self.obaVersionInfo isEqual:object.obaVersionInfo]) {
+        return NO;
+    }
+
+    if (![self.language isEqual:object.language]) {
+        return NO;
+    }
+
+    if (![self.bounds isEqual:object.bounds]) {
+        return NO;
+    }
+
+    if (![self.contactEmail isEqual:object.contactEmail]) {
+        return NO;
+    }
+
+    if (![self.twitterUrl isEqual:object.twitterUrl]) {
+        return NO;
+    }
+
+    if (![self.facebookUrl isEqual:object.facebookUrl]) {
+        return NO;
+    }
+
+    if (![self.obaBaseUrl isEqual:object.obaBaseUrl]) {
+        return NO;
+    }
+    
+    if (![self.regionName isEqual:object.regionName]) {
+        return NO;
+    }
+
+    if (self.supportsSiriRealtimeApis != object.supportsSiriRealtimeApis) {
+        return NO;
+    }
+
+    if (self.supportsObaRealtimeApis != object.supportsObaRealtimeApis) {
+        return NO;
+    }
+
+    if (self.supportsObaDiscoveryApis != object.supportsObaDiscoveryApis) {
+        return NO;
+    }
+
+    if (self.active != object.active) {
+        return NO;
+    }
+
+    if (self.experimental != object.experimental) {
+        return NO;
+    }
+
+    if (self.identifier != object.identifier) {
+        return NO;
+    }
+
+    if (self.custom != object.custom) {
+        return NO;
+    }
+
+    return YES;
 }
 
 - (NSString*)description


### PR DESCRIPTION
Hopefully fixes #773 - Map doesn't consistently show stops when it first loads (https://github.com/OneBusAway/onebusaway-iphone/issues/773)

It appears that what was causing this issue to manifest was the thrashing of the current region on app launch. I've improved the -isEqual: method for regions and stopped updating the region if the current region is equal to the parameter. Also, I eliminated an assert that was triggering on a perfectly reasonable condition.