### PR TITLE
Fix analytics

### DIFF
--- a/OBAKit/Helpers/OBACommon.h
+++ b/OBAKit/Helpers/OBACommon.h
@@ -27,6 +27,9 @@ extern NSString * const kApplicationShortcutMap;
 extern NSString * const kApplicationShortcutRecents;
 extern NSString * const kApplicationShortcutBookmarks;
 
+// User Defaults Keys
+extern NSString * const OBAOptInToTrackingDefaultsKey;
+
 /**
  We report "YES" and "NO" to Google Analytics in several places. This method
  DRYs those up.

--- a/OBAKit/Helpers/OBACommon.m
+++ b/OBAKit/Helpers/OBACommon.m
@@ -24,6 +24,8 @@ NSString * const kApplicationShortcutMap = @"org.onebusaway.iphone.shortcut.map"
 NSString * const kApplicationShortcutRecents = @"org.onebusaway.iphone.shortcut.recents";
 NSString * const kApplicationShortcutBookmarks = @"org.onebusaway.iphone.shortcut.bookmarks";
 
+NSString * const OBAOptInToTrackingDefaultsKey = @"OBAOptInToTrackingDefaultsKey";
+
 const NSInteger kOBAErrorDuplicateEntity = 1000;
 const NSInteger kOBAErrorMissingFieldInData = 1001;
 

--- a/OneBusAway/OBAApplicationDelegate.m
+++ b/OneBusAway/OBAApplicationDelegate.m
@@ -36,7 +36,6 @@
 #import "EXTScope.h"
 
 static NSString *const kTrackingId = @"UA-2423527-17";
-static NSString *const kOptOutOfTracking = @"OptOutOfTracking";
 static NSString *const kApptentiveKey = @"3363af9a6661c98dec30fedea451a06dd7d7bc9f70ef38378a9d5a15ac7d4926";
 
 @interface OBAApplicationDelegate () <OBABackgroundTaskExecutor, OBARegionHelperDelegate, RegionListDelegate>
@@ -69,7 +68,7 @@ static NSString *const kApptentiveKey = @"3363af9a6661c98dec30fedea451a06dd7d7bc
 
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(reachabilityChanged:) name:kReachabilityChangedNotification object:nil];
 
-        NSDictionary *appDefaults = @{ kOptOutOfTracking: @(NO) };
+        NSDictionary *appDefaults = @{ OBAOptInToTrackingDefaultsKey: @(YES) };
         [[OBAApplication sharedApplication] startWithAppDefaults:appDefaults];
 
         [OBAApplication sharedApplication].regionHelper.delegate = self;
@@ -130,7 +129,7 @@ static NSString *const kApptentiveKey = @"3363af9a6661c98dec30fedea451a06dd7d7bc
     [Apptentive sharedConnection].APIKey = kApptentiveKey;
 
     // Set up Google Analytics. User must be able to opt out of tracking.
-    [GAI sharedInstance].optOut = ![[NSUserDefaults standardUserDefaults] boolForKey:kOptOutOfTracking];
+    [GAI sharedInstance].optOut = ![[NSUserDefaults standardUserDefaults] boolForKey:OBAOptInToTrackingDefaultsKey];
     [GAI sharedInstance].trackUncaughtExceptions = YES;
     [GAI sharedInstance].logger.logLevel = kGAILogLevelWarning;
 
@@ -161,7 +160,7 @@ static NSString *const kApptentiveKey = @"3363af9a6661c98dec30fedea451a06dd7d7bc
 
     [self.applicationUI applicationDidBecomeActive];
 
-    [GAI sharedInstance].optOut = [[NSUserDefaults standardUserDefaults] boolForKey:kOptOutOfTracking];
+    [GAI sharedInstance].optOut = ![[NSUserDefaults standardUserDefaults] boolForKey:OBAOptInToTrackingDefaultsKey];
 
     NSString *label = [NSString stringWithFormat:@"API Region: %@", [OBAApplication sharedApplication].modelDao.currentRegion.regionName];
 

--- a/OneBusAway/ui/info/OBAInfoViewController.m
+++ b/OneBusAway/ui/info/OBAInfoViewController.m
@@ -11,6 +11,7 @@
 @import Masonry;
 
 #import "OBAAgenciesListViewController.h"
+#import "OBASettingsViewController.h"
 #import "OBACreditsViewController.h"
 #import "OBAAnalytics.h"
 #import "Apptentive.h"
@@ -41,6 +42,8 @@ static NSString * const kPrivacyURLString = @"http://onebusaway.org/privacy/";
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+
+    self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Settings", @"Settings bar button item title on the info view controller.") style:UIBarButtonItemStylePlain target:self action:@selector(showSettings)];
 
     UIView *header = [self buildTableHeaderView];
     [self setTableViewHeader:header];
@@ -236,6 +239,13 @@ static NSString * const kPrivacyURLString = @"http://onebusaway.org/privacy/";
 }
 
 #pragma mark - Private
+
+- (void)showSettings {
+    OBASettingsViewController *settings = [[OBASettingsViewController alloc] init];
+    UINavigationController *navigation = [[UINavigationController alloc] initWithRootViewController:settings];
+
+    [self presentViewController:navigation animated:YES completion:nil];
+}
 
 - (void)presentApptentiveMessageCenter {
     // Information that cannot be used to uniquely identify the user is shared automatically.

--- a/OneBusAway/ui/info/OBASettingsViewController.h
+++ b/OneBusAway/ui/info/OBASettingsViewController.h
@@ -1,0 +1,13 @@
+//
+//  OBASettingsViewController.h
+//  org.onebusaway.iphone
+//
+//  Created by Aaron Brethorst on 11/6/16.
+//  Copyright © 2016 OneBusAway. All rights reserved.
+//
+
+#import "OBAStaticTableViewController.h"
+
+@interface OBASettingsViewController : OBAStaticTableViewController
+
+@end

--- a/OneBusAway/ui/info/OBASettingsViewController.m
+++ b/OneBusAway/ui/info/OBASettingsViewController.m
@@ -1,0 +1,52 @@
+//
+//  OBASettingsViewController.m
+//  org.onebusaway.iphone
+//
+//  Created by Aaron Brethorst on 11/6/16.
+//  Copyright © 2016 OneBusAway. All rights reserved.
+//
+
+#import "OBASettingsViewController.h"
+@import OBAKit;
+#import "OBASwitchRow.h"
+
+@interface OBASettingsViewController ()
+
+@end
+
+@implementation OBASettingsViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+    self.title = NSLocalizedString(@"Settings", @"title of OBASettingsViewController");
+
+    self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(close)];
+
+    [self loadData];
+}
+
+#pragma mark - Actions
+
+- (void)close {
+    [self.navigationController dismissViewControllerAnimated:YES completion:nil];
+}
+
+#pragma mark - Data Loading
+
+- (void)loadData {
+    OBATableSection *analyticsSection = [[OBATableSection alloc] initWithTitle:nil];
+
+    BOOL analyticsValue = [[NSUserDefaults standardUserDefaults] boolForKey:OBAOptInToTrackingDefaultsKey];
+    OBASwitchRow *switchRow = [[OBASwitchRow alloc] initWithTitle:NSLocalizedString(@"Enable Google Analytics", @"A switch option's text for enabling and disabling Google Analytics") action:^{
+        [[NSUserDefaults standardUserDefaults] setBool:!analyticsValue forKey:OBAOptInToTrackingDefaultsKey];
+    } switchValue:analyticsValue];
+    [analyticsSection addRow:switchRow];
+
+    analyticsSection.footerView = [OBAUIBuilder footerViewWithText:NSLocalizedString(@"Some information about how you use this app is sent to Google Analytics in non-personally identifiable form to help us better understand how to improve the app. To learn more, please read our Privacy Policy.", @"Analytics explanation on the Settings view controller.") maximumWidth:CGRectGetWidth(self.tableView.frame)];
+
+    self.sections = @[analyticsSection];
+    [self.tableView reloadData];
+}
+
+@end

--- a/org.onebusaway.iphone.xcodeproj/project.pbxproj
+++ b/org.onebusaway.iphone.xcodeproj/project.pbxproj
@@ -172,6 +172,7 @@
 		9359D1281DB92B4200CABFBD /* OBAModelService_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9359D1271DB92B4200CABFBD /* OBAModelService_Tests.m */; };
 		93631E4C1604F96800CB7209 /* OBAApplicationDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 93631E4B1604F96800CB7209 /* OBAApplicationDelegate.m */; };
 		9368E5C01DB1584900C329D0 /* OBAEmptyDataSetSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 9368E5BF1DB1584900C329D0 /* OBAEmptyDataSetSource.m */; };
