### PR TITLE
Properly escape forward slashes ('/') that appear in stop IDs

### DIFF
--- a/OBAKit/Services/OBAModelService.m
+++ b/OBAKit/Services/OBAModelService.m
@@ -51,16 +51,18 @@ static const CLLocationAccuracy kRegionalRadius = 40000;
 
 - (AnyPromise*)requestStopForID:(NSString*)stopID minutesBefore:(NSUInteger)minutesBefore minutesAfter:(NSUInteger)minutesAfter {
 
-    OBAGuard(stopID) else {
+    OBAGuard(stopID.length > 0) else {
         return nil;
     }
+
+    NSString *escapedStopID = [stopID stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]];
 
     NSDictionary *args = @{ @"minutesBefore": @(minutesBefore),
                             @"minutesAfter":  @(minutesAfter) };
     
     return [AnyPromise promiseWithResolverBlock:^(PMKResolver resolve) {
         [self request:self.obaJsonDataSource
-                  url:[NSString stringWithFormat:@"/api/where/arrivals-and-departures-for-stop/%@.json", stopID]
+                  url:[NSString stringWithFormat:@"/api/where/arrivals-and-departures-for-stop/%@.json", escapedStopID]
                  args:args
              selector:@selector(getArrivalsAndDeparturesForStopV2FromJSON:error:)
       completionBlock:^(id responseData, NSUInteger responseCode, NSError *error) {

--- a/gpx_files/boston.gpx
+++ b/gpx_files/boston.gpx
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<gpx
+xmlns="http://www.topografix.com/GPX/1/1"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd"
+version="1.1"
+creator="gpx-poi.com">
+   <wpt lat="42.0784821" lon="-71.433823">
+      <time>2015-12-01T03:01:44Z</time>
+   </wpt>
+</gpx>

--- a/org.onebusaway.iphone.xcodeproj/project.pbxproj
+++ b/org.onebusaway.iphone.xcodeproj/project.pbxproj
@@ -358,6 +358,7 @@
 		93E4A7621CE65B2100E769B0 /* atlanta.gpx in Resources */ = {isa = PBXBuildFile; fileRef = 93E4A7611CE65B2100E769B0 /* atlanta.gpx */; };
 		93EBC2ED1D9331B300B731A3 /* OBADataSourceConfig_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 93EBC2EC1D9331B300B731A3 /* OBADataSourceConfig_Tests.m */; };
 		93F05A631C8E080000BF36B1 /* OBAAnimation.m in Sources */ = {isa = PBXBuildFile; fileRef = 93F05A621C8E080000BF36B1 /* OBAAnimation.m */; };
+		93F5CF8F1DA820A4003947A8 /* boston.gpx in Resources */ = {isa = PBXBuildFile; fileRef = 93F5CF8E1DA820A4003947A8 /* boston.gpx */; };
 		93F64E971BE5ACC300323527 /* OBAAlerts.m in Sources */ = {isa = PBXBuildFile; fileRef = 93F64E961BE5ACC300323527 /* OBAAlerts.m */; };
 		93F8F4431D375B77008659D2 /* OBAArrivalAndDepartureSectionBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 93F8F4421D375B77008659D2 /* OBAArrivalAndDepartureSectionBuilder.m */; };
 		93FF25E61D6E329A00A58E72 /* RegionBuilderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93FF25E51D6E329A00A58E72 /* RegionBuilderViewController.swift */; };
@@ -836,6 +837,7 @@
 		93EBC2EC1D9331B300B731A3 /* OBADataSourceConfig_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBADataSourceConfig_Tests.m; sourceTree = "<group>"; };
 		93F05A611C8E080000BF36B1 /* OBAAnimation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAAnimation.h; sourceTree = "<group>"; };
 		93F05A621C8E080000BF36B1 /* OBAAnimation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAAnimation.m; sourceTree = "<group>"; };
+		93F5CF8E1DA820A4003947A8 /* boston.gpx */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = boston.gpx; sourceTree = "<group>"; };
 		93F64E951BE5ACC300323527 /* OBAAlerts.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAAlerts.h; sourceTree = "<group>"; };
 		93F64E961BE5ACC300323527 /* OBAAlerts.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAAlerts.m; sourceTree = "<group>"; };
 		93F8F4411D375B77008659D2 /* OBAArrivalAndDepartureSectionBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAArrivalAndDepartureSectionBuilder.h; sourceTree = "<group>"; };
@@ -1302,6 +1304,7 @@
 		934445F71AB105FB005B3333 /* gpx_files */ = {
 			isa = PBXGroup;
 			children = (
+				93F5CF8E1DA820A4003947A8 /* boston.gpx */,
 				935640331DA03B810017AB87 /* san_joaquin.gpx */,
 				9363D58E1D6ADE6600A7021A /* invalid.gpx */,
 				9363D58F1D6ADE6600A7021A /* tampa.gpx */,
@@ -2128,6 +2131,7 @@
 				9347860E1D3453E9002A5627 /* sandiego.gpx in Resources */,
 				935640341DA03B810017AB87 /* san_joaquin.gpx in Resources */,
 				932BE5031AB66FCB0011F2FB /* OBACreditsViewController.xib in Resources */,
+				93F5CF8F1DA820A4003947A8 /* boston.gpx in Resources */,
 				9330DEEA16050CA600E14AF4 /* credits.html in Resources */,
 				93C3938F1D8CE6100080F370 /* ApptentiveResources.bundle in Resources */,
 				9363D5951D6ADE6600A7021A /* yorkca.gpx in Resources */,

--- a/ui/alerts/AlertPresenter.swift
+++ b/ui/alerts/AlertPresenter.swift
@@ -39,7 +39,7 @@ import SwiftMessages
         // files in the main bundle first, so you can easily copy them into your project and make changes.
         let view = MessageView.viewFromNib(layout: .CardView)
         view.button?.isHidden = true
-        view.configureTheme(.success)
+        view.configureTheme(theme)
         view.configureDropShadow()
         view.configureContent(title: title, body: body)
 


### PR DESCRIPTION
Fixes #787 - Error when tapping on stop that contains a forward slash "/" in stopId

Also:

* Add GPX file for Boston
* Make sure the AlertPresenter shows the warning theme when appropriate, as opposed to always showing success