### PR TITLE
Properly label arrivals and departures at stops

### DIFF
--- a/OBAKit/Models/unmanaged/OBAArrivalAndDepartureV2.m
+++ b/OBAKit/Models/unmanaged/OBAArrivalAndDepartureV2.m
@@ -213,7 +213,7 @@
 }
 
 - (OBAArrivalDepartureState)arrivalDepartureState {
-    if (self.stopSequence == 0) {
+    if (self.stopSequence != 0) {
         return OBAArrivalDepartureStateArriving;
     }
     else {


### PR DESCRIPTION
Fixes #886 - Arrivals and departures seem to be reversed in latest beta

Flip the labeling of arrivals and departures