### PR TITLE
Update app version to 17.1.0

### DIFF
--- a/OBAKit/Info.plist
+++ b/OBAKit/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.6.5</string>
+	<string>17.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>20161111.16</string>
+	<string>20161226.00</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/OBAKit/OBAKit.xcodeproj/project.pbxproj
+++ b/OBAKit/OBAKit.xcodeproj/project.pbxproj
@@ -1248,6 +1248,7 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1272,6 +1273,7 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1369,6 +1371,7 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;

--- a/OneBusAway/Info.plist
+++ b/OneBusAway/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.6.5</string>
+	<string>17.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>20161111.16</string>
+	<string>2016126.00</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>

--- a/OneBusAway/externals/SVPulsingAnnotationView/SVPulsingAnnotationView.m
+++ b/OneBusAway/externals/SVPulsingAnnotationView/SVPulsingAnnotationView.m
@@ -42,7 +42,7 @@
         self.pulseAnimationDuration = 1.5;
         self.outerPulseAnimationDuration = 3;
         self.delayBetweenPulseCycles = 0;
-        self.annotationColor = [UIColor colorWithRed:0.000 green:0.478 blue:1.000 alpha:1];
+        self.annotationColor = [UIColor colorWithRed:0.f green:0.478f blue:1.f alpha:1.f];
         self.outerColor = [UIColor whiteColor];
         self.outerDotAlpha = 1;
 


### PR DESCRIPTION
I think version numbers are kind of lame. Chrome and Firefox release a new 'major version' every month-and-a-half, but Apple hasn't released a new major version of their desktop operating system since 2001.

OneBusAway has been on version 2.something since 2013. Since then, the application has been virtually rewritten. But, I still haven't changed the major version number because I was saving '3.0' for something special. I have since decided that this is silly.

Instead of tying major and minor version numbers to particular features, OBA for iOS will—henceforth—treat the version number as nothing more than an analog for the date.

17.1.0:

Year: (20)17
Month: 1 (January)
Release: 0 (zero indexed)

If a bug fix release comes out in January 2017, it will be 17.1.1. If a bug fix release comes out in February, it will be 17.2.0. If a major feature release comes out in February after that, it will be 17.2.1.

I hope to be less hung up on the version number and more hung up on delivering awesome software to our users. <3.