### PR TITLE
Show the user which buses they can reach before departure

### DIFF
--- a/OBAKit/Helpers/OBACanvasView.h
+++ b/OBAKit/Helpers/OBACanvasView.h
@@ -6,7 +6,7 @@
 //  Copyright © 2016 OneBusAway. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
+@import UIKit;
 
 @interface OBACanvasView : UIView
 

--- a/OBAKit/Helpers/OBACanvasView.m
+++ b/OBAKit/Helpers/OBACanvasView.m
@@ -6,7 +6,7 @@
 //  Copyright © 2016 OneBusAway. All rights reserved.
 //
 
-#import "OBACanvasView.h"
+#import <OBAKit/OBACanvasView.h>
 
 // This is a lightweight view derived from UIView to offer only an opportunity
 // to have a custom drawRect implementation with a reusable class rather than

--- a/OBAKit/Helpers/OBAWalkingDirections.h
+++ b/OBAKit/Helpers/OBAWalkingDirections.h
@@ -1,0 +1,22 @@
+//
+//  OBAWalkingDirections.h
+//  OBAKit
+//
+//  Created by Aaron Brethorst on 11/7/16.
+//  Copyright © 2016 OneBusAway. All rights reserved.
+//
+
+@import Foundation;
+@import CoreLocation;
+@import PromiseKit;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface OBAWalkingDirections : NSObject
+/**
+ Resolves to an MKETAResponse object.
+ */
++ (AnyPromise*)requestWalkingETA:(CLLocationCoordinate2D)destination;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/OBAKit/Helpers/OBAWalkingDirections.m
+++ b/OBAKit/Helpers/OBAWalkingDirections.m
@@ -1,0 +1,56 @@
+//
+//  OBAWalkingDirections.m
+//  OBAKit
+//
+//  Created by Aaron Brethorst on 11/7/16.
+//  Copyright © 2016 OneBusAway. All rights reserved.
+//
+
+#import <OBAKit/OBAWalkingDirections.h>
+@import MapKit;
+@import PMKCoreLocation;
+@import PMKMapKit;
+
+@implementation OBAWalkingDirections
+
++ (AnyPromise*)requestWalkingETA:(CLLocationCoordinate2D)destination {
+    __block NSUInteger iterations = 0;
+    return [AnyPromise promiseWithResolverBlock:^(PMKResolver resolve) {
+        [CLLocationManager until:^BOOL(CLLocation *location) {
+            iterations += 1;
+            if (iterations >= 5) {
+                return YES;
+            }
+            else {
+                return location.horizontalAccuracy <= kCLLocationAccuracyNearestTenMeters;
+            }
+        }].thenInBackground(^(CLLocation* currentLocation) {
+            MKPlacemark *sourcePlacemark = [self.class placemarkForCoordinate:currentLocation.coordinate];
+            MKPlacemark *destinationPlacemark = [self.class placemarkForCoordinate:destination];
+            MKDirections *directions = [self.class walkingDirectionsFrom:sourcePlacemark to:destinationPlacemark];
+            return [directions calculateETA];
+        }).then(^(MKETAResponse* ETA) {
+            resolve(ETA);
+        }).catch(^(NSError *error) {
+            resolve(error);
+        }).always(^{
+            iterations = 0;
+        });
+    }];
+}
+
++ (MKPlacemark*)placemarkForCoordinate:(CLLocationCoordinate2D)coordinate {
+    return [[MKPlacemark alloc] initWithCoordinate:coordinate addressDictionary:nil];
+}
+
++ (MKDirections*)walkingDirectionsFrom:(MKPlacemark*)fromPlacemark to:(MKPlacemark*)toPlacemark {
+    return [[MKDirections alloc] initWithRequest:({
+        MKDirectionsRequest *r = [[MKDirectionsRequest alloc] init];
+        r.source = [[MKMapItem alloc] initWithPlacemark:fromPlacemark];
+        r.destination = [[MKMapItem alloc] initWithPlacemark:toPlacemark];
+        r.transportType = MKDirectionsTransportTypeWalking;
+        r;
+    })];
+}
+
+@end