+		9385EC3B1DCF14C60020CCB2 /* OBASettingsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 9385EC3A1DCF14C60020CCB2 /* OBASettingsViewController.m */; };
 		938B842C1D868A0500DB0AF0 /* GoogleAnalytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 938B84241D8689E900DB0AF0 /* GoogleAnalytics.framework */; };
 		938B84361D868A0500DB0AF0 /* DZNEmptyDataSet.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 938B84311D868A0500DB0AF0 /* DZNEmptyDataSet.framework */; };
 		938B84381D868A0500DB0AF0 /* SVProgressHUD.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 938B84331D868A0500DB0AF0 /* SVProgressHUD.framework */; };
@@ -502,6 +503,8 @@
 		9368E5BE1DB1584900C329D0 /* OBAEmptyDataSetSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAEmptyDataSetSource.h; sourceTree = "<group>"; };
 		9368E5BF1DB1584900C329D0 /* OBAEmptyDataSetSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAEmptyDataSetSource.m; sourceTree = "<group>"; };
 		936F45D91C78D06600C61656 /* OneBusAwayTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OneBusAwayTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		9385EC391DCF14C60020CCB2 /* OBASettingsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBASettingsViewController.h; sourceTree = "<group>"; };
+		9385EC3A1DCF14C60020CCB2 /* OBASettingsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBASettingsViewController.m; sourceTree = "<group>"; };
 		938B84241D8689E900DB0AF0 /* GoogleAnalytics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GoogleAnalytics.framework; path = Carthage/Build/iOS/GoogleAnalytics.framework; sourceTree = "<group>"; };
 		938B84311D868A0500DB0AF0 /* DZNEmptyDataSet.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = DZNEmptyDataSet.framework; path = Carthage/Build/iOS/DZNEmptyDataSet.framework; sourceTree = "<group>"; };
 		938B84331D868A0500DB0AF0 /* SVProgressHUD.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SVProgressHUD.framework; path = Carthage/Build/iOS/SVProgressHUD.framework; sourceTree = "<group>"; };
@@ -733,6 +736,8 @@
 				934197041DB0C13F004BBBB7 /* OBACreditsViewController.xib */,
 				934197051DB0C13F004BBBB7 /* OBAInfoViewController.h */,
 				934197061DB0C13F004BBBB7 /* OBAInfoViewController.m */,
