### PR TITLE
Strip the text "(beta)" from region names

### DIFF
--- a/OBAKit/Models/unmanaged/OBARegionV2.m
+++ b/OBAKit/Models/unmanaged/OBARegionV2.m
@@ -78,11 +78,26 @@ static NSString * kCustom = @"custom";
         _experimental = [decoder decodeBoolForKey:kExperimental];
         _obaBaseUrl = [decoder decodeObjectForKey:kObaBaseUrl];
         _identifier = [decoder decodeIntegerForKey:kIdentifier];
-        _regionName = [decoder decodeObjectForKey:kRegionName];
+        _regionName = [self.class cleanUpRegionName:[decoder decodeObjectForKey:kRegionName]];
         _custom = [decoder decodeBoolForKey:kCustom];
     }
 
     return self;
+}
+
+#pragma mark - Region Name
+
+- (void)setRegionName:(NSString *)regionName {
+    _regionName = [self.class cleanUpRegionName:regionName];
+}
+
++ (NSString*)cleanUpRegionName:(NSString*)regionName {
+    if (regionName.length == 0) {
+        return regionName;
+    }
+
+    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"\\s?\\(?beta\\)?" options:NSRegularExpressionCaseInsensitive error:nil];
+    return [regex stringByReplacingMatchesInString:regionName options:(NSMatchingOptions)0 range:NSMakeRange(0, regionName.length) withTemplate:@""];
 }
 
 #pragma mark - Other Public Methods

--- a/OneBusAwayTests/OBAKitTests/models/OBARegionV2_Tests.m
+++ b/OneBusAwayTests/OBAKitTests/models/OBARegionV2_Tests.m
@@ -43,6 +43,37 @@
     XCTAssertEqual(regions.count, 12);
 }
 
+#pragma mark - Region Name
+
+- (void)testRemovalOfBetaTextFromName {
+    OBARegionV2 *region = [[OBARegionV2 alloc] init];
+    region.regionName = @"San Joaquin RTD (beta)";
+    XCTAssertEqualObjects(region.regionName, @"San Joaquin RTD");
+}
+
+- (void)testRemovalOfBetaTextFromNameCaseInsensitive {
+    OBARegionV2 *region = [[OBARegionV2 alloc] init];
+    region.regionName = @"San Joaquin RTD (BETA)";
+    XCTAssertEqualObjects(region.regionName, @"San Joaquin RTD");
+}
+
+- (void)testRemovalOfBetaTextSansParentheses {
+    OBARegionV2 *region = [[OBARegionV2 alloc] init];
+    region.regionName = @"San Joaquin RTD BETA";
+    XCTAssertEqualObjects(region.regionName, @"San Joaquin RTD");
+}
+
+- (void)testRegionNameWithoutBeta {
+    OBARegionV2 *region = [[OBARegionV2 alloc] init];
+    region.regionName = @"Puget Sound";
+    XCTAssertEqualObjects(region.regionName, @"Puget Sound");
+}
+
+- (void)testNilRegionName {
+    OBARegionV2 *region = [[OBARegionV2 alloc] init];
+    XCTAssertNil(region.regionName);
+}
+
 #pragma mark - Tampa
 
 - (void)testTampa {
@@ -106,14 +137,14 @@
 
 - (void)testBoston {
     NSArray<OBARegionV2*>* regions = [self getRegions];
-    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"regionName == %@", @"Boston (beta)"];
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"regionName == %@", @"Boston"];
     OBARegionV2 *boston = [[regions filteredArrayUsingPredicate:predicate] firstObject];
     [self testBostonWithRegion:boston];
 }
 
 - (void)testUnarchivingBoston {
     NSArray<OBARegionV2*>* regions = [self getRegions];
-    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"regionName == %@", @"Boston (beta)"];
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"regionName == %@", @"Boston"];
     OBARegionV2 *boston = [[regions filteredArrayUsingPredicate:predicate] firstObject];
 
     NSData *data = [NSKeyedArchiver archivedDataWithRootObject:boston];

--- a/gpx_files/san_joaquin.gpx
+++ b/gpx_files/san_joaquin.gpx
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<gpx
+xmlns="http://www.topografix.com/GPX/1/1"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd"
+version="1.1"
+creator="gpx-poi.com">
+   <wpt lat="37.9337345" lon="-121.3456095">
+      <time>2015-12-01T03:01:44Z</time>
+   </wpt>
+</gpx>

--- a/org.onebusaway.iphone.xcodeproj/project.pbxproj
+++ b/org.onebusaway.iphone.xcodeproj/project.pbxproj
@@ -268,6 +268,7 @@
 		934E7EE71D586240003A343D /* OBADrawerUI.m in Sources */ = {isa = PBXBuildFile; fileRef = 934E7EE61D586240003A343D /* OBADrawerUI.m */; };
 		93528AAE1C8D50D200783E9A /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 93528AAD1C8D50D200783E9A /* MapKit.framework */; };
 		93528AB11C8D517100783E9A /* CloudKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 93528AB01C8D517100783E9A /* CloudKit.framework */; };