--- a/OBAKit/Models/unmanaged/OBAArrivalAndDepartureV2.h
+++ b/OBAKit/Models/unmanaged/OBAArrivalAndDepartureV2.h
@@ -109,6 +109,13 @@ typedef NS_ENUM(NSUInteger, OBAArrivalDepartureState) {
  */
 - (NSInteger)minutesUntilBestDeparture;
 
+/**
+ How far away are we right now from the best departure time available to us? Uses real time data when available, and scheduled data otherwise.
+
+ @return The number of seconds until departure.
+ */
+- (NSTimeInterval)timeIntervalUntilBestDeparture;
+
 - (NSComparisonResult)compareRouteName:(OBAArrivalAndDepartureV2*)dep;
 
 /**

--- a/OBAKit/Models/unmanaged/OBAArrivalAndDepartureV2.m
+++ b/OBAKit/Models/unmanaged/OBAArrivalAndDepartureV2.m
@@ -52,7 +52,7 @@
 - (NSString*)tripHeadsign {
 
     NSString *headsign = nil;
-    
+
     OBATripV2 *trip = self.trip;
     OBARouteV2 *route = trip.route;
 
@@ -206,8 +206,12 @@
     return [OBADateHelpers dateWithMillisecondsSince1970:self.bestDepartureTime];
 }
 
+- (NSTimeInterval)timeIntervalUntilBestDeparture {
+    return self.bestDeparture.timeIntervalSinceNow;
+}
+
 - (NSInteger)minutesUntilBestDeparture {
-    return (NSInteger)(self.bestDeparture.timeIntervalSinceNow / 60.0);
+    return (NSInteger)(self.timeIntervalUntilBestDeparture / 60.0);
 }
 
 - (NSString*)statusText {

--- a/OBAKit/OBAKit.h
+++ b/OBAKit/OBAKit.h
@@ -101,4 +101,5 @@ FOUNDATION_EXPORT const unsigned char OBAKitVersionString[];
 #import <OBAKit/OBAUser.h>
 #import <OBAKit/OBAVehicleMapAnnotation.h>
 #import <OBAKit/OBAVehicleStatusV2.h>
+#import <OBAKit/OBAWalkingDirections.h>
 #import <OBAKit/UILabel+OBAAdditions.h>

--- a/OBAKit/OBAKit.xcodeproj/project.pbxproj
+++ b/OBAKit/OBAKit.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		5B7C4A641DB96E8200853DD5 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5B7C4A661DB96E8200853DD5 /* Localizable.strings */; };
 		5B7C4A691DB96E8300853DD5 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5B7C4A6B1DB96E8300853DD5 /* InfoPlist.strings */; };
 		930AFE901DD0717A0092AE82 /* Array+Functional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 930AFE8F1DD0717A0092AE82 /* Array+Functional.swift */; };
+		930AFE9E1DD183720092AE82 /* OBAWalkingDirections.h in Headers */ = {isa = PBXBuildFile; fileRef = 930AFE9C1DD183720092AE82 /* OBAWalkingDirections.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		930AFE9F1DD183720092AE82 /* OBAWalkingDirections.m in Sources */ = {isa = PBXBuildFile; fileRef = 930AFE9D1DD183720092AE82 /* OBAWalkingDirections.m */; };
 		932CCED01DC3D315001C8405 /* CocoaLumberjack.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 932CCECA1DC3D315001C8405 /* CocoaLumberjack.framework */; };
 		932CCED11DC3D315001C8405 /* CocoaLumberjackSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 932CCECB1DC3D315001C8405 /* CocoaLumberjackSwift.framework */; };
 		932CCED21DC3D315001C8405 /* PMKCoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 932CCECC1DC3D315001C8405 /* PMKCoreLocation.framework */; };
