### PR TITLE
Remove the connections section in Arrivals and departures

### DIFF
--- a/OneBusAway/ui/trip_details/OBAArrivalAndDepartureViewController.m
+++ b/OneBusAway/ui/trip_details/OBAArrivalAndDepartureViewController.m
@@ -159,15 +159,9 @@ static NSTimeInterval const kRefreshTimeInterval = 30;
     }
 
     // Stops Section
-    OBATableSection *stopsSection = [OBATripScheduleSectionBuilder buildStopsSection:tripDetails currentStopIndex:currentStopIndex navigationController:self.navigationController];
+    OBATableSection *stopsSection = [OBATripScheduleSectionBuilder buildStopsSection:tripDetails tripInstance:arrivalAndDeparture.tripInstance currentStopIndex:currentStopIndex navigationController:self.navigationController];
     stopsSection.headerView = [self buildTableHeaderViewWithArrivalAndDeparture:arrivalAndDeparture];
     [sections addObject:stopsSection];
-
-    // Connections Section
-    OBATableSection *connectionsSection = [OBATripScheduleSectionBuilder buildConnectionsSectionWithTripDetails:tripDetails tripInstance:arrivalAndDeparture.tripInstance navigationController:self.navigationController];
-    if (connectionsSection) {
-        [sections addObject:connectionsSection];
-    }
 
     // Actions Section
     [sections addObject:[self.class createActionsSection:arrivalAndDeparture navigationController:self.navigationController]];

--- a/OneBusAway/ui/trip_details/OBATripScheduleListViewController.m
+++ b/OneBusAway/ui/trip_details/OBATripScheduleListViewController.m
@@ -101,14 +101,9 @@ typedef NS_ENUM(NSUInteger, OBASectionType) {
 - (void)buildUI {
     NSMutableArray *sections = [[NSMutableArray alloc] init];
 
-    OBATableSection *stopsSection = [OBATripScheduleSectionBuilder buildStopsSection:self.tripDetails currentStopIndex:INT_MAX navigationController:self.navigationController];
+    OBATableSection *stopsSection = [OBATripScheduleSectionBuilder buildStopsSection:self.tripDetails tripInstance:self.tripInstance currentStopIndex:INT_MAX navigationController:self.navigationController];
 
     [sections addObject:stopsSection];
-
-    if ([self.tripDetails hasTripConnections]) {
-        OBATableSection *connectionsSection = [OBATripScheduleSectionBuilder buildConnectionsSectionWithTripDetails:self.tripDetails tripInstance:self.tripInstance navigationController:self.navigationController];
-        [sections addObject:connectionsSection];
-    }
 
     self.sections = [NSArray arrayWithArray:sections];
     [self.tableView reloadData];

--- a/OneBusAway/ui/trip_details/OBATripScheduleSectionBuilder.h
+++ b/OneBusAway/ui/trip_details/OBATripScheduleSectionBuilder.h
@@ -13,9 +13,10 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface OBATripScheduleSectionBuilder : NSObject
-+ (OBATableSection*)buildStopsSection:(OBATripDetailsV2*)tripDetails currentStopIndex:(NSUInteger)currentStopIndex navigationController:(UINavigationController*)navigationController;
-+ (nullable OBATableSection*)buildConnectionsSectionWithTripDetails:(OBATripDetailsV2*)tripDetails tripInstance:(OBATripInstanceRef*)tripInstance navigationController:(UINavigationController*)navigationController;
++ (OBATableSection*)buildStopsSection:(OBATripDetailsV2*)tripDetails tripInstance:(OBATripInstanceRef*)tripInstance currentStopIndex:(NSUInteger)currentStopIndex navigationController:(UINavigationController*)navigationController;
+
 + (NSUInteger)indexOfStopID:(NSString*)stopID inSchedule:(OBATripScheduleV2*)tripSchedule;
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Fixes #841 - Get rid of the connections section in OBAArrivalAndDepartureViewController

Move connections to the beginning and end of the list of stops for a given trip