### PR TITLE
Fully support App Transport Security (ATS)

### DIFF
--- a/OBAKit/Models/unmanaged/OBARegionV2.m
+++ b/OBAKit/Models/unmanaged/OBARegionV2.m
@@ -103,7 +103,7 @@ static NSString * kCustom = @"custom";
 #pragma mark - Other Public Methods
 
 - (BOOL)isValidModel {
-    return self.baseURL && self.regionName.length > 0;
+    return [self.baseURL.scheme isEqual:@"https"] && self.regionName.length > 0;
 }
 
 - (NSURL*)baseURL {

--- a/OneBusAway/Info.plist
+++ b/OneBusAway/Info.plist
@@ -45,7 +45,7 @@
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
-		<true/>
+		<false/>
 		<key>NSExceptionDomains</key>
 		<dict>
 			<key>194.89.230.196</key>

--- a/OneBusAway/en.lproj/Localizable.strings
+++ b/OneBusAway/en.lproj/Localizable.strings
@@ -535,8 +535,8 @@
 /* view.message */
 "msg_sucessfull_report_send" = "The problem was sucessfully reported. Thank you!";
 
-/* No comment provided by engineer. */
-"msg_alert_custom_region_not_valid" = "The region you have specified is not valid. Please specify at least a base URL and a name.";
+/* Invalid region error message */
+"msg_alert_custom_region_not_valid" = "The region you have specified is not valid. Please specify at least a base URL (HTTPS) and a name.";
 
 /* view.message */
 "msg_problem_internet_connection_on_map" = "There was a problem with your Internet connection.\r\n\r\nPlease check your network connection or contact us if you think the problem is on our end.";

--- a/OneBusAway/es.lproj/Localizable.strings
+++ b/OneBusAway/es.lproj/Localizable.strings
@@ -535,8 +535,8 @@
 /* view.message */
 "msg_sucessfull_report_send" = "El problema fue reportado exitosamente. ¡Gracias!";
 
-/* No comment provided by engineer. */
-"msg_alert_custom_region_not_valid" = "La región que ha especificado no es válido. Por favor especificar al menos una dirección URL base y un nombre.";
+/* Invalid region error message */
+"msg_alert_custom_region_not_valid" = "La región que ha especificado no es válido. Por favor especificar al menos una dirección URL base (HTTPS) y un nombre.";
 
 /* view.message */
 "msg_problem_internet_connection_on_map" = "Hubo un problema con tu conexión a Internet.\r\n\r\nPor favor, compruebe su conexión a la red o contáctanos si crees que el problema es nuestro.";

--- a/OneBusAway/ui/regions/RegionBuilderViewController.swift
+++ b/OneBusAway/ui/regions/RegionBuilderViewController.swift
@@ -114,13 +114,12 @@ class RegionBuilderViewController: OBAStaticTableViewController {
     }
 
     func save() {
-
         self.view.endEditing(true)
 
         self.loadDataIntoRegion()
 
         guard self.region.isValidModel() else {
-            let alert = UIAlertController.init(title: NSLocalizedString("msg_invalid_region", comment: ""), message: NSLocalizedString("msg_alert_custom_region_not_valid", comment: ""), preferredStyle: .alert)
+            let alert = UIAlertController.init(title: NSLocalizedString("msg_invalid_region", comment: ""), message: NSLocalizedString("msg_alert_custom_region_not_valid", comment: "Invalid region error message"), preferredStyle: .alert)
             alert.addAction(UIAlertAction.init(title: OBAStrings.dismiss(), style: .default, handler: nil))
             self.present(alert, animated: true, completion: nil)
             return


### PR DESCRIPTION
Fixes #681 - Support New ATS requirements

* Require custom regions to use HTTPS
* Turn off arbitrary HTTP loads
* Update the custom region creation error message to mention HTTPS