@@ -220,6 +222,8 @@
 		5B7C4A651DB96E8200853DD5 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
 		5B7C4A6A1DB96E8300853DD5 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		930AFE8F1DD0717A0092AE82 /* Array+Functional.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+Functional.swift"; sourceTree = "<group>"; };
+		930AFE9C1DD183720092AE82 /* OBAWalkingDirections.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAWalkingDirections.h; sourceTree = "<group>"; };
+		930AFE9D1DD183720092AE82 /* OBAWalkingDirections.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAWalkingDirections.m; sourceTree = "<group>"; };
 		932CCECA1DC3D315001C8405 /* CocoaLumberjack.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CocoaLumberjack.framework; path = ../Carthage/Build/iOS/CocoaLumberjack.framework; sourceTree = "<group>"; };
 		932CCECB1DC3D315001C8405 /* CocoaLumberjackSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CocoaLumberjackSwift.framework; path = ../Carthage/Build/iOS/CocoaLumberjackSwift.framework; sourceTree = "<group>"; };
 		932CCECC1DC3D315001C8405 /* PMKCoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PMKCoreLocation.framework; path = ../Carthage/Build/iOS/PMKCoreLocation.framework; sourceTree = "<group>"; };
@@ -537,6 +541,8 @@
 				934195781DB0B099004BBBB7 /* OBAUser.m */,
 				932CCEE01DC40221001C8405 /* OBADeepLinkRouter.h */,
 				932CCEE11DC40221001C8405 /* OBADeepLinkRouter.m */,
+				930AFE9C1DD183720092AE82 /* OBAWalkingDirections.h */,
+				930AFE9D1DD183720092AE82 /* OBAWalkingDirections.m */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -839,6 +845,7 @@
 				934196761DB0B099004BBBB7 /* OBASearchResult.h in Headers */,
 				9341960E1DB0B099004BBBB7 /* OBAMapHelpers.h in Headers */,
 				9341964F1DB0B099004BBBB7 /* OBAArrivalsAndDeparturesForStopV2.h in Headers */,
+				930AFE9E1DD183720092AE82 /* OBAWalkingDirections.h in Headers */,
 				934196091DB0B099004BBBB7 /* OBAImageHelpers.h in Headers */,
 				934196281DB0B099004BBBB7 /* OBATripContinuationMapAnnotation.h in Headers */,
 				934196551DB0B099004BBBB7 /* OBACoordinateBounds.h in Headers */,
@@ -1047,6 +1054,7 @@
 				934196061DB0B099004BBBB7 /* OBADateHelpers.m in Sources */,
 				934196771DB0B099004BBBB7 /* OBASearchResult.m in Sources */,
 				934196381DB0B099004BBBB7 /* OBAJsonDigester.m in Sources */,
+				930AFE9F1DD183720092AE82 /* OBAWalkingDirections.m in Sources */,
 				934196AF1DB0B0AF004BBBB7 /* OBADataSourceConfig.m in Sources */,
 				9341964E1DB0B099004BBBB7 /* OBAArrivalAndDepartureV2.m in Sources */,
 				934196421DB0B099004BBBB7 /* OBASetNextOBAJsonDigesterRule.m in Sources */,