+				9385EC391DCF14C60020CCB2 /* OBASettingsViewController.h */,
+				9385EC3A1DCF14C60020CCB2 /* OBASettingsViewController.m */,
 			);
 			path = info;
 			sourceTree = "<group>";
@@ -1537,6 +1542,7 @@
 				9341978E1DB0C140004BBBB7 /* OBASearchController.m in Sources */,
 				934197EE1DB0C14C004BBBB7 /* SMFloatingLabelTextField.m in Sources */,
 				9341981B1DB0C1BA004BBBB7 /* OBAProgressIndicatorView.m in Sources */,
+				9385EC3B1DCF14C60020CCB2 /* OBASettingsViewController.m in Sources */,
 				934197EA1DB0C14C004BBBB7 /* PulleyPassthroughScrollView.swift in Sources */,
 				934197B81DB0C140004BBBB7 /* OBAArrivalAndDepartureViewController.m in Sources */,
 				9341978C1DB0C140004BBBB7 /* RegionBuilderViewController.swift in Sources */,


### PR DESCRIPTION
(and give users a way to opt out of analytics again too)

Fixes #849 - Investigate drop-off in analytics numbers

* At some point, the ‘opt out of analytics’ flag ended up always being set to true. Doh, my bad. I’ve fixed this, and renamed it so that we can avoid not not having double negatives.
* Add a ‘Settings’ view controller to consolidate all of the toggles we have to have in the app.
* Make it possible to get to Settings from the Info tab