### PR TITLE
Fix Analytics (again, but for real this time)

### DIFF
--- a/OBAKit/Info.plist
+++ b/OBAKit/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>17.1.1</string>
 	<key>CFBundleVersion</key>
-	<string>20170104.09</string>
+	<string>20170105.12</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/OBAKit/OBAApplication.h
+++ b/OBAKit/OBAApplication.h
@@ -42,6 +42,9 @@ extern NSString *const kOBAApplicationSettingsRegionRefreshNotification;
 @property (nonatomic, strong, readonly) PrivacyBroker *privacyBroker;
 @property (nonatomic, strong, readonly) OBAConsoleLogger *consoleLogger;
 
+@property (nonatomic, copy, readonly) NSString *apptentiveAPIKey;
+@property (nonatomic, copy, readonly) NSString *googleAnalyticsID;
+
 /**
  *  This method should always be used to get an instance of this class.  This class should not be initialized directly.
  *

--- a/OBAKit/OBAApplication.m
+++ b/OBAKit/OBAApplication.m
@@ -138,6 +138,16 @@ NSString *const kOBAApplicationSettingsRegionRefreshNotification = @"kOBAApplica
     return [NSString stringWithFormat:@"%@ (%@)", [self formattedAppVersion], [self formattedAppBuild]];
 }
 
+#pragma mark - App Keys
+
+- (NSString*)apptentiveAPIKey {
+    return @"3363af9a6661c98dec30fedea451a06dd7d7bc9f70ef38378a9d5a15ac7d4926";
+}
+
+- (NSString*)googleAnalyticsID {
+    return @"UA-2423527-17";
+}
+
 #pragma mark - App/Region/API State
 
 - (void)refreshSettings {    

--- a/OneBusAway/Info.plist
+++ b/OneBusAway/Info.plist
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>20170104.09</string>
+	<string>20170105.12</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>

--- a/OneBusAway/OBAApplicationDelegate.m
+++ b/OneBusAway/OBAApplicationDelegate.m
@@ -35,9 +35,6 @@
 #import "OBADrawerUI.h"
 #import "EXTScope.h"
 
-static NSString *const kTrackingId = @"UA-2423527-17";
-static NSString *const kApptentiveKey = @"3363af9a6661c98dec30fedea451a06dd7d7bc9f70ef38378a9d5a15ac7d4926";
-
 @interface OBAApplicationDelegate () <OBABackgroundTaskExecutor, OBARegionHelperDelegate, RegionListDelegate>
 @property(nonatomic,strong) UINavigationController *regionNavigationController;
 @property(nonatomic,strong) RegionListViewController *regionListViewController;
@@ -125,20 +122,15 @@ static NSString *const kApptentiveKey = @"3363af9a6661c98dec30fedea451a06dd7d7bc
     [OBAModelService addBackgroundExecutor:self];
 
     // Configure the Apptentive feedback system
-    [Apptentive sharedConnection].APIKey = kApptentiveKey;
+    [Apptentive sharedConnection].APIKey = [OBAApplication sharedApplication].apptentiveAPIKey;
 
     // Set up Google Analytics. User must be able to opt out of tracking.
-    [GAI sharedInstance].optOut = ![[NSUserDefaults standardUserDefaults] boolForKey:OBAOptInToTrackingDefaultsKey];
+    id<GAITracker> tracker = [[GAI sharedInstance] trackerWithTrackingId:[OBAApplication sharedApplication].googleAnalyticsID];
+    BOOL optOut = ![[NSUserDefaults standardUserDefaults] boolForKey:OBAOptInToTrackingDefaultsKey];
+    [GAI sharedInstance].optOut = optOut;
     [GAI sharedInstance].trackUncaughtExceptions = YES;
     [GAI sharedInstance].logger.logLevel = kGAILogLevelWarning;
-
-    //don't report to Google Analytics when developing
-#ifdef DEBUG
-    DDLogInfo(@"In DEBUG mode. Not reporting to Google Analytics.");
-    [[GAI sharedInstance] setDryRun:YES];
-#endif
-
-    [[GAI sharedInstance].defaultTracker set:[GAIFields customDimensionForIndex:1] value:[OBAApplication sharedApplication].modelDao.currentRegion.regionName];
+    [tracker set:[GAIFields customDimensionForIndex:1] value:[OBAApplication sharedApplication].modelDao.currentRegion.regionName];
 
     [OBAAnalytics configureVoiceOverStatus];
 

--- a/OneBusAway/ui/info/OBASettingsViewController.m
+++ b/OneBusAway/ui/info/OBASettingsViewController.m
@@ -8,6 +8,7 @@
 
 #import "OBASettingsViewController.h"
 @import OBAKit;
+@import GoogleAnalytics;
 #import "OBASwitchRow.h"
 
 @interface OBASettingsViewController ()
@@ -40,6 +41,7 @@
     BOOL analyticsValue = [[NSUserDefaults standardUserDefaults] boolForKey:OBAOptInToTrackingDefaultsKey];
     OBASwitchRow *switchRow = [[OBASwitchRow alloc] initWithTitle:NSLocalizedString(@"msg_enable_google_analytics", @"A switch option's text for enabling and disabling Google Analytics") action:^{
         [[NSUserDefaults standardUserDefaults] setBool:!analyticsValue forKey:OBAOptInToTrackingDefaultsKey];
+        [GAI sharedInstance].optOut = !analyticsValue;
     } switchValue:analyticsValue];
     [analyticsSection addRow:switchRow];
 

--- a/OneBusAway/utilities/OBAAnalytics.h
+++ b/OneBusAway/utilities/OBAAnalytics.h
@@ -15,12 +15,12 @@
 @import UIKit;
 @import GoogleAnalytics;
 
-extern NSString * _Nonnull const OBAAnalyticsCategoryAppSettings;
-extern NSString * _Nonnull const OBAAnalyticsCategoryUIAction;
-extern NSString * _Nonnull const OBAAnalyticsCategoryAccessibility;
-extern NSString * _Nonnull const OBAAnalyticsCategorySubmit;
-
 NS_ASSUME_NONNULL_BEGIN
+
+extern NSString * const OBAAnalyticsCategoryAppSettings;
+extern NSString * const OBAAnalyticsCategoryUIAction;
+extern NSString * const OBAAnalyticsCategoryAccessibility;
+extern NSString * const OBAAnalyticsCategorySubmit;
 
 @interface OBAAnalytics : NSObject
 + (void)configureVoiceOverStatus;


### PR DESCRIPTION
Fixes #849

The default Analytics tracker was not being created. This is now fixed.

* Move app-specific keys (Analytics and Apptentive) into OBAApplication. This will be useful down the road if/when transit agencies want to rebrand OBA. Having these pieces of app-specific information consolidated helps us achieve this goal.
* Remove the ifdef that would disable analytics in development. The number of developers is so minuscule compared to the number of users that this will not affect our stats at all. Plus, it reduces the potential risk of analytics failing again in the future.
* Remove an unsightly batch of `_Nonnull` annotations by setting `NS_ASSUME_NONNULL_BEGIN` sooner in OBAAnalytics.h.