--- a/OneBusAway/ui/static_table/OBAStaticTableViewController.h
+++ b/OneBusAway/ui/static_table/OBAStaticTableViewController.h
@@ -55,6 +55,15 @@ typedef NS_ENUM(NSUInteger, OBARootViewStyle) {
 - (void)deleteRowAtIndexPath:(NSIndexPath*)indexPath;
 
 /**
+ Inserts a new row into the table view, optionally with animation.
+
+ @param row An instance or subclass of OBABaseRow that will be inserted into the table's data.
+ @param indexPath The index path where the row will be inserted.
+ @param animation The desired insertion animation
+ */
+- (void)insertRow:(OBABaseRow*)row atIndexPath:(NSIndexPath*)indexPath animation:(UITableViewRowAnimation)animation;
+
+/**
  returns the index path for the row that contains a link
  to the specified model.
 

--- a/OneBusAway/ui/static_table/OBAStaticTableViewController.m
+++ b/OneBusAway/ui/static_table/OBAStaticTableViewController.m
@@ -106,13 +106,17 @@
 #pragma mark - Public Methods
 
 - (OBABaseRow*)rowAtIndexPath:(NSIndexPath*)indexPath {
-    OBAGuard(indexPath && indexPath.section < self.sections.count) else {
+    OBAGuard(indexPath) else {
+        return nil;
+    }
+
+    if (indexPath.section >= self.sections.count) {
         return nil;
     }
 
     OBATableSection *section = self.sections[indexPath.section];
 
-    OBAGuard(indexPath.row < section.rows.count) else {
+    if (indexPath.row >= section.rows.count) {
         return nil;
     }
 
@@ -185,6 +189,24 @@
     tableRow.deleteModel(tableRow);
 
     [self.tableView deleteRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
+}
+
+- (void)insertRow:(OBABaseRow*)row atIndexPath:(NSIndexPath*)indexPath animation:(UITableViewRowAnimation)animation {
+    OBAGuard(row && indexPath) else {
+        return;
+    }
+
+    OBAGuard(indexPath.section < self.sections.count) else {
+        return;
+    }
+
+    OBATableSection *section = self.sections[indexPath.section];
+    NSMutableArray *rows = [NSMutableArray arrayWithArray:section.rows];
+
+    [rows insertObject:row atIndex:MIN(indexPath.row, section.rows.count)];
+    section.rows = [NSArray arrayWithArray:rows];
+
+    [self.tableView insertRowsAtIndexPaths:@[indexPath] withRowAnimation:animation];
 }
 
 #pragma mark - UITableView Section Headers

--- a/OneBusAway/ui/static_table/viewmodels/OBATableSection.h
+++ b/OneBusAway/ui/static_table/viewmodels/OBATableSection.h
@@ -42,6 +42,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property(nonatomic,weak,nullable) id model;
 
+/**
+ An arbitrary piece of data that you can associate with a table section object to help you identify it later.
+ */
+@property(nonatomic,assign) NSInteger tag;
+
 + (instancetype)tableSectionWithTitle:(nullable NSString*)title rows:(NSArray*)rows;
 - (instancetype)initWithTitle:(nullable NSString*)title rows:(nullable NSArray*)rows NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithTitle:(nullable NSString*)title;

--- a/OneBusAway/ui/stops/viewmodels/OBAWalkableRow.h
+++ b/OneBusAway/ui/stops/viewmodels/OBAWalkableRow.h
@@ -1,0 +1,13 @@
+//
+//  OBAWalkableRow.h
+//  org.onebusaway.iphone
+//
+//  Created by Aaron Brethorst on 11/7/16.
+//  Copyright © 2016 OneBusAway. All rights reserved.
+//
+
+#import "OBABaseRow.h"
+
+@interface OBAWalkableRow : OBABaseRow
+
+@end

--- a/OneBusAway/ui/stops/viewmodels/OBAWalkableRow.m
+++ b/OneBusAway/ui/stops/viewmodels/OBAWalkableRow.m
@@ -1,0 +1,29 @@
+//
+//  OBAWalkableRow.m
+//  org.onebusaway.iphone
+//
+//  Created by Aaron Brethorst on 11/7/16.
+//  Copyright © 2016 OneBusAway. All rights reserved.
+//
+
+#import "OBAWalkableRow.h"
+#import "OBAViewModelRegistry.h"
+#import "OBAWalkableCell.h"
+
+@implementation OBAWalkableRow
+
++ (void)load {
+    [OBAViewModelRegistry registerClass:self.class];
+}
+
+- (id)copyWithZone:(NSZone *)zone {
+    OBAWalkableRow *row = [super copyWithZone:zone];
+
+    return row;
+}
+
++ (void)registerViewsWithTableView:(UITableView*)tableView {
+    [tableView registerClass:[OBAWalkableCell class] forCellReuseIdentifier:[self cellReuseIdentifier]];
+}
+
+@end

--- a/OneBusAway/ui/stops/views/OBAStopTableHeaderView.h
+++ b/OneBusAway/ui/stops/views/OBAStopTableHeaderView.h
@@ -1,5 +1,5 @@
 //
-//  OBAParallaxTableHeaderView.h
+//  OBAStopTableHeaderView.h
 //  org.onebusaway.iphone
 //
 //  Created by Aaron Brethorst on 3/4/16.
@@ -7,10 +7,16 @@
 //
 
 @import UIKit;
+@import MapKit;
+
+NS_ASSUME_NONNULL_BEGIN
 
 @class OBAArrivalsAndDeparturesForStopV2;
 
-@interface OBAParallaxTableHeaderView : UIView
+@interface OBAStopTableHeaderView : UIView
 @property(nonatomic,assign) BOOL highContrastMode;
+@property(nonatomic,strong,nullable) MKETAResponse *walkingETA;
 - (void)populateTableHeaderFromArrivalsAndDeparturesModel:(OBAArrivalsAndDeparturesForStopV2*)result;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/OneBusAway/ui/stops/views/OBAWalkableCell.h
+++ b/OneBusAway/ui/stops/views/OBAWalkableCell.h
@@ -1,0 +1,14 @@
+//
+//  OBAWalkableCell.h
+//  org.onebusaway.iphone
+//
+//  Created by Aaron Brethorst on 11/7/16.
+//  Copyright © 2016 OneBusAway. All rights reserved.
+//
+
+@import UIKit;
+#import "OBATableCell.h"
+
+@interface OBAWalkableCell : UITableViewCell<OBATableCell>
+
+@end

--- a/OneBusAway/ui/stops/views/OBAWalkableCell.m
+++ b/OneBusAway/ui/stops/views/OBAWalkableCell.m
@@ -1,0 +1,66 @@
+//
+//  OBAWalkableCell.m
+//  org.onebusaway.iphone
+//
+//  Created by Aaron Brethorst on 11/7/16.
+//  Copyright © 2016 OneBusAway. All rights reserved.
+//
+
+#import "OBAWalkableCell.h"
+@import OBAKit;
+@import Masonry;
+#import "OBAAnimation.h"
+
+@interface OBAWalkableCell ()
+@property(nonatomic,strong) OBACanvasView *triangleView;
+@property(nonatomic,strong) UIImageView *walkImageView;
+@end
+
+@implementation OBAWalkableCell
+@synthesize tableRow;
+
+- (instancetype)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier {
+    self = [super initWithStyle:style reuseIdentifier:reuseIdentifier];
+
+    if (self) {
+        self.selectionStyle = UITableViewCellSelectionStyleNone;
+        UIColor *backgroundColor = [OBATheme OBAGreen];
+
+        CGFloat barHeight = [OBATheme defaultPadding];
+        CGFloat triangleWidth = 30.f;
+        CGFloat triangleHeight = 15.f;
+
+        [self.contentView mas_makeConstraints:^(MASConstraintMaker *make) {
+            make.height.equalTo(@(barHeight+triangleHeight));
+        }];
+
+        CGFloat yPoint = 0.f;
+
+        _triangleView = [[OBACanvasView alloc] initWithFrame:CGRectMake(self.layoutMargins.left, [OBATheme defaultPadding], triangleWidth, triangleHeight) drawRectBlock:^(CGRect rect) {
+            UIBezierPath *path = [UIBezierPath bezierPath];
+            [path moveToPoint:CGPointMake(0, yPoint)];
+            [path addLineToPoint:CGPointMake(triangleWidth/2.f, triangleHeight)];
+            [path addLineToPoint:CGPointMake(triangleWidth, yPoint)];
+            [path closePath];
+            [backgroundColor set];
+            [path fill];
+        }];
+        [self addSubview:_triangleView];
+
+        UIView *barView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, CGRectGetWidth(self.frame), barHeight)];
+        barView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
+        barView.backgroundColor = backgroundColor;
+        [self addSubview:barView];
+
+        UIImage *walkImage = [[UIImage imageNamed:@"walkTransport"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+        _walkImageView = [[UIImageView alloc] initWithImage:walkImage];
+        _walkImageView.tintColor = [UIColor whiteColor];
+        _walkImageView.contentMode = UIViewContentModeScaleAspectFit;
+        _walkImageView.frame = CGRectMake(self.layoutMargins.left + 8, 2, triangleHeight, triangleHeight);
+        [self addSubview:_walkImageView];
+    }
+
+    return self;
+}
+
+@end

--- a/org.onebusaway.iphone.xcodeproj/project.pbxproj
+++ b/org.onebusaway.iphone.xcodeproj/project.pbxproj
@@ -17,8 +17,10 @@
 		930AFE891DD04D2F0092AE82 /* OBAClassicDepartureView.m in Sources */ = {isa = PBXBuildFile; fileRef = 930AFE801DD04D2F0092AE82 /* OBAClassicDepartureView.m */; };
 		930AFE8A1DD04D2F0092AE82 /* OBADepartureCellHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 930AFE821DD04D2F0092AE82 /* OBADepartureCellHelpers.m */; };
 		930AFE8B1DD04D2F0092AE82 /* OBADepartureTimeLabel.m in Sources */ = {isa = PBXBuildFile; fileRef = 930AFE841DD04D2F0092AE82 /* OBADepartureTimeLabel.m */; };
