### PR TITLE
Prospective fix for a crash on the map

### DIFF
--- a/OBAKit/Helpers/OBAMapHelpers.h
+++ b/OBAKit/Helpers/OBAMapHelpers.h
@@ -64,16 +64,6 @@ NSInteger OBASortStopsByDistanceFromLocation(OBAStopV2 *stop1, OBAStopV2 *stop2,
 + (MKMapRect)mapRectForCoordinateRegion:(MKCoordinateRegion)region;
 
 /**
- This method is used to determine the correct coordinate region to display on the map when rendering a collection of agencies.
-
- @param agenciesWithCoverage The list of agencies to display.
- @param defaultRegion        The fallback region to display if something goes wrong.
-
- @return An MKCoordinateRegion to display in an MKMapView.
- */
-+ (MKCoordinateRegion)computeRegionForAgenciesWithCoverage:(NSArray*)agenciesWithCoverage defaultRegion:(MKCoordinateRegion)defaultRegion;
-
-/**
  Calculate the coordinate region for the list of stops provided with a provided center location.
 
  @param stops    The list of stops from which to calculate a region.

--- a/OBAKit/Helpers/OBAMapHelpers.m
+++ b/OBAKit/Helpers/OBAMapHelpers.m
@@ -151,35 +151,6 @@ NSInteger OBASortStopsByDistanceFromLocation(OBAStopV2 *stop1, OBAStopV2 *stop2,
     return MKMapRectMake(MIN(a.x, b.x), MIN(a.y, b.y), ABS(a.x - b.x), ABS(a.y - b.y));
 }
 
-+ (MKCoordinateRegion)computeRegionForAgenciesWithCoverage:(NSArray*)agenciesWithCoverage defaultRegion:(MKCoordinateRegion)defaultRegion {
-    if (0 == agenciesWithCoverage.count) {
-        return defaultRegion;
-    }
-
-    OBACoordinateBounds *bounds = [OBACoordinateBounds bounds];
-
-    for (OBAAgencyWithCoverageV2 *agencyWithCoverage in agenciesWithCoverage) {
-        [bounds addCoordinate:agencyWithCoverage.coordinate];
-    }
-
-    if (bounds.empty) {
-        return defaultRegion;
-    }
-
-    MKCoordinateRegion region = bounds.region;
-    MKCoordinateRegion minRegion = [OBASphericalGeometryLibrary createRegionWithCenter:region.center latRadius:50000 lonRadius:50000];
-
-    if (region.span.latitudeDelta < minRegion.span.latitudeDelta) {
-        region.span.latitudeDelta = minRegion.span.latitudeDelta;
-    }
-
-    if (region.span.longitudeDelta < minRegion.span.longitudeDelta) {
-        region.span.longitudeDelta = minRegion.span.longitudeDelta;
-    }
-
-    return region;
-}
-
 + (MKCoordinateRegion)computeRegionForStops:(NSArray *)stops center:(CLLocation *)location {
     CLLocationCoordinate2D center = location.coordinate;
 

--- a/OBAKit/Models/unmanaged/OBASearch.h
+++ b/OBAKit/Models/unmanaged/OBASearch.h
@@ -34,7 +34,6 @@ typedef NS_ENUM(NSInteger, OBASearchType) {
     OBASearchTypeAddress,
     OBASearchTypePlacemark,
     OBASearchTypeStopId,
-    OBASearchTypeAgenciesWithCoverage,
 };
 
 @interface OBASearch : NSObject
@@ -46,7 +45,6 @@ typedef NS_ENUM(NSInteger, OBASearchType) {
 + (OBANavigationTarget*) getNavigationTargetForSearchAddress:(NSString*)addressQuery;
 + (OBANavigationTarget*) getNavigationTargetForSearchPlacemark:(OBAPlacemark*)placemark;
 + (OBANavigationTarget*) getNavigationTargetForSearchStopCode:(NSString*)stopIdQuery;
-+ (OBANavigationTarget*) getNavigationTargetForSearchAgenciesWithCoverage;
 
 + (OBASearchType)getSearchTypeForNavigationTarget:(OBANavigationTarget*)target;
 + (id)getSearchTypeParameterForNavigationTarget:(OBANavigationTarget*)target;

--- a/OBAKit/Models/unmanaged/OBASearch.m
+++ b/OBAKit/Models/unmanaged/OBASearch.m
@@ -56,10 +56,6 @@ NSString * const kOBASearchControllerSearchLocationParameter = @"OBASearchContro
     return [self getNavigationTargetForSearchType:OBASearchTypeStopId argument:stopIdQuery];    
 }
 
-+ (OBANavigationTarget*) getNavigationTargetForSearchAgenciesWithCoverage {
-    return [self getNavigationTargetForSearchType:OBASearchTypeAgenciesWithCoverage];
-}
-
 + (OBASearchType) getSearchTypeForNavigationTarget:(OBANavigationTarget*)target {
 
     // Update our target parameters
@@ -82,8 +78,6 @@ NSString * const kOBASearchControllerSearchLocationParameter = @"OBASearchContro
             return OBASearchTypePlacemark;
         case OBASearchTypeStopId:
             return OBASearchTypeStopId;
-        case OBASearchTypeAgenciesWithCoverage:
-            return OBASearchTypeAgenciesWithCoverage;
         default:
             return OBASearchTypeNone;
     }    

--- a/OneBusAway/en.lproj/Localizable.strings
+++ b/OneBusAway/en.lproj/Localizable.strings
@@ -33,7 +33,6 @@
 
 /* Agencies tab title
    Info Page Agencies Row Title
-   OBASearchTypeAgenciesWithCoverage
    self.navigationItem.title */
 "msg_agencies" = "Agencies";
 
@@ -550,9 +549,6 @@
 
 /* cell.textLabel.text */
 "msg_touch_to_edit" = "Touch to edit";
-
-/* OBASearchTypeAgenciesWithCoverage */
-"msg_transit_agencies" = "Transit Agencies";
 
 /* No comment provided by engineer. */
 "msg_trip_schedule" = "Trip Schedule";

--- a/OneBusAway/es.lproj/Localizable.strings
+++ b/OneBusAway/es.lproj/Localizable.strings
@@ -33,7 +33,6 @@
 
 /* Agencies tab title
    Info Page Agencies Row Title
-   OBASearchTypeAgenciesWithCoverage
    self.navigationItem.title */
 "msg_agencies" = "Agencias";
 
@@ -550,9 +549,6 @@
 
 /* cell.textLabel.text */
 "msg_touch_to_edit" = "Toca para editar";
-
-/* OBASearchTypeAgenciesWithCoverage */
-"msg_transit_agencies" = "Agencias de Transito";
 
 /* No comment provided by engineer. */
 "msg_trip_schedule" = "Horario de Viaje";

--- a/OneBusAway/ui/search/OBASearchController.m
+++ b/OneBusAway/ui/search/OBASearchController.m
@@ -245,13 +245,6 @@ NSString * const OBASearchControllerUserInfoDataKey = @"OBASearchControllerUserI
             }];
         }
 
