### PR TITLE
Ensure that the user always has a selected region

### DIFF
--- a/OBAKit/Location/OBALocationManager.m
+++ b/OBAKit/Location/OBALocationManager.m
@@ -112,11 +112,10 @@ NSString * const OBALocationErrorUserInfoKey = @"OBALocationErrorUserInfoKey";
 }
 
 - (void)locationManager:(CLLocationManager *)manager didFailWithError:(NSError *)error {
-    
     if (error.code == kCLErrorDenied) {
         [self stopUpdatingLocation];
-        [[NSNotificationCenter defaultCenter] postNotificationName:OBALocationManagerDidFailWithErrorNotification object:self userInfo:@{OBALocationErrorUserInfoKey: error}];
     }
+    [[NSNotificationCenter defaultCenter] postNotificationName:OBALocationManagerDidFailWithErrorNotification object:self userInfo:@{OBALocationErrorUserInfoKey: error}];
 }
 
 - (void)locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status {

--- a/OBAKit/Location/OBARegionHelper.m
+++ b/OBAKit/Location/OBARegionHelper.m
@@ -188,6 +188,7 @@
 
 - (void)locationManagerDidFailWithError:(NSNotification*)note {
     if (!self.modelDAO.currentRegion) {
+        self.modelDAO.automaticallySelectRegion = NO;
         [self.delegate regionHelperShowRegionListController:self];
     }
 }

--- a/OneBusAway/ui/regions/RegionListViewController.swift
+++ b/OneBusAway/ui/regions/RegionListViewController.swift
@@ -18,7 +18,6 @@ import SVProgressHUD
 }
 
 class RegionListViewController: OBAStaticTableViewController, RegionBuilderDelegate {
-    var currentLocation: CLLocation?
     var regions: [OBARegionV2]?
     weak var delegate: RegionListDelegate?
 
@@ -37,6 +36,8 @@ class RegionListViewController: OBAStaticTableViewController, RegionBuilderDeleg
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+
+        self.title = NSLocalizedString("Pick Your Location", comment: "Title of the Region List Controller")
 
         NotificationCenter.default.addObserver(self, selector: #selector(selectedRegionDidChange), name: NSNotification.Name.OBARegionDidUpdate, object: nil)
     }
@@ -126,13 +127,9 @@ class RegionListViewController: OBAStaticTableViewController, RegionBuilderDeleg
 
     func updateData() {
 
-        SVProgressHUD.show()
+        SVProgressHUD.show(withStatus: NSLocalizedString("Loading Regions", comment: "Progress HUD status when first locating the user on the Region List Controller"))
 
-        CLLocationManager.promise().recover { error -> CLLocation in
-            return CLLocation.init(latitude: 0, longitude: 0)
-        }.then { location -> Void in
-            self.currentLocation = location as CLLocation
-        }.then { _ in
+        firstly { _ in
             OBAApplication.shared().modelService.requestRegions()
         }.then { regions in
             self.regions = regions as? [OBARegionV2]


### PR DESCRIPTION
Fixes #810 - A region is not selected on first launch after the user authorizes location access when location data is unavailable

* Always post a notification from the `OBALocationManager` when it fails to find the user's location so that the region helper prompts the user to pick a region.
* Disable `automaticallySelectRegion` if the location manager was unable to retrieve the user's current location when we also happen to not have a region set yet. This way, the user will be able to tap entries in the region list controller when it appears.
* Remove any knowledge of the user's current location from the Region List controller. It doesn't need to know it.