-		930AFE8C1DD04D2F0092AE82 /* OBAParallaxTableHeaderView.m in Sources */ = {isa = PBXBuildFile; fileRef = 930AFE861DD04D2F0092AE82 /* OBAParallaxTableHeaderView.m */; };
+		930AFE8C1DD04D2F0092AE82 /* OBAStopTableHeaderView.m in Sources */ = {isa = PBXBuildFile; fileRef = 930AFE861DD04D2F0092AE82 /* OBAStopTableHeaderView.m */; };
 		930AFE8E1DD04D3D0092AE82 /* NearbyStopsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 930AFE8D1DD04D3D0092AE82 /* NearbyStopsViewController.swift */; };
+		930AFE961DD11ECB0092AE82 /* OBAWalkableRow.m in Sources */ = {isa = PBXBuildFile; fileRef = 930AFE951DD11ECB0092AE82 /* OBAWalkableRow.m */; };
+		930AFE991DD11EF90092AE82 /* OBAWalkableCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 930AFE981DD11EF90092AE82 /* OBAWalkableCell.m */; };
 		932CCEC31DC3D2DB001C8405 /* CocoaLumberjack.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 932CCEBC1DC3D2DB001C8405 /* CocoaLumberjack.framework */; };
 		932CCEC41DC3D2DB001C8405 /* CocoaLumberjackSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 932CCEBD1DC3D2DB001C8405 /* CocoaLumberjackSwift.framework */; };
 		932CCEC51DC3D2DB001C8405 /* PMKCoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 932CCEBE1DC3D2DB001C8405 /* PMKCoreLocation.framework */; };