-        case OBASearchTypeAgenciesWithCoverage:
-            return [_modelService requestAgenciesWithCoverage:^(id jsonData, NSUInteger responseCode, NSError *error) {
-                WrapperCompletion(jsonData, responseCode, error, ^(id data) {
-                    [self fireUpdateFromList:data];
-                });
-            }];
-
         default:
             break;
     }
@@ -280,10 +273,6 @@ NSString * const OBASearchControllerUserInfoDataKey = @"OBASearchControllerUserI
 
         case OBASearchTypeAddress:
             title = NSLocalizedString(@"msg_places", @"OBASearchTypeAddress");
-            break;
-
-        case OBASearchTypeAgenciesWithCoverage:
-            title = NSLocalizedString(@"msg_agencies", @"OBASearchTypeAgenciesWithCoverage");
             break;
 
         default:

--- a/OneBusAway/ui/search/OBASearchResultsListViewController.m
+++ b/OneBusAway/ui/search/OBASearchResultsListViewController.m
@@ -110,15 +110,6 @@
                 }];
                 break;
             }
-            case OBASearchTypeAgenciesWithCoverage: {
-                // There's no action to take when an agency is selected.
-                // hence the lack of a -setAction: call.
-                OBAAgencyWithCoverageV2 * awc = obj;
-                tableRow.style = UITableViewCellStyleDefault;
-                tableRow.title = awc.agency.name;
-                tableRow.accessoryType = UITableViewCellAccessoryNone;
-                break;
-            }
             default: {
                 // no-op.
             }
@@ -146,8 +137,6 @@
             return NSLocalizedString(@"msg_routes",@"OBASearchTypeRoute");
         case OBASearchTypeAddress:
             return NSLocalizedString(@"msg_places",@"OBASearchTypeAddress");
-        case OBASearchTypeAgenciesWithCoverage:
-            return NSLocalizedString(@"msg_agencies",@"OBASearchTypeAgenciesWithCoverage");
         default:
             return nil;
     }


### PR DESCRIPTION
Fixes #825 - Crash in OBASearchResultsMapViewController

* Stop making the assumption that everything that should displayed on the map will respond to the `stopId` selector.
* Simplify the code for building the list of stops to render as map annotations.
* Delete unnecessary code around showing map annotations for transit agencies