### PR TITLE
Replace 'scheduled arrivals' footer with row

### DIFF
--- a/OBAKit/UI/OBATheme.h
+++ b/OBAKit/UI/OBATheme.h
@@ -44,6 +44,12 @@
 + (UIFont*)boldFootnoteFont;
 
 /**
+ * The appropriate font to use for footer text, or a sidenote, but italicized.
+ * Please use sparingly.
+ */
++ (UIFont*)italicFootnoteFont;
+
+/**
  * A bold variant of the appropriate font to use for body or label text.
  * Resizes based upon the user's chosen font sizes at the system level.
  */

--- a/OBAKit/UI/OBATheme.m
+++ b/OBAKit/UI/OBATheme.m
@@ -16,6 +16,7 @@ static UIFont *_titleFont = nil;
 static UIFont *_subtitleFont = nil;
 static UIFont *_footnoteFont = nil;
 static UIFont *_boldFootnoteFont = nil;
+static UIFont *_italicFootnoteFont = nil;
 
 @implementation OBATheme
 
@@ -28,6 +29,7 @@ static UIFont *_boldFootnoteFont = nil;
     _subtitleFont = nil;
     _footnoteFont = nil;
     _boldFootnoteFont = nil;
+    _italicFootnoteFont = nil;
 }
 
 #pragma mark - Appearance Proxies
@@ -91,6 +93,13 @@ static UIFont *_boldFootnoteFont = nil;
     return _boldFootnoteFont;
 }
 
++ (UIFont*)italicFootnoteFont {
+    if (!_italicFootnoteFont) {
+        _italicFootnoteFont = [self italicFontWithTextStyle:UIFontTextStyleFootnote];
+    }
+    return _italicFootnoteFont;
+}
+
 #pragma mark - Private Font Helpers
 
 + (UIFont*)fontWithTextStyle:(NSString*)textStyle {
@@ -99,9 +108,17 @@ static UIFont *_boldFootnoteFont = nil;
 }
 
 + (UIFont*)boldFontWithTextStyle:(NSString*)textStyle {
+    return [self fontWithTextStyle:textStyle symbolicTraits:UIFontDescriptorTraitBold];
+}
+
++ (UIFont*)italicFontWithTextStyle:(NSString*)textStyle {
+    return [self fontWithTextStyle:textStyle symbolicTraits:UIFontDescriptorTraitItalic];
+}
+
++ (UIFont*)fontWithTextStyle:(NSString*)textStyle symbolicTraits:(UIFontDescriptorSymbolicTraits)symbolicTraits {
     UIFontDescriptor *descriptor = [UIFontDescriptor preferredFontDescriptorWithTextStyle:textStyle];
-    UIFontDescriptor *boldDescriptor = [descriptor fontDescriptorWithSymbolicTraits:UIFontDescriptorTraitBold];
-    return [UIFont fontWithDescriptor:boldDescriptor size:MIN(boldDescriptor.pointSize, kMaxFontSize)];
+    UIFontDescriptor *augmentedDescriptor = [descriptor fontDescriptorWithSymbolicTraits:symbolicTraits];
+    return [UIFont fontWithDescriptor:augmentedDescriptor size:MIN(augmentedDescriptor.pointSize, kMaxFontSize)];
 }
 
 #pragma mark - Colors

--- a/OneBusAway/ui/stops/OBAStopViewController.m
+++ b/OneBusAway/ui/stops/OBAStopViewController.m
@@ -281,11 +281,11 @@ static NSInteger kStopsSectionTag = 101;
     // "Load More Departures..."
     OBATableSection *loadMoreSection = [self createLoadMoreDeparturesSection];
     if (result.lacksRealTimeData) {
-        loadMoreSection.footerView = ({
-            OBALabelFooterView *label = [[OBALabelFooterView alloc] initWithFrame:CGRectMake(0, 0, CGRectGetWidth(self.tableView.frame), 20)];
-            label.text = [OBAStrings scheduledDepartureExplanation];
-            label;
-        });
+        OBATableRow *scheduledExplanationRow = [[OBATableRow alloc] initWithTitle:[OBAStrings scheduledDepartureExplanation] action:nil];
+        scheduledExplanationRow.textAlignment = NSTextAlignmentCenter;
+        scheduledExplanationRow.titleFont = [OBATheme italicFootnoteFont];
+        scheduledExplanationRow.selectionStyle = UITableViewCellSelectionStyleNone;
+        [loadMoreSection addRow:scheduledExplanationRow];
     }
     [sections addObject:loadMoreSection];
 


### PR DESCRIPTION
Fixes #896 - Turn the "scheduled: no vehicle location data available" section footer into just another row

* Add italic footnote font helper method to OBATheme
* Refactor bold and italic font generators to use a helper method