### PR TITLE
Fix #826

### DIFF
--- a/OBAKit/Info.plist
+++ b/OBAKit/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.6.4</string>
+	<string>2.6.5</string>
 	<key>CFBundleVersion</key>
-	<string>20161021.16</string>
+	<string>20161025.13</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/OBAKit/Models/unmanaged/OBAReferencesV2.h
+++ b/OBAKit/Models/unmanaged/OBAReferencesV2.h
@@ -24,32 +24,24 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface OBAReferencesV2 : NSObject {
-    NSMutableDictionary * _agencies;
-    NSMutableDictionary * _routes;
-    NSMutableDictionary * _stops;
-    NSMutableDictionary * _trips;
-    NSMutableDictionary * _situations;
-}
-
-- (void) addAgency:(OBAAgencyV2*)agency;
-- (OBAAgencyV2*) getAgencyForId:(NSString*)agencyId;
+@interface OBAReferencesV2 : NSObject
+- (void)addAgency:(OBAAgencyV2*)agency;
+- (nullable OBAAgencyV2*)getAgencyForId:(NSString*)agencyId;
 - (NSDictionary*) getAllAgencies;
 
-- (void) addRoute:(OBARouteV2*)route;
-- (OBARouteV2*) getRouteForId:(NSString*)routeId;
+- (void)addRoute:(OBARouteV2*)route;
+- (nullable OBARouteV2*)getRouteForId:(NSString*)routeId;
 
-- (void) addStop:(OBAStopV2*)stop;
-- (OBAStopV2*) getStopForId:(NSString*)stopId;
+- (void)addStop:(OBAStopV2*)stop;
+- (nullable OBAStopV2*)getStopForId:(NSString*)stopId;
 
-- (void) addTrip:(OBATripV2*)trip;
-- (OBATripV2*) getTripForId:(NSString*)tripId;
+- (void)addTrip:(OBATripV2*)trip;
+- (nullable OBATripV2*)getTripForId:(NSString*)tripId;
 
-- (void) addSituation:(OBASituationV2*)situation;
-- (OBASituationV2*) getSituationForId:(NSString*)situationId;
+- (void)addSituation:(OBASituationV2*)situation;
+- (nullable OBASituationV2*)getSituationForId:(NSString*)situationId;
 
-- (void) clear;
-                             
+- (void)clear;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/OBAKit/Models/unmanaged/OBAReferencesV2.m
+++ b/OBAKit/Models/unmanaged/OBAReferencesV2.m
@@ -21,11 +21,17 @@
 #import <OBAKit/OBATripV2.h>
 #import <OBAKit/OBASituationV2.h>
 
-@implementation OBAReferencesV2
+@implementation OBAReferencesV2 {
+    NSMutableDictionary * _agencies;
+    NSMutableDictionary * _routes;
+    NSMutableDictionary * _stops;
+    NSMutableDictionary * _trips;
+    NSMutableDictionary * _situations;
+}
 
--(id) init {
+- (instancetype)init {
     self = [super init];
-    if( self ) {
+    if (self) {
         _agencies = [[NSMutableDictionary alloc] init];
         _routes = [[NSMutableDictionary alloc] init];
         _stops = [[NSMutableDictionary alloc] init];
@@ -35,28 +41,27 @@
     return self;
 }
 
-
-- (void) addAgency:(OBAAgencyV2*)agency {
+- (void)addAgency:(OBAAgencyV2*)agency {
     _agencies[agency.agencyId] = agency;
 }
 
-- (OBAAgencyV2*) getAgencyForId:(NSString*)agencyId {
+- (OBAAgencyV2*)getAgencyForId:(NSString*)agencyId {
     return _agencies[agencyId];
 }
 
-- (NSDictionary*) getAllAgencies {
-    return [NSDictionary dictionaryWithDictionary:_agencies];;
+- (NSDictionary*)getAllAgencies {
+    return [NSDictionary dictionaryWithDictionary:_agencies];
 }
 
-- (void) addRoute:(OBARouteV2*)route {
+- (void)addRoute:(OBARouteV2*)route {
     _routes[route.routeId] = route;
 }
 
-- (OBARouteV2*) getRouteForId:(NSString*)routeId {
+- (OBARouteV2*)getRouteForId:(NSString*)routeId {
     return _routes[routeId];
 }    
 
-- (void) addStop:(OBAStopV2*)stop {
+- (void)addStop:(OBAStopV2*)stop {
     _stops[stop.stopId] = stop;
 }
 

--- a/OBAKit/Models/unmanaged/OBAStopV2.m
+++ b/OBAKit/Models/unmanaged/OBAStopV2.m
@@ -164,7 +164,7 @@
 
 #pragma mark NSObject
 
-- (BOOL)isEqual:(id)object {
+- (BOOL)isEqual:(OBAStopV2*)object {
     if (self == object) {
         return YES;
     }
@@ -173,7 +173,7 @@
         return NO;
     }
 
-    return [self.stopId isEqual:[object stopId]];
+    return [self.stopId isEqual:object.stopId];
 }
 
 - (NSString*) description {

--- a/OBAKit/Models/unmanaged/OBAStopV2.m
+++ b/OBAKit/Models/unmanaged/OBAStopV2.m
@@ -84,14 +84,16 @@
 #pragma mark - Public
 
 - (NSArray<OBARouteV2*>*)routes {
-
     @synchronized (self) {
         if (!_routes) {
             NSMutableArray *routes = [NSMutableArray array];
 
             for (NSString *routeId in _routeIds) {
                 OBARouteV2 *route = [self.references getRouteForId:routeId];
-                [routes addObject:route];
+
+                if (route) {
+                    [routes addObject:route];
+                }
             }
 
             [routes sortUsingSelector:@selector(compareUsingName:)];

--- a/OneBusAway/Info.plist
+++ b/OneBusAway/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.6.4</string>
+	<string>2.6.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>20161021.16</string>
+	<string>20161025.13</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>


### PR DESCRIPTION
Check to make sure route objects exist before adding them to the array

Fixes #826 - Crash in OBAStopV2

------

Mark a number of methods that are nullable as such in OBAReferencesV2

* Hide implementation details inside the class.
* Type `-[OBAStopV2 isEqual:]`'s parameter so we can use dot notation

-------

Update the app version and bundle identifiers so we can properly kick off the OBA 2.6.5 release cycle