### PR TITLE
Fix Region Selection and Management Bugs

### DIFF
--- a/OBAKit/Location/OBALocationManager.h
+++ b/OBAKit/Location/OBALocationManager.h
@@ -31,7 +31,15 @@ extern NSString * const OBALocationErrorUserInfoKey;
 
 @interface OBALocationManager : NSObject <CLLocationManagerDelegate>
 @property(nonatomic,copy,nullable,readonly) CLLocation * currentLocation;
+
+/**
+ Informs the caller whether or not location services are enabled for the app.
+
+ Returns true if device-level location services are enabled and the user has
+ authorized location services for the app.
+ */
 @property(nonatomic,assign,readonly) BOOL locationServicesEnabled;
+
 @property(nonatomic,assign,readonly) CLAuthorizationStatus authorizationStatus;
 
 - (instancetype)initWithModelDAO:(OBAModelDAO*)modelDAO;

--- a/OBAKit/Location/OBALocationManager.m
+++ b/OBAKit/Location/OBALocationManager.m
@@ -99,9 +99,8 @@ NSString * const OBALocationErrorUserInfoKey = @"OBALocationErrorUserInfoKey";
     return [CLLocationManager authorizationStatus];
 }
 
-
 - (BOOL)locationServicesEnabled {
-    return [CLLocationManager locationServicesEnabled];
+    return [CLLocationManager locationServicesEnabled] && self.authorizationStatus == kCLAuthorizationStatusAuthorizedWhenInUse;
 }
 
 #pragma mark - CLLocationManagerDelegate
@@ -121,6 +120,11 @@ NSString * const OBALocationErrorUserInfoKey = @"OBALocationErrorUserInfoKey";
 }
 
 - (void)locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status {
+
+    if (status == kCLAuthorizationStatusRestricted || status == kCLAuthorizationStatusDenied) {
+        self.modelDao.automaticallySelectRegion = NO;
+    }
+
     [[NSNotificationCenter defaultCenter] postNotificationName:OBALocationAuthorizationStatusChangedNotification object:self userInfo:@{OBALocationAuthorizationStatusUserInfoKey: @(status)}];
 }
 

--- a/OBAKit/Location/OBAMapRegionManager.h
+++ b/OBAKit/Location/OBAMapRegionManager.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface OBAMapRegionManager : NSObject
 @property (nonatomic) BOOL lastRegionChangeWasProgrammatic;
 
-- (id)initWithMapView:(MKMapView*)mapView;
+- (instancetype)initWithMapView:(MKMapView*)mapView;
 
 - (void)setRegion:(MKCoordinateRegion)region;
 - (void)setRegion:(MKCoordinateRegion)region changeWasProgrammatic:(BOOL)changeWasProgrammatic;
@@ -22,8 +22,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)mapView:(MKMapView *)mapView regionWillChangeAnimated:(BOOL)animated;
 
 /**
- * @return TRUE, if applying a pending region-change request, otherwise false
+ * @return YES, if applying a pending region-change request, otherwise false
  */
+
 - (BOOL)mapView:(MKMapView *)mapView regionDidChangeAnimated:(BOOL)animated;
 
 @end

--- a/OBAKit/Location/OBAMapRegionManager.m
+++ b/OBAKit/Location/OBAMapRegionManager.m
@@ -36,7 +36,7 @@ static const double kRegionChangeRequestsTimeToLive = 3.0;
 
 @implementation OBAMapRegionManager
 