@@ -256,9 +258,13 @@
 		930AFE821DD04D2F0092AE82 /* OBADepartureCellHelpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBADepartureCellHelpers.m; sourceTree = "<group>"; };
 		930AFE831DD04D2F0092AE82 /* OBADepartureTimeLabel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBADepartureTimeLabel.h; sourceTree = "<group>"; };
 		930AFE841DD04D2F0092AE82 /* OBADepartureTimeLabel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBADepartureTimeLabel.m; sourceTree = "<group>"; };
-		930AFE851DD04D2F0092AE82 /* OBAParallaxTableHeaderView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAParallaxTableHeaderView.h; sourceTree = "<group>"; };
-		930AFE861DD04D2F0092AE82 /* OBAParallaxTableHeaderView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAParallaxTableHeaderView.m; sourceTree = "<group>"; };
+		930AFE851DD04D2F0092AE82 /* OBAStopTableHeaderView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAStopTableHeaderView.h; sourceTree = "<group>"; };
+		930AFE861DD04D2F0092AE82 /* OBAStopTableHeaderView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAStopTableHeaderView.m; sourceTree = "<group>"; };
 		930AFE8D1DD04D3D0092AE82 /* NearbyStopsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NearbyStopsViewController.swift; sourceTree = "<group>"; };
+		930AFE941DD11ECB0092AE82 /* OBAWalkableRow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAWalkableRow.h; sourceTree = "<group>"; };
+		930AFE951DD11ECB0092AE82 /* OBAWalkableRow.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAWalkableRow.m; sourceTree = "<group>"; };
+		930AFE971DD11EF90092AE82 /* OBAWalkableCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAWalkableCell.h; sourceTree = "<group>"; };
+		930AFE981DD11EF90092AE82 /* OBAWalkableCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAWalkableCell.m; sourceTree = "<group>"; };
 		932CCEBC1DC3D2DB001C8405 /* CocoaLumberjack.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CocoaLumberjack.framework; path = Carthage/Build/iOS/CocoaLumberjack.framework; sourceTree = "<group>"; };
 		932CCEBD1DC3D2DB001C8405 /* CocoaLumberjackSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CocoaLumberjackSwift.framework; path = Carthage/Build/iOS/CocoaLumberjackSwift.framework; sourceTree = "<group>"; };
 		932CCEBE1DC3D2DB001C8405 /* PMKCoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PMKCoreLocation.framework; path = Carthage/Build/iOS/PMKCoreLocation.framework; sourceTree = "<group>"; };
@@ -640,6 +646,8 @@
 				930AFE751DD04CCA0092AE82 /* OBADepartureRow.m */,
 				930AFE761DD04CCA0092AE82 /* OBAUpcomingDeparture.h */,
 				930AFE771DD04CCA0092AE82 /* OBAUpcomingDeparture.m */,