+		935640341DA03B810017AB87 /* san_joaquin.gpx in Resources */ = {isa = PBXBuildFile; fileRef = 935640331DA03B810017AB87 /* san_joaquin.gpx */; };
 		93631E4C1604F96800CB7209 /* OBAApplicationDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 93631E4B1604F96800CB7209 /* OBAApplicationDelegate.m */; };
 		9363D5921D6ADE6600A7021A /* invalid.gpx in Resources */ = {isa = PBXBuildFile; fileRef = 9363D58E1D6ADE6600A7021A /* invalid.gpx */; };
 		9363D5931D6ADE6600A7021A /* tampa.gpx in Resources */ = {isa = PBXBuildFile; fileRef = 9363D58F1D6ADE6600A7021A /* tampa.gpx */; };
@@ -707,6 +708,7 @@
 		93528AAD1C8D50D200783E9A /* MapKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MapKit.framework; path = System/Library/Frameworks/MapKit.framework; sourceTree = SDKROOT; };
 		93528AAF1C8D50E900783E9A /* OneBusAway.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.xml; name = OneBusAway.entitlements; path = OneBusAway/OneBusAway.entitlements; sourceTree = "<group>"; };
 		93528AB01C8D517100783E9A /* CloudKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CloudKit.framework; path = System/Library/Frameworks/CloudKit.framework; sourceTree = SDKROOT; };
+		935640331DA03B810017AB87 /* san_joaquin.gpx */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = san_joaquin.gpx; sourceTree = "<group>"; };
 		93631E4A1604F96800CB7209 /* OBAApplicationDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAApplicationDelegate.h; sourceTree = "<group>"; };
 		93631E4B1604F96800CB7209 /* OBAApplicationDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = OBAApplicationDelegate.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		9363D58E1D6ADE6600A7021A /* invalid.gpx */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = invalid.gpx; sourceTree = "<group>"; };
@@ -1299,6 +1301,7 @@
 		934445F71AB105FB005B3333 /* gpx_files */ = {
 			isa = PBXGroup;
 			children = (
+				935640331DA03B810017AB87 /* san_joaquin.gpx */,
 				9363D58E1D6ADE6600A7021A /* invalid.gpx */,
 				9363D58F1D6ADE6600A7021A /* tampa.gpx */,
 				9363D5901D6ADE6600A7021A /* washingtondc.gpx */,
@@ -2121,6 +2124,7 @@
 				93E4A7621CE65B2100E769B0 /* atlanta.gpx in Resources */,
 				932BE5151AB672940011F2FB /* OBATextFieldTableViewCell.xib in Resources */,
 				9347860E1D3453E9002A5627 /* sandiego.gpx in Resources */,
+				935640341DA03B810017AB87 /* san_joaquin.gpx in Resources */,
 				932BE5031AB66FCB0011F2FB /* OBACreditsViewController.xib in Resources */,
 				9330DEEA16050CA600E14AF4 /* credits.html in Resources */,
 				93C3938F1D8CE6100080F370 /* ApptentiveResources.bundle in Resources */,

--- a/ui/regions/RegionListViewController.swift
+++ b/ui/regions/RegionListViewController.swift
@@ -151,7 +151,7 @@ class RegionListViewController: OBAStaticTableViewController, RegionBuilderDeleg
     func loadData() {
         let regions = self.regions!
         let customRows = tableRowsFromRegions(self.modelDAO.customRegions())
-        let activeRows = tableRowsFromRegions(regions.filter { $0.active })
+        let activeRows = tableRowsFromRegions(regions.filter { $0.active && !$0.experimental })
         let experimentalRows = tableRowsFromRegions(regions.filter { $0.experimental })
 
         let autoSelectRow = OBASwitchRow.init(title: NSLocalizedString("Automatically Select Region", comment: ""), action: { row in
@@ -177,7 +177,7 @@ class RegionListViewController: OBAStaticTableViewController, RegionBuilderDeleg
         sections.append(OBATableSection.init(title: NSLocalizedString("Active Regions", comment: ""), rows: activeRows))
 
         if experimentalRows.count > 0 {
-            sections.append(OBATableSection.init(title: NSLocalizedString("Experimental Regions", comment: ""), rows: experimentalRows))
+            sections.append(OBATableSection.init(title: NSLocalizedString("Newest Regions", comment: ""), rows: experimentalRows))
         }
 
         self.sections = sections


### PR DESCRIPTION
Fixes #781 - https://github.com/OneBusAway/onebusaway-iphone/issues/781

Apple, unfortunately, is now rejecting new versions of OBA from the App Store because there is a new, currently-in-beta region in California, "San Joaquin RTD (beta)", that violates their rule "PERFORMANCE: BETA TESTING"

This fix identifies region names that contain variations on the text "(beta)" and strips it from them. It also removes the word "experimental" from the region list view controller, because maybe Apple won't like that either.