### PR TITLE
Update the URL pattern for trip deep links

### DIFF
--- a/OneBusAway/OBAApplicationDelegate.m
+++ b/OneBusAway/OBAApplicationDelegate.m
@@ -181,7 +181,7 @@ static NSString *const kApptentiveKey = @"3363af9a6661c98dec30fedea451a06dd7d7bc
 
 #pragma mark - Deep Linking
 
-#define kDeepLinkTripPattern @"\\/regions\\/(\\d+).*\\/stops\\/(.*)\\/arrivals\\/?"
+#define kDeepLinkTripPattern @"\\/regions\\/(\\d+).*\\/stops\\/(.*)\\/trips\\/?"
 
 + (OBADeepLinkRouter*)setupDeepLinkRouterWithModelDAO:(OBAModelDAO*)modelDAO appDelegate:(OBAApplicationDelegate*)appDelegate {
     OBADeepLinkRouter *deepLinkRouter = [[OBADeepLinkRouter alloc] init];


### PR DESCRIPTION
Fixes #871 - Deep links not working properly

I had missed a spot in the app delegate when I updated the URLs for trip deep links.