+				930AFE941DD11ECB0092AE82 /* OBAWalkableRow.h */,
+				930AFE951DD11ECB0092AE82 /* OBAWalkableRow.m */,
 			);
 			path = viewmodels;
 			sourceTree = "<group>";
@@ -655,8 +663,10 @@
 				930AFE821DD04D2F0092AE82 /* OBADepartureCellHelpers.m */,
 				930AFE831DD04D2F0092AE82 /* OBADepartureTimeLabel.h */,
 				930AFE841DD04D2F0092AE82 /* OBADepartureTimeLabel.m */,
-				930AFE851DD04D2F0092AE82 /* OBAParallaxTableHeaderView.h */,
-				930AFE861DD04D2F0092AE82 /* OBAParallaxTableHeaderView.m */,
+				930AFE851DD04D2F0092AE82 /* OBAStopTableHeaderView.h */,
+				930AFE861DD04D2F0092AE82 /* OBAStopTableHeaderView.m */,
+				930AFE971DD11EF90092AE82 /* OBAWalkableCell.h */,
+				930AFE981DD11EF90092AE82 /* OBAWalkableCell.m */,
 			);
 			path = views;
 			sourceTree = "<group>";
@@ -1605,13 +1615,14 @@
 				930AFE791DD04CCA0092AE82 /* OBAUpcomingDeparture.m in Sources */,
 				934197BB1DB0C140004BBBB7 /* OBATripScheduleListViewController.m in Sources */,
 				93ADC5171DCA6C540024FBD6 /* YMTableViewCell.m in Sources */,
-				930AFE8C1DD04D2F0092AE82 /* OBAParallaxTableHeaderView.m in Sources */,
+				930AFE8C1DD04D2F0092AE82 /* OBAStopTableHeaderView.m in Sources */,
 				934197811DB0C140004BBBB7 /* OBABookmarksViewController.m in Sources */,
 				934197A11DB0C140004BBBB7 /* OBASegmentedRow.m in Sources */,
 				9341977D1DB0C140004BBBB7 /* AlertPresenter.swift in Sources */,
 				934197BD1DB0C140004BBBB7 /* OBATripScheduleSectionBuilder.m in Sources */,
 				934198181DB0C1BA004BBBB7 /* OBALabelActivityIndicatorView.m in Sources */,
 				93ADC5181DCA6C540024FBD6 /* YMTwoButtonSwipeView.m in Sources */,
+				930AFE961DD11ECB0092AE82 /* OBAWalkableRow.m in Sources */,
 				934197961DB0C140004BBBB7 /* OBAStaticTableViewController+Builders.m in Sources */,
 				9341979B1DB0C140004BBBB7 /* OBATextFieldCell.m in Sources */,
 				9341979A1DB0C140004BBBB7 /* OBATableViewCellValue1.m in Sources */,
@@ -1639,6 +1650,7 @@
 				9341978F1DB0C140004BBBB7 /* OBASearchResultsListViewController.m in Sources */,
 				934198171DB0C1BA004BBBB7 /* OBARotatingButton.m in Sources */,
 				934197A81DB0C140004BBBB7 /* OBAReportProblemWithRecentTripsViewController.m in Sources */,
+				930AFE991DD11EF90092AE82 /* OBAWalkableCell.m in Sources */,
 				934197B71DB0C140004BBBB7 /* OBAArrivalAndDepartureSectionBuilder.m in Sources */,
 				9341981F1DB0C1BA004BBBB7 /* OBALabelAndTextFieldTableViewCell.m in Sources */,
 				934197A61DB0C140004BBBB7 /* OBAViewModelRegistry.m in Sources */,


### PR DESCRIPTION
Fixes #829 - Improve 'walk time' feature by showing which buses can be caught

* Extract walking directions/ETA calculation into a wrapped promise in a new class.
* Rename Parallax Table Header View to the far more accurate Stop Table Header View
* Row insertion API for static table controller
* Add a row to the table that shows the user which buses can be caught
* Add a little walking person image to the header to improve the visual link between the new row and the walk time.

------

![simulator screen shot nov 10 2016 2 54 00 pm](https://cloud.githubusercontent.com/assets/2254/20197692/a900a832-a755-11e6-9923-0a98269566a3.png)
