### PR TITLE
Fix issue where Stop Controller refresh buttons 'pops' on reload

### DIFF
--- a/ui/stops/OBAStopViewController.m
+++ b/ui/stops/OBAStopViewController.m
@@ -145,7 +145,8 @@ static CGFloat const kTableHeaderHeight = 150.f;
 #pragma mark - Data Loading
 
 - (void)reloadData:(id)sender {
-    [self reloadDataAnimated:YES];
+    BOOL animated = ![sender isEqual:self.navigationItem.rightBarButtonItem];
+    [self reloadDataAnimated:animated];
 }
 
 - (void)reloadDataAnimated:(BOOL)animated {


### PR DESCRIPTION
Fixes #788

Only animate reloading if -reloadData: is called from an object other than the right navigation item button.