### PR TITLE
Unlock stop refreshes before the walk time has been calculated

### DIFF
--- a/OneBusAway/ui/stops/OBAStopViewController.m
+++ b/OneBusAway/ui/stops/OBAStopViewController.m
@@ -190,6 +190,11 @@ static NSInteger kStopsSectionTag = 101;
         [AlertPresenter showWarning:OBAStrings.error body:error.localizedDescription ?: NSLocalizedString(@"msg_error_min_connecting_dot", @"requestDidFail")];
         DDLogError(@"An error occurred while displaying a stop: %@", error);
         return error;
+    }).always(^{
+        if (animated) {
+            [self.refreshControl endRefreshing];
+        }
+        [self.reloadLock unlock];
     }).then(^{
         return [OBAWalkingDirections requestWalkingETA:self.arrivalsAndDepartures.stop.coordinate];
     }).then(^(MKETAResponse *ETA) {
@@ -198,11 +203,6 @@ static NSInteger kStopsSectionTag = 101;
     }).catch(^(NSError *error) {
         DDLogError(@"Unable to calculate walk time to stop: %@", error);
         self.stopHeaderView.walkingETA = nil;
-    }).always(^{
-        if (animated) {
-            [self.refreshControl endRefreshing];
-        }
-        [self.reloadLock unlock];
     });
 }
 


### PR DESCRIPTION
Fixes #885 - "Load More" doesn't seem to work until the 'walk bar' appears