-- (id) initWithMapView:(MKMapView*)mapView {
+- (instancetype)initWithMapView:(MKMapView*)mapView {
     self = [super init];
     if (self) {
         self.mapView = mapView;
@@ -108,7 +108,7 @@ static const double kRegionChangeRequestsTimeToLive = 3.0;
 #pragma mark - Private Methods
 
 
-- (void) setMapRegion:(MKCoordinateRegion)region requestType:(OBARegionChangeRequestType)requestType {
+- (void)setMapRegion:(MKCoordinateRegion)region requestType:(OBARegionChangeRequestType)requestType {
 
     OBARegionChangeRequest * request = [[OBARegionChangeRequest alloc] initWithRegion:region type:requestType];
     [self setMapRegionWithRequest:request];

--- a/OBAKit/Location/OBARegionHelper.m
+++ b/OBAKit/Location/OBARegionHelper.m
@@ -27,10 +27,6 @@
     return self;
 }
 
-- (void)dealloc {
-    [self unregisterFromLocationNotifications];
-}
-
 - (void)updateNearestRegion {
     [self updateRegion];
     [self.locationManager startUpdatingLocation];
@@ -146,7 +142,7 @@
 - (void)setRegion {
     NSString *regionName = self.modelDAO.currentRegion.regionName;
 
-    if (!regionName) {
+    if (!regionName && self.locationManager.hasRequestedInUseAuthorization) {
         [self.delegate regionHelperShowRegionListController:self];
         return;
     }
@@ -182,11 +178,6 @@
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(locationManagerDidUpdateLocation:) name:OBALocationDidUpdateNotification object:self.locationManager];
 
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(locationManagerDidFailWithError:) name:OBALocationManagerDidFailWithErrorNotification object:self.locationManager];
-}
-
-- (void)unregisterFromLocationNotifications {
-    [[NSNotificationCenter defaultCenter] removeObserver:self name:OBALocationDidUpdateNotification object:self.locationManager];
-    [[NSNotificationCenter defaultCenter] removeObserver:self name:OBALocationManagerDidFailWithErrorNotification object:self.locationManager];
 }
 
 - (void)locationManagerDidUpdateLocation:(NSNotification*)note {

--- a/OneBusAway/ui/search/OBASearchResultsMapViewController.h
+++ b/OneBusAway/ui/search/OBASearchResultsMapViewController.h
@@ -23,6 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class OBAModelDAO;
 
 @interface OBASearchResultsMapViewController : UIViewController <OBANavigationTargetAware, OBASearchControllerDelegate, OBAProgressIndicatorDelegate>
+@property(nonatomic,strong) OBAModelDAO *modelDAO;
 @property(nonatomic,strong) OBAModelService *modelService;
 - (IBAction)updateLocation:(id)sender;
 - (IBAction)showListView:(id)sender;

--- a/OneBusAway/ui/search/OBASearchResultsMapViewController.m
+++ b/OneBusAway/ui/search/OBASearchResultsMapViewController.m
@@ -276,6 +276,13 @@ static const double kStopsInRegionRefreshDelayOnDrag = 0.1;
     return _modelService;
 }
 
+- (OBAModelDAO*)modelDAO {
+    if (!_modelDAO) {
+        _modelDAO = [OBAApplication sharedApplication].modelDao;
+    }
+    return _modelDAO;
+}
+
 #pragma mark - OBANavigationTargetAware
 
 - (OBANavigationTarget *)navigationTarget {
@@ -658,6 +665,10 @@ static const double kStopsInRegionRefreshDelayOnDrag = 0.1;
             MKCoordinateRegion region = [OBASphericalGeometryLibrary createRegionWithCenter:location.coordinate latRadius:radius lonRadius:radius];
             [self.mapRegionManager setRegion:region changeWasProgrammatic:YES];
         }
+    }
+    else if (self.modelDAO.currentRegion) {
+        MKCoordinateRegion coordinateRegion = MKCoordinateRegionForMapRect(self.modelDAO.currentRegion.serviceRect);
+        [self.mapRegionManager setRegion:coordinateRegion changeWasProgrammatic:YES];
     }
 }
 


### PR DESCRIPTION
* Fixes #792 - Incorrect region assignment
* Fixes #794 - region selection issue

-----------

* Remove unnecessary notification deregistration calls
* Only display the region picker view controller if there is no available region and the user has rejected the location service prompt
* Extend -[OBALocationManager locationServicesEnabled] so that it returns true only if the user has authorized location services
* Disable automaticallySelectRegion when location services are disabled
* Automatically set the map view's visible region to be the current region's service rect if the user's location is unavailable.