### PR TITLE
Show activity controller popover for trip sharing on iPad

### DIFF
--- a/OneBusAway/externals/AFMSlidingCell/AFMSlidingButtonContainer.h
+++ b/OneBusAway/externals/AFMSlidingCell/AFMSlidingButtonContainer.h
@@ -15,6 +15,9 @@
 @property (nonatomic, readonly) CGFloat bothButtonsWidth;
 @property (nonatomic, weak) AFMSlidingCell *parentCell;
 
+@property(nonatomic,strong,readonly) UIButton *leftButton;
+@property(nonatomic,strong,readonly) UIButton *rightButton;
+
 - (void)addLeftButton:(UIButton *)button withWidth:(CGFloat)width withTappedBlock:(void (^)(AFMSlidingCell *))tappedBlock;
 - (void)addRightButton:(UIButton *)button withWidth:(CGFloat)width withTappedBlock:(void (^)(AFMSlidingCell *))tappedBlock;
 - (void)clearButtons;

--- a/OneBusAway/externals/AFMSlidingCell/AFMSlidingButtonContainer.m
+++ b/OneBusAway/externals/AFMSlidingCell/AFMSlidingButtonContainer.m
@@ -10,8 +10,8 @@
 
 @interface AFMSlidingButtonContainer ()
 
-@property (nonatomic) UIButton *leftButton;
-@property (nonatomic) UIButton *rightButton;
+@property (nonatomic,strong,readwrite) UIButton *leftButton;
+@property (nonatomic,strong,readwrite) UIButton *rightButton;
 @property (nonatomic) CGFloat leftButtonWidth;
 @property (nonatomic) CGFloat rightButtonWidth;
 @property (nonatomic, copy) void (^leftButtonTappedBlock)(AFMSlidingCell *);

--- a/OneBusAway/externals/AFMSlidingCell/AFMSlidingCell.h
+++ b/OneBusAway/externals/AFMSlidingCell/AFMSlidingCell.h
@@ -21,6 +21,9 @@
 
 @interface AFMSlidingCell : UITableViewCell
 
+@property(nonatomic,assign,readonly) CGRect leftButtonFrame;
+@property(nonatomic,assign,readonly) CGRect rightButtonFrame;
+
 @property (nonatomic, weak) id<AFMSlidingCellDelegate> delegate;
 
 - (void)addFirstButton:(UIButton *)button withWidth:(CGFloat)width withTappedBlock:(void (^)(AFMSlidingCell *))tappedBlock;

--- a/OneBusAway/externals/AFMSlidingCell/AFMSlidingCell.m
+++ b/OneBusAway/externals/AFMSlidingCell/AFMSlidingCell.m
@@ -247,6 +247,16 @@ shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherG
     [self hideButtonViewAnimated:YES];
 }
 
+#pragma mark - Frames
+
+- (CGRect)leftButtonFrame {
+    return [self convertRect:self.buttonContainer.leftButton.frame fromView:self.buttonContainer];
+}
+
+- (CGRect)rightButtonFrame {
+    return [self convertRect:self.buttonContainer.rightButton.frame fromView:self.buttonContainer];
+}
+
 #pragma mark - Showing/hiding buttons
 
 - (void)showButtonViewAnimated:(BOOL)animated {


### PR DESCRIPTION
Fixes #919 - UIActivityVC needs sourcerect and sourceView on iPads

* Add public readonly accessors for the left and right button frames on AFMSlidingCell
* When presenting the trip sharing activity controller, check to see if the current device idiom is `Pad`. If it is, then ask the cell for its right sliding button frame and present from that, if available.