### PR TITLE
DRY up NSCoder

### DIFF
--- a/OBAKit/Categories/NSCoder+OBAAdditions.h
+++ b/OBAKit/Categories/NSCoder+OBAAdditions.h
@@ -1,0 +1,28 @@
+//
+//  NSCoder+OBAAdditions.h
+//  OBAKit
+//
+//  Created by Aaron Brethorst on 1/13/17.
+//  Copyright © 2017 OneBusAway. All rights reserved.
+//
+
+@import Foundation;
+
+@interface NSCoder (OBAAdditions)
+
+- (NSInteger)oba_decodeInteger:(SEL)selector;
+- (id)oba_decodeObject:(SEL)selector;
+- (double)oba_decodeDouble:(SEL)selector;
+- (int64_t)oba_decodeInt64:(SEL)selector;
+- (BOOL)oba_decodeBool:(SEL)selector;
+
+- (void)oba_encodeInteger:(NSInteger)value forSelector:(SEL)selector;
+- (void)oba_encodeInt64:(int64_t)value forSelector:(SEL)selector;
+- (void)oba_encodeDouble:(double)value forSelector:(SEL)selector;
+- (void)oba_encodeObject:(id)value forSelector:(SEL)selector;
+- (void)oba_encodeBool:(BOOL)value forSelector:(SEL)selector;
+
+- (void)oba_encodePropertyOnObject:(id)obj withSelector:(SEL)selector;
+
+- (BOOL)oba_containsValue:(SEL)selector;
+@end

--- a/OBAKit/Categories/NSCoder+OBAAdditions.m
+++ b/OBAKit/Categories/NSCoder+OBAAdditions.m
@@ -1,0 +1,71 @@
+//
+//  NSCoder+OBAAdditions.m
+//  OBAKit
+//
+//  Created by Aaron Brethorst on 1/13/17.
+//  Copyright © 2017 OneBusAway. All rights reserved.
+//
+
+#import <OBAKit/NSCoder+OBAAdditions.h>
+#import <OBAKit/OBAMacros.h>
+
+@implementation NSCoder (OBAAdditions)
+
+#pragma mark - Decode
+
+- (NSInteger)oba_decodeInteger:(SEL)selector {
+    return [self decodeIntegerForKey:NSStringFromSelector(selector)];
+}
+
+- (id)oba_decodeObject:(SEL)selector {
+    return [self decodeObjectForKey:NSStringFromSelector(selector)];
+}
+
+- (double)oba_decodeDouble:(SEL)selector {
+    return [self decodeDoubleForKey:NSStringFromSelector(selector)];
+}
+
+- (int64_t)oba_decodeInt64:(SEL)selector {
+    return [self decodeInt64ForKey:NSStringFromSelector(selector)];
+}
+
+- (BOOL)oba_decodeBool:(SEL)selector {
+    return [self decodeBoolForKey:NSStringFromSelector(selector)];
+}
+
+#pragma mark - Encode
+
+- (void)oba_encodePropertyOnObject:(id)obj withSelector:(SEL)selector {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+    [self oba_encodeObject:[obj performSelector:selector] forSelector:selector];
+#pragma clang diagnostic pop
+}
+
+- (void)oba_encodeInteger:(NSInteger)integer forSelector:(SEL)selector {
+    [self encodeInteger:integer forKey:NSStringFromSelector(selector)];
+}
+
+- (void)oba_encodeDouble:(double)value forSelector:(SEL)selector {
+    [self encodeDouble:value forKey:NSStringFromSelector(selector)];
+}
+
+- (void)oba_encodeObject:(id)value forSelector:(SEL)selector {
+    [self encodeObject:value forKey:NSStringFromSelector(selector)];
+}
+
+- (void)oba_encodeInt64:(int64_t)value forSelector:(SEL)selector {
+    [self encodeInt64:value forKey:NSStringFromSelector(selector)];
+}
+
+- (void)oba_encodeBool:(BOOL)value forSelector:(SEL)selector {
+    [self encodeBool:value forKey:NSStringFromSelector(selector)];
+}
+
+#pragma mark - Other
+
+- (BOOL)oba_containsValue:(SEL)selector {
+    return [self containsValueForKey:NSStringFromSelector(selector)];
+}
+
+@end

--- a/OBAKit/Helpers/OBAMapHelpers.m
+++ b/OBAKit/Helpers/OBAMapHelpers.m
@@ -172,7 +172,7 @@ NSInteger OBASortStopsByDistanceFromLocation(OBAStopV2 *stop1, OBAStopV2 *stop2,
 }
 
 + (MKCoordinateRegion)computeRegionForPlacemarks:(NSArray<OBAPlacemark*>*)placemarks defaultRegion:(MKCoordinateRegion)defaultRegion {
-    OBACoordinateBounds *bounds = [OBACoordinateBounds bounds];
+    OBACoordinateBounds *bounds = [[OBACoordinateBounds alloc] init];
 
     for (OBAPlacemark *placemark in placemarks) {
         [bounds addCoordinate:placemark.coordinate];

--- a/OBAKit/Models/unmanaged/OBAAgencyV2.m
+++ b/OBAKit/Models/unmanaged/OBAAgencyV2.m
@@ -15,6 +15,7 @@
  */
 
 #import <OBAKit/OBAAgencyV2.h>
+#import <OBAKit/NSCoder+OBAAdditions.h>
 
 @implementation OBAAgencyV2
 
@@ -24,17 +25,17 @@
     self = [super init];
 
     if (self) {
-        _agencyId = [aDecoder decodeObjectForKey:@"agencyId"];
-        _url = [aDecoder decodeObjectForKey:@"url"];
-        _name = [aDecoder decodeObjectForKey:@"name"];
+        _agencyId = [aDecoder oba_decodeObject:@selector(agencyId)];
+        _url = [aDecoder oba_decodeObject:@selector(url)];
+        _name = [aDecoder oba_decodeObject:@selector(name)];
     }
     return self;
 }
 
 - (void)encodeWithCoder:(NSCoder *)aCoder {
-    [aCoder encodeObject:_agencyId forKey:@"agencyId"];
-    [aCoder encodeObject:_url forKey:@"url"];
-    [aCoder encodeObject:_name forKey:@"name"];
+    [aCoder oba_encodeObject:_agencyId forSelector:@selector(agencyId)];
+    [aCoder oba_encodeObject:_url forSelector:@selector(url)];
+    [aCoder oba_encodeObject:_name forSelector:@selector(name)];
 }
 
 #pragma mark - NSCopying

--- a/OBAKit/Models/unmanaged/OBABookmarkGroup.m
+++ b/OBAKit/Models/unmanaged/OBABookmarkGroup.m
@@ -9,12 +9,7 @@
 #import <OBAKit/OBABookmarkGroup.h>
 #import <OBAKit/NSObject+OBADescription.h>
 #import <OBAKit/OBAMacros.h>
-
-static NSString * const kNameKey = @"name";
-static NSString * const kBookmarksKey = @"bookmarks";
-static NSString * const kOpenKey = @"open";
-static NSString * const kUUIDKey = @"UUID";
-static NSString * const kSortOrderKey = @"sortOrder";
+#import <OBAKit/NSCoder+OBAAdditions.h>
 
 @implementation OBABookmarkGroup
 
@@ -33,40 +28,39 @@ static NSString * const kSortOrderKey = @"sortOrder";
 - (id)initWithCoder:(NSCoder*)coder
 {
     if (self = [super init]) {
-        _name = [coder decodeObjectForKey:kNameKey];
-        _bookmarks = [coder decodeObjectForKey:kBookmarksKey];
+        _name = [coder oba_decodeObject:@selector(name)];
+        _bookmarks = [coder oba_decodeObject:@selector(bookmarks)];
         for (OBABookmarkV2 *bookmark in _bookmarks) {
             bookmark.group = self;
         }
 
-        if ([coder containsValueForKey:kOpenKey]) {
-            _open = [coder decodeBoolForKey:kOpenKey];
+        if ([coder oba_containsValue:@selector(open)]) {
+            _open = [coder oba_decodeBool:@selector(open)];
         }
         else {
             _open = YES;
         }
 
-        if ([coder containsValueForKey:kUUIDKey]) {
-            _UUID = [coder decodeObjectForKey:kUUIDKey];
+        if ([coder oba_containsValue:@selector(UUID)]) {
+            _UUID = [coder oba_decodeObject:@selector(UUID)];
         }
         else {
             _UUID = [[NSUUID UUID] UUIDString];
         }
 
-        if ([coder containsValueForKey:kSortOrderKey]) {
-            _sortOrder = [coder decodeIntegerForKey:kSortOrderKey];
+        if ([coder oba_containsValue:@selector(sortOrder)]) {
+            _sortOrder = [coder oba_decodeInteger:@selector(sortOrder)];
         }
     }
     return self;
 }
 
-- (void)encodeWithCoder:(NSCoder*)coder
-{
-    [coder encodeObject:_name forKey:kNameKey];
-    [coder encodeObject:_bookmarks forKey:kBookmarksKey];
-    [coder encodeBool:_open forKey:kOpenKey];
-    [coder encodeObject:_UUID forKey:kUUIDKey];
-    [coder encodeInteger:_sortOrder forKey:kSortOrderKey];
+- (void)encodeWithCoder:(NSCoder*)coder {
+    [coder oba_encodeObject:_name forSelector:@selector(name)];
+    [coder oba_encodeObject:_bookmarks forSelector:@selector(bookmarks)];
+    [coder oba_encodeBool:_open forSelector:@selector(open)];
+    [coder oba_encodeObject:_UUID forSelector:@selector(UUID)];
+    [coder oba_encodeInteger:_sortOrder forSelector:@selector(sortOrder)];
 }
 
 #pragma mark - NSObject
@@ -88,7 +82,7 @@ static NSString * const kSortOrderKey = @"sortOrder";
 }
 
 - (NSString*)description {
-    return [self oba_description:@[kNameKey, kBookmarksKey, kOpenKey, kUUIDKey, kSortOrderKey]];
+    return [self oba_description:@[@"name", @"bookmarks", @"open", @"UUID", @"sortOrder"]];
 }
 
 @end

--- a/OBAKit/Models/unmanaged/OBABookmarkV2.m
+++ b/OBAKit/Models/unmanaged/OBABookmarkV2.m
@@ -20,16 +20,7 @@
 #import <OBAKit/OBAStopV2.h>
 #import <OBAKit/OBARegionV2.h>
 #import <OBAKit/NSObject+OBADescription.h>
-
-static NSString * const kRegionIdentifier = @"regionIdentifier";
-static NSString * const kName = @"name";
-static NSString * const kRouteShortName = @"routeShortName";
-static NSString * const kStopId = @"stopId";
-static NSString * const kStop = @"stop";
-static NSString * const kRouteID = @"routeID";
-static NSString * const kTripHeadsign = @"tripHeadsign";
-static NSString * const kSortOrder = @"sortOrder";
-static NSString * const kBookmarkVersion = @"bookmarkVersion";
+#import <OBAKit/NSCoder+OBAAdditions.h>
 
 @implementation OBABookmarkV2
 
@@ -68,7 +59,7 @@ static NSString * const kBookmarkVersion = @"bookmarkVersion";
 
 - (id)initWithCoder:(NSCoder*)coder {
     if (self = [super init]) {
-        _name = [coder decodeObjectForKey:kName];
+        _name = [coder oba_decodeObject:@selector(name)];
 
         // Handle legacy bookmark models.
         NSArray *stopIds = [coder decodeObjectForKey:@"stopIds"];
@@ -76,44 +67,44 @@ static NSString * const kBookmarkVersion = @"bookmarkVersion";
             _stopId = stopIds[0];
         }
         else {
-            _stopId = [coder decodeObjectForKey:kStopId];
+            _stopId = [coder oba_decodeObject:@selector(stopId)];
         }
 
         // Normally, we'd simply try decoding the object and use the fact that
         // nil would simply resolve to 0 to our advantage, but the Tampa region
         // has the ID of 0, so we're stuck trying to be clever here to work
         // around that issue.
-        if ([coder containsValueForKey:kRegionIdentifier]) {
-            _regionIdentifier = [coder decodeIntegerForKey:kRegionIdentifier];
+        if ([coder oba_containsValue:@selector(regionIdentifier)]) {
+            _regionIdentifier = [coder oba_decodeInteger:@selector(regionIdentifier)];
         }
         else {
             _regionIdentifier = NSNotFound;
         }
 
-        _stop = [coder decodeObjectForKey:kStop];
+        _stop = [coder oba_decodeObject:@selector(stop)];
 
         // New in 2.6.0
-        _routeShortName = [coder decodeObjectForKey:kRouteShortName];
-        _tripHeadsign = [coder decodeObjectForKey:kTripHeadsign];
-        _routeID = [coder decodeObjectForKey:kRouteID];
-        _sortOrder = [coder decodeIntegerForKey:kSortOrder];
-        _bookmarkVersion = [coder decodeIntegerForKey:kBookmarkVersion];
+        _routeShortName = [coder oba_decodeObject:@selector(routeShortName)];
+        _tripHeadsign = [coder oba_decodeObject:@selector(tripHeadsign)];
+        _routeID = [coder oba_decodeObject:@selector(routeID)];
+        _sortOrder = [coder oba_decodeInteger:@selector(sortOrder)];
+        _bookmarkVersion = [coder oba_decodeInteger:@selector(bookmarkVersion)];
     }
     return self;
 }
 
 - (void)encodeWithCoder:(NSCoder*)coder {
-    [coder encodeObject:_name forKey:kName];
-    [coder encodeObject:_stopId forKey:kStopId];
-    [coder encodeObject:_stop forKey:kStop];
-    [coder encodeInteger:_regionIdentifier forKey:kRegionIdentifier];
+    [coder oba_encodeObject:_name forSelector:@selector(name)];
+    [coder oba_encodeObject:_stopId forSelector:@selector(stopId)];
+    [coder oba_encodeObject:_stop forSelector:@selector(stop)];
+    [coder oba_encodeInteger:_regionIdentifier forSelector:@selector(regionIdentifier)];
 
     // New in 2.6.0
-    [coder encodeObject:_routeShortName forKey:kRouteShortName];
-    [coder encodeObject:_tripHeadsign forKey:kTripHeadsign];
-    [coder encodeObject:_routeID forKey:kRouteID];
-    [coder encodeInteger:_sortOrder forKey:kSortOrder];
-    [coder encodeInteger:_bookmarkVersion forKey:kBookmarkVersion];
+    [coder oba_encodeObject:_routeShortName forSelector:@selector(routeShortName)];
+    [coder oba_encodeObject:_tripHeadsign forSelector:@selector(tripHeadsign)];
+    [coder oba_encodeObject:_routeID forSelector:@selector(routeID)];
+    [coder oba_encodeInteger:_sortOrder forSelector:@selector(sortOrder)];
+    [coder oba_encodeInteger:_bookmarkVersion forSelector:@selector(bookmarkVersion)];
 }
 
 #pragma mark - NSCopying

--- a/OBAKit/Models/unmanaged/OBACoordinateBounds.h
+++ b/OBAKit/Models/unmanaged/OBACoordinateBounds.h
@@ -21,9 +21,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface OBACoordinateBounds : NSObject <NSCoding>
 
-- (id) initWithBounds:(OBACoordinateBounds*)bounds;
-- (id) initWithRegion:(MKCoordinateRegion)region;
-+ (id) bounds;
+- (instancetype)initWithBounds:(OBACoordinateBounds*)bounds;
+- (instancetype)initWithRegion:(MKCoordinateRegion)region;
 
 @property (nonatomic,readonly) BOOL empty;
 @property (nonatomic) double minLatitude;

--- a/OBAKit/Models/unmanaged/OBACoordinateBounds.m
+++ b/OBAKit/Models/unmanaged/OBACoordinateBounds.m
@@ -15,12 +15,13 @@
  */
 
 #import <OBAKit/OBACoordinateBounds.h>
+#import <OBAKit/NSCoder+OBAAdditions.h>
 
 @implementation OBACoordinateBounds
 
-- (id) init {
+- (instancetype)init {
     self = [super init];
-    if( self ) {
+    if (self) {
         _empty = YES;
     }
     return self;
@@ -38,33 +39,41 @@
     return self;
 }
 
-- (id) initWithRegion:(MKCoordinateRegion)region {
+- (instancetype)initWithRegion:(MKCoordinateRegion)region {
     self = [super init];
-    if( self ) {
+    if (self) {
         _empty = YES;
         [self addRegion:region];
     }
     return self;
 }
 
-- (id) initWithCoder:(NSCoder*)coder {
+#pragma mark - NSCoder
+
+- (id)initWithCoder:(NSCoder*)coder {
     self = [super init];
-    if( self ) {
-        _empty = [coder decodeBoolForKey:@"empty"];
-        _minLatitude = [coder decodeDoubleForKey:@"minLatitude"];
-        _maxLatitude = [coder decodeDoubleForKey:@"maxLatitude"];
-        _minLongitude = [coder decodeDoubleForKey:@"minLongitude"];
-        _maxLongitude = [coder decodeDoubleForKey:@"maxLongitude"];
+    if (self) {
+        _empty = [coder oba_decodeBool:@selector(empty)];
+        _minLatitude = [coder oba_decodeDouble:@selector(minLatitude)];
+        _maxLatitude = [coder oba_decodeDouble:@selector(maxLatitude)];
+        _minLongitude = [coder oba_decodeDouble:@selector(minLongitude)];
+        _maxLongitude = [coder oba_decodeDouble:@selector(maxLongitude)];
     }
     return self;
 }
 
-+ (id) bounds {
-    return [[OBACoordinateBounds alloc] init];
+- (void)encodeWithCoder:(NSCoder*)coder {
+    [coder oba_encodeBool:_empty forSelector:@selector(empty)];
+    [coder oba_encodeDouble:_minLatitude forSelector:@selector(minLatitude)];
+    [coder oba_encodeDouble:_maxLatitude forSelector:@selector(maxLatitude)];
+    [coder oba_encodeDouble:_minLongitude forSelector:@selector(minLongitude)];
+    [coder oba_encodeDouble:_maxLongitude forSelector:@selector(maxLongitude)];
 }
 
-- (MKCoordinateRegion) region {
-    return MKCoordinateRegionMake([self center],[self span]);
+#pragma mark - Public Methods
+
+- (MKCoordinateRegion)region {
+    return MKCoordinateRegionMake(self.center,self.span);
 }
 
 - (CLLocationCoordinate2D) center {
@@ -122,9 +131,10 @@
     }
 }
 
-- (void) expandByRatio:(double)ratio {
-    if( _empty )
+- (void)expandByRatio:(double)ratio {
+    if (self.empty) {
         return;
+    }
     double latDelta = (_maxLatitude - _minLatitude) * ratio / 2;
     double lonDelta = (_maxLongitude - _minLongitude) * ratio / 2;
     _maxLatitude += latDelta;
@@ -135,16 +145,6 @@
 
 - (NSString*) description {
     return [NSString stringWithFormat:@"%f %f %f %f",_minLatitude,_minLongitude,_maxLatitude,_maxLongitude];
-}
-
-#pragma mark NSCoder Methods
-
-- (void) encodeWithCoder: (NSCoder *)coder {
-    [coder encodeBool:_empty forKey:@"empty"];
-    [coder encodeDouble:_minLatitude forKey:@"minLatitude"];
-    [coder encodeDouble:_maxLatitude forKey:@"maxLatitude"];
-    [coder encodeDouble:_minLongitude forKey:@"minLongitude"];
-    [coder encodeDouble:_maxLongitude forKey:@"maxLongitude"];
 }
 
 @end

--- a/OBAKit/Models/unmanaged/OBANavigationTarget.m
+++ b/OBAKit/Models/unmanaged/OBANavigationTarget.m
@@ -15,6 +15,7 @@
  */
 
 #import <OBAKit/OBANavigationTarget.h>
+#import <OBAKit/NSCoder+OBAAdditions.h>
 
 NSString * const OBAStopIDNavigationTargetParameter = @"stopId";
 
@@ -44,24 +45,19 @@ NSString * const OBAStopIDNavigationTargetParameter = @"stopId";
 #pragma mark - NSCoding
 
 - (id)initWithCoder:(NSCoder*)coder {
-    if( self = [super init] ) {
-        
-        NSNumber * target = [coder decodeObjectForKey:@"target"];
-        _target = [target intValue];
-
-        NSDictionary * dictionary = [coder decodeObjectForKey:@"parameters"];
-        _parameters = [[NSMutableDictionary alloc] initWithDictionary:dictionary];
-
-        _object = [coder decodeObjectForKey:@"object"];
+    if (self = [super init]) {
+        _target = [coder oba_decodeInteger:@selector(target)];
+        _parameters = [NSMutableDictionary dictionaryWithDictionary:[coder oba_decodeObject:@selector(parameters)]];
+        _object = [coder oba_decodeObject:@selector(object)];
     }
     return self;
 }
 
-- (void)encodeWithCoder: (NSCoder *)coder {
-    [coder encodeObject:[NSNumber numberWithInt:_target] forKey:@"target"];
-    [coder encodeObject:_parameters forKey:@"parameters"];
+- (void)encodeWithCoder:(NSCoder *)coder {
+    [coder oba_encodeInteger:_target forSelector:@selector(target)];
+    [coder oba_encodeObject:_parameters forSelector:@selector(parameters)];
     if ([_object conformsToProtocol:@protocol(NSCoding)]) {
-        [coder encodeObject:_object forKey:@"object"];
+        [coder oba_encodeObject:_object forSelector:@selector(object)];
     }
 }
 

--- a/OBAKit/Models/unmanaged/OBAPlacemark.h
+++ b/OBAKit/Models/unmanaged/OBAPlacemark.h
@@ -18,18 +18,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface OBAPlacemark : NSObject <NSCoding,MKAnnotation> {
-    NSString * _name;
-    NSString * _address;
-    NSString * _icon;
-    CLLocationCoordinate2D _coordinate;
-}
-
-@property (nonatomic,strong) NSString * name;
-@property (nonatomic,strong) NSString * address;
-@property (nonatomic,strong) NSString * icon;
-@property (nonatomic) CLLocationCoordinate2D coordinate;
-@property (weak, nonatomic,readonly) CLLocation * location;
+@interface OBAPlacemark : NSObject <NSCoding,MKAnnotation>
+@property(nonatomic,copy) NSString * name;
+@property(nonatomic,copy) NSString * address;
+@property(nonatomic,copy) NSString * icon;
+@property(nonatomic,assign) CLLocationCoordinate2D coordinate;
+@property(weak,nonatomic,readonly) CLLocation * location;
 
 - (instancetype)initWithAddress:(NSString*)address coordinate:(CLLocationCoordinate2D)coordinate;
 

--- a/OBAKit/Models/unmanaged/OBAPlacemark.m
+++ b/OBAKit/Models/unmanaged/OBAPlacemark.m
@@ -15,30 +15,43 @@
  */
 
 #import <OBAKit/OBAPlacemark.h>
+#import <OBAKit/NSCoder+OBAAdditions.h>
 
 @implementation OBAPlacemark
 
--(id) initWithAddress:(NSString*)address coordinate:(CLLocationCoordinate2D)coordinate {
+- (instancetype)initWithAddress:(NSString*)address coordinate:(CLLocationCoordinate2D)coordinate {
     self = [super init];
-    if( self ) {
+
+    if (self) {
         _address = address;
         _coordinate = coordinate;
     }
     return self;
 }
 
-- (id) initWithCoder:(NSCoder*)coder {
+#pragma mark NSCoder Methods
+
+- (id)initWithCoder:(NSCoder*)coder {
     self = [super init];
-    if( self ) {
-        _name = [coder decodeObjectForKey:@"name"];
-        _address =  [coder decodeObjectForKey:@"address"];
-        _icon =  [coder decodeObjectForKey:@"icon"];
-        NSData * data = [coder decodeObjectForKey:@"coordinate"];
+    if (self) {
+        _name = [coder oba_decodeObject:@selector(name)];
+        _address = [coder oba_decodeObject:@selector(address)];
+        _icon = [coder oba_decodeObject:@selector(icon)];
+
+        NSData * data = [coder oba_decodeObject:@selector(coordinate)];
         [data getBytes:&_coordinate length:sizeof(CLLocationCoordinate2D)];
     }
     return self;
 }
 
+- (void) encodeWithCoder:(NSCoder *)coder {
+    [coder oba_encodeObject:_name forSelector:@selector(name)];
+    [coder oba_encodeObject:_address forSelector:@selector(address)];
+    [coder oba_encodeObject:_icon forSelector:@selector(icon)];
+
+    NSData * data = [NSData dataWithBytes:&_coordinate length:sizeof(CLLocationCoordinate2D)];
+    [coder oba_encodeObject:data forSelector:@selector(coordinate)];
+}
 
 - (CLLocation*) location {
     return [[CLLocation alloc] initWithLatitude:_coordinate.latitude longitude:_coordinate.longitude];
@@ -46,20 +59,8 @@
 
 #pragma mark MKAnnotation
 
-- (NSString*) title {
-    if( _name )
-        return _name;
-    return _address;
-}
-
-#pragma mark NSCoder Methods
-
-- (void) encodeWithCoder: (NSCoder *)coder {
-    [coder encodeObject:_name forKey:@"name"];
-    [coder encodeObject:_address forKey:@"address"];
-    [coder encodeObject:_icon forKey:@"icon"];
-    NSData * data = [NSData dataWithBytes:&_coordinate length:sizeof(CLLocationCoordinate2D)];
-    [coder encodeObject:data forKey:@"coordinate"];
+- (NSString*)title {
+    return self.name ?: self.address;
 }
 
 @end

--- a/OBAKit/Models/unmanaged/OBARegionBoundsV2.m
+++ b/OBAKit/Models/unmanaged/OBARegionBoundsV2.m
@@ -8,13 +8,9 @@
 
 #import <OBAKit/OBARegionBoundsV2.h>
 #import <OBAKit/NSObject+OBADescription.h>
+#import <OBAKit/NSCoder+OBAAdditions.h>
 
 @implementation OBARegionBoundsV2
-
-static NSString * kLatKey = @"lat";
-static NSString * kLatSpanKey = @"latSpan";
-static NSString * kLonKey = @"lon";
-static NSString * kLonSpanKey = @"lonSpan";
 
 #pragma mark - NSCoder
 
@@ -22,20 +18,20 @@ static NSString * kLonSpanKey = @"lonSpan";
     self = [super init];
 
     if (self) {
-        self.lat = [decoder decodeDoubleForKey:kLatKey];
-        self.lon = [decoder decodeDoubleForKey:kLonKey];
-        self.latSpan = [decoder decodeDoubleForKey:kLatSpanKey];
-        self.lonSpan = [decoder decodeDoubleForKey:kLonSpanKey];
+        _lat = [decoder oba_decodeDouble:@selector(lat)];
+        _lon = [decoder oba_decodeDouble:@selector(lon)];
+        _latSpan = [decoder oba_decodeDouble:@selector(latSpan)];
+        _lonSpan = [decoder oba_decodeDouble:@selector(lonSpan)];
     }
 
     return self;
 }
 
 - (void)encodeWithCoder:(NSCoder *)encoder {
-    [encoder encodeDouble:self.lat forKey:kLatKey];
-    [encoder encodeDouble:self.lon forKey:kLonKey];
-    [encoder encodeDouble:self.latSpan forKey:kLatSpanKey];
-    [encoder encodeDouble:self.lonSpan forKey:kLonSpanKey];
+    [encoder oba_encodeDouble:_lat forSelector:@selector(lat)];
+    [encoder oba_encodeDouble:_lon forSelector:@selector(lon)];
+    [encoder oba_encodeDouble:_latSpan forSelector:@selector(latSpan)];
+    [encoder oba_encodeDouble:_lonSpan forSelector:@selector(lonSpan)];
 }
 
 #pragma mark - Equality

--- a/OBAKit/Models/unmanaged/OBARegionV2.m
+++ b/OBAKit/Models/unmanaged/OBARegionV2.m
@@ -10,23 +10,7 @@
 #import <OBAKit/OBARegionBoundsV2.h>
 #import <OBAKit/NSArray+OBAAdditions.h>
 #import <OBAKit/NSObject+OBADescription.h>
-
-static NSString * kSiriBaseUrl = @"siriBaseUrl";
-static NSString * kObaVersionInfo = @"obaVersionInfo";
-static NSString * kSupportsSiriRealtimeApis = @"supportsSiriRealtimeApis";
-static NSString * kLanguage = @"language";
-static NSString * kSupportsObaRealtimeApis = @"supportsObaRealtimeApis";
-static NSString * kBounds = @"bounds";
-static NSString * kSupportsObaDiscoveryApis = @"supportsObaDiscoveryApis";
-static NSString * kContactEmail = @"contactEmail";
-static NSString * kTwitterUrl = @"twitterUrl";
-static NSString * kFacebookUrl = @"facebookUrl";
-static NSString * kActive = @"active";
-static NSString * kExperimental = @"experimental";
-static NSString * kObaBaseUrl = @"obaBaseUrl";
-static NSString * kIdentifier = @"id_number";
-static NSString * kRegionName = @"regionName";
-static NSString * kCustom = @"custom";
+#import <OBAKit/NSCoder+OBAAdditions.h>
 
 @implementation OBARegionV2
 @dynamic baseURL;
@@ -42,44 +26,45 @@ static NSString * kCustom = @"custom";
 #pragma mark - NSCoding
 
 - (void)encodeWithCoder:(NSCoder *)encoder {
-    [encoder encodeObject:self.siriBaseUrl forKey:kSiriBaseUrl];
-    [encoder encodeObject:self.obaVersionInfo forKey:kObaVersionInfo];
-    [encoder encodeBool:self.supportsSiriRealtimeApis forKey:kSupportsSiriRealtimeApis];
-    [encoder encodeObject:self.language forKey:kLanguage];
-    [encoder encodeBool:self.supportsObaRealtimeApis forKey:kSupportsObaRealtimeApis];
-    [encoder encodeObject:self.bounds forKey:kBounds];
-    [encoder encodeBool:self.supportsObaDiscoveryApis forKey:kSupportsObaDiscoveryApis];
-    [encoder encodeObject:self.contactEmail forKey:kContactEmail];
-    [encoder encodeObject:self.twitterUrl forKey:kTwitterUrl];
-    [encoder encodeObject:self.facebookUrl forKey:kFacebookUrl];
-    [encoder encodeBool:self.active forKey:kActive];
-    [encoder encodeBool:self.experimental forKey:kExperimental];
-    [encoder encodeObject:self.obaBaseUrl forKey:kObaBaseUrl];
-    [encoder encodeInteger:self.identifier forKey:kIdentifier];
-    [encoder encodeObject:self.regionName forKey:kRegionName];
-    [encoder encodeBool:self.custom forKey:kCustom];
+    [encoder oba_encodeBool:_active forSelector:@selector(active)];
+    [encoder oba_encodePropertyOnObject:self withSelector:@selector(bounds)];
+    [encoder oba_encodePropertyOnObject:self withSelector:@selector(contactEmail)];
+    [encoder oba_encodeBool:_custom forSelector:@selector(custom)];
+    [encoder oba_encodeBool:_experimental forSelector:@selector(experimental)];
+    [encoder oba_encodePropertyOnObject:self withSelector:@selector(facebookUrl)];
+    [encoder oba_encodeInteger:_identifier forSelector:@selector(identifier)];
+    [encoder oba_encodePropertyOnObject:self withSelector:@selector(language)];
+    [encoder oba_encodePropertyOnObject:self withSelector:@selector(obaBaseUrl)];
+    [encoder oba_encodePropertyOnObject:self withSelector:@selector(obaVersionInfo)];
+    [encoder oba_encodePropertyOnObject:self withSelector:@selector(regionName)];
+    [encoder oba_encodePropertyOnObject:self withSelector:@selector(siriBaseUrl)];
+    [encoder oba_encodeBool:_supportsObaRealtimeApis forSelector:@selector(supportsObaRealtimeApis)];
+    [encoder oba_encodeBool:_supportsObaDiscoveryApis forSelector:@selector(supportsObaDiscoveryApis)];
+    [encoder oba_encodeBool:_supportsSiriRealtimeApis forSelector:@selector(supportsSiriRealtimeApis)];
+    [encoder oba_encodePropertyOnObject:self withSelector:@selector(twitterUrl)];
 }
 
 - (id)initWithCoder:(NSCoder *)decoder {
     self = [super init];
 
     if (self) {
-        _siriBaseUrl = [decoder decodeObjectForKey:kSiriBaseUrl];
-        _obaVersionInfo = [decoder decodeObjectForKey:kObaVersionInfo];
-        _supportsSiriRealtimeApis = [decoder decodeBoolForKey:kSupportsSiriRealtimeApis];
-        _language = [decoder decodeObjectForKey:kLanguage];
-        _supportsObaRealtimeApis = [decoder decodeBoolForKey:kSupportsObaRealtimeApis];
-        _bounds = [NSArray arrayWithArray:[decoder decodeObjectForKey:kBounds]];
-        _supportsObaDiscoveryApis = [decoder decodeBoolForKey:kSupportsObaDiscoveryApis];
-        _contactEmail = [decoder decodeObjectForKey:kContactEmail];
-        _twitterUrl = [decoder decodeObjectForKey:kTwitterUrl];
-        _facebookUrl = [decoder decodeObjectForKey:kFacebookUrl];
-        _active = [decoder decodeBoolForKey:kActive];
-        _experimental = [decoder decodeBoolForKey:kExperimental];
-        _obaBaseUrl = [decoder decodeObjectForKey:kObaBaseUrl];
-        _identifier = [decoder decodeIntegerForKey:kIdentifier];
-        _regionName = [self.class cleanUpRegionName:[decoder decodeObjectForKey:kRegionName]];
-        _custom = [decoder decodeBoolForKey:kCustom];
+        _siriBaseUrl = [decoder oba_decodeObject:@selector(siriBaseUrl)];
+        _obaVersionInfo = [decoder oba_decodeObject:@selector(obaVersionInfo)];
+        _supportsSiriRealtimeApis = [decoder oba_decodeBool:@selector(supportsSiriRealtimeApis)];
+        _language = [decoder oba_decodeObject:@selector(language)];
+
+        _supportsObaRealtimeApis = [decoder oba_decodeBool:@selector(supportsObaRealtimeApis)];
+        _bounds = [NSArray arrayWithArray:[decoder oba_decodeObject:@selector(bounds)]];
+        _supportsObaDiscoveryApis = [decoder oba_decodeBool:@selector(supportsObaDiscoveryApis)];
+        _contactEmail = [decoder oba_decodeObject:@selector(contactEmail)];
+        _twitterUrl = [decoder oba_decodeObject:@selector(twitterUrl)];
+        _facebookUrl = [decoder oba_decodeObject:@selector(facebookUrl)];
+        _active = [decoder oba_decodeBool:@selector(active)];
+        _experimental = [decoder oba_decodeBool:@selector(experimental)];
+        _obaBaseUrl = [decoder oba_decodeObject:@selector(obaBaseUrl)];
+        _identifier = [decoder oba_decodeInteger:@selector(identifier)];
+        _regionName = [self.class cleanUpRegionName:[decoder oba_decodeObject:@selector(regionName)]];
+        _custom = [decoder oba_decodeBool:@selector(custom)];
     }
 
     return self;

--- a/OBAKit/Models/unmanaged/OBARouteV2.m
+++ b/OBAKit/Models/unmanaged/OBARouteV2.m
@@ -16,6 +16,7 @@
 
 #import <OBAKit/OBARouteV2.h>
 #import <OBAKit/NSObject+OBADescription.h>
+#import <OBAKit/NSCoder+OBAAdditions.h>
 
 @interface OBARouteV2 ()
 @property(nonatomic,copy,readwrite) OBAAgencyV2 *agency;
@@ -29,24 +30,24 @@
     self = [super init];
 
     if (self) {
-        _routeId = [aDecoder decodeObjectForKey:@"routeId"];
-        _shortName = [aDecoder decodeObjectForKey:@"shortName"];
-        _longName = [aDecoder decodeObjectForKey:@"longName"];
-        _routeType = [aDecoder decodeObjectForKey:@"routeType"];
-        _agencyId = [aDecoder decodeObjectForKey:@"agencyId"];
-        _agency = [aDecoder decodeObjectForKey:@"agency"];
+        _routeId = [aDecoder oba_decodeObject:@selector(routeId)];
+        _shortName = [aDecoder oba_decodeObject:@selector(shortName)];
+        _longName = [aDecoder oba_decodeObject:@selector(longName)];
+        _routeType = [aDecoder oba_decodeObject:@selector(routeType)];
+        _agencyId = [aDecoder oba_decodeObject:@selector(agencyId)];
+        _agency = [aDecoder oba_decodeObject:@selector(agency)];
     }
 
     return self;
 }
 
 - (void)encodeWithCoder:(NSCoder *)aCoder {
-    [aCoder encodeObject:_routeId forKey:@"routeId"];
-    [aCoder encodeObject:_shortName forKey:@"shortName"];
-    [aCoder encodeObject:_longName forKey:@"longName"];
-    [aCoder encodeObject:_routeType forKey:@"routeType"];
-    [aCoder encodeObject:_agencyId forKey:@"agencyId"];
-    [aCoder encodeObject:_agency forKey:@"agency"];
+    [aCoder oba_encodePropertyOnObject:self withSelector:@selector(routeId)];
+    [aCoder oba_encodePropertyOnObject:self withSelector:@selector(shortName)];
+    [aCoder oba_encodePropertyOnObject:self withSelector:@selector(longName)];
+    [aCoder oba_encodePropertyOnObject:self withSelector:@selector(routeType)];
+    [aCoder oba_encodePropertyOnObject:self withSelector:@selector(agencyId)];
+    [aCoder oba_encodePropertyOnObject:self withSelector:@selector(agency)];
 }
 
 #pragma mark - NSCopying

--- a/OBAKit/Models/unmanaged/OBAStopAccessEventV2.m
+++ b/OBAKit/Models/unmanaged/OBAStopAccessEventV2.m
@@ -15,6 +15,7 @@
  */
 
 #import <OBAKit/OBAStopAccessEventV2.h>
+#import <OBAKit/NSCoder+OBAAdditions.h>
 
 @implementation OBAStopAccessEventV2
 
@@ -23,17 +24,18 @@
 - (id)initWithCoder:(NSCoder*)coder {
     self = [super init];
     if (self) {
-        _title = [coder decodeObjectForKey:@"title"];
-        _subtitle = [coder decodeObjectForKey:@"subtitle"];
-        _stopIds = [coder decodeObjectForKey:@"stopIds"];
+        _title = [coder oba_decodeObject:@selector(title)];
+        _title = [coder oba_decodeObject:@selector(title)];
+        _subtitle = [coder oba_decodeObject:@selector(subtitle)];
+        _stopIds = [coder oba_decodeObject:@selector(stopIds)];
     }
     return self;
 }
 
 - (void)encodeWithCoder:(NSCoder*)coder {
-    [coder encodeObject:self.title forKey:@"title"];
-    [coder encodeObject:self.subtitle forKey:@"subtitle"];
-    [coder encodeObject:self.stopIds forKey:@"stopIds"];
+    [coder oba_encodePropertyOnObject:self withSelector:@selector(title)];
+    [coder oba_encodePropertyOnObject:self withSelector:@selector(subtitle)];
+    [coder oba_encodePropertyOnObject:self withSelector:@selector(stopIds)];
 }
 
 #pragma mark - Equality

--- a/OBAKit/Models/unmanaged/OBAStopPreferencesV2.m
+++ b/OBAKit/Models/unmanaged/OBAStopPreferencesV2.m
@@ -16,6 +16,7 @@
 
 #import <OBAKit/OBAStopPreferencesV2.h>
 #import <OBAKit/NSObject+OBADescription.h>
+#import <OBAKit/NSCoder+OBAAdditions.h>
 
 NSString * _Nullable NSStringFromOBASortTripsByTypeV2(OBASortTripsByTypeV2 val);
 NSString * _Nullable NSStringFromOBASortTripsByTypeV2(OBASortTripsByTypeV2 val) {
@@ -54,17 +55,16 @@ NSString * _Nullable NSStringFromOBASortTripsByTypeV2(OBASortTripsByTypeV2 val) 
 
 - (instancetype)initWithCoder:(NSCoder*)coder {
     self = [super init];
-    if( self ) {
-        NSNumber * sortTripsByType = [coder decodeObjectForKey:@"sortTripsByType"];
-        _sortTripsByType = [sortTripsByType unsignedIntegerValue];
-        _routeFilter = [coder decodeObjectForKey:@"routeFilter"];
+    if (self) {
+        _sortTripsByType = [coder oba_decodeInteger:@selector(sortTripsByType)];
+        _routeFilter = [coder oba_decodeObject:@selector(routeFilter)];
     }
     return self;
 }
 
 - (void)encodeWithCoder:(NSCoder*)coder {
-    [coder encodeObject:[NSNumber numberWithInt:_sortTripsByType] forKey:@"sortTripsByType"];
-    [coder encodeObject:_routeFilter forKey:@"routeFilter"];
+    [coder oba_encodeInteger:_sortTripsByType forSelector:@selector(sortTripsByType)];
+    [coder oba_encodePropertyOnObject:self withSelector:@selector(routeFilter)];
 }
 
 

--- a/OBAKit/Models/unmanaged/OBAStopV2.m
+++ b/OBAKit/Models/unmanaged/OBAStopV2.m
@@ -17,6 +17,7 @@
 #import <OBAKit/OBAStopV2.h>
 #import <OBAKit/OBARouteV2.h>
 #import <OBAKit/OBAMacros.h>
+#import <OBAKit/NSCoder+OBAAdditions.h>
 
 @interface OBAStopV2 ()
 @property(nonatomic,strong,readwrite) NSArray<OBARouteV2*> *routes;
@@ -30,40 +31,41 @@
     self = [super init];
 
     if (self) {
-        _stopId = [aDecoder decodeObjectForKey:@"stopId"];
-        _name = [aDecoder decodeObjectForKey:@"name"];
-        _code = [aDecoder decodeObjectForKey:@"code"];
-        _direction = [aDecoder decodeObjectForKey:@"direction"];
+        _stopId = [aDecoder oba_decodeObject:@selector(stopId)];
+        _name = [aDecoder oba_decodeObject:@selector(name)];
+        _code = [aDecoder oba_decodeObject:@selector(code)];
+        _direction = [aDecoder oba_decodeObject:@selector(direction)];
 
         if ([aDecoder containsValueForKey:@"lat"]) {
-            _lat = [aDecoder decodeDoubleForKey:@"lat"];
+            _lat = [aDecoder oba_decodeDouble:@selector(lat)];
         }
         else {
             _lat = [[aDecoder decodeObjectForKey:@"latitude"] doubleValue];
         }
 
         if ([aDecoder containsValueForKey:@"lon"]) {
-            _lon = [aDecoder decodeDoubleForKey:@"lon"];
+            _lon = [aDecoder oba_decodeDouble:@selector(lon)];
         }
         else {
             _lon = [[aDecoder decodeObjectForKey:@"longitude"] doubleValue];
         }
 
-        _routeIds = [aDecoder decodeObjectForKey:@"routeIds"];
-        _routes = [aDecoder decodeObjectForKey:@"routes"];
+        _routeIds = [aDecoder oba_decodeObject:@selector(routeIds)];
+        _routes = [aDecoder oba_decodeObject:@selector(routes)];
     }
     return self;
 }
 
 - (void)encodeWithCoder:(NSCoder *)aCoder {
-    [aCoder encodeObject:_stopId forKey:@"stopId"];
-    [aCoder encodeObject:_name forKey:@"name"];
-    [aCoder encodeObject:_code forKey:@"code"];
-    [aCoder encodeObject:_direction forKey:@"direction"];
-    [aCoder encodeDouble:_lat forKey:@"lat"];
-    [aCoder encodeDouble:_lon forKey:@"lon"];
-    [aCoder encodeObject:_routeIds forKey:@"routeIds"];
-    [aCoder encodeObject:_routes forKey:@"routes"];
+    [aCoder oba_encodePropertyOnObject:self withSelector:@selector(stopId)];
+    [aCoder oba_encodePropertyOnObject:self withSelector:@selector(name)];
+    [aCoder oba_encodePropertyOnObject:self withSelector:@selector(code)];
+    [aCoder oba_encodePropertyOnObject:self withSelector:@selector(direction)];
+    [aCoder oba_encodePropertyOnObject:self withSelector:@selector(routeIds)];
+    [aCoder oba_encodePropertyOnObject:self withSelector:@selector(routes)];
+
+    [aCoder oba_encodeDouble:_lat forSelector:@selector(lat)];
+    [aCoder oba_encodeDouble:_lon forSelector:@selector(lon)];
 }
 
 #pragma mark - NSCopying

--- a/OBAKit/Models/unmanaged/OBATripDeepLink.m
+++ b/OBAKit/Models/unmanaged/OBATripDeepLink.m
@@ -9,6 +9,7 @@
 #import <OBAKit/OBATripDeepLink.h>
 #import <OBAKit/OBAURLHelpers.h>
 #import <OBAKit/NSObject+OBADescription.h>
+#import <OBAKit/NSCoder+OBAAdditions.h>
 
 NSString * const OBADeepLinkURL = @"https://www.onebusaway.co";
 
@@ -53,24 +54,24 @@ NSString * const OBADeepLinkURL = @"https://www.onebusaway.co";
     self = [super init];
 
     if (self) {
-        _name = [aDecoder decodeObjectForKey:kName];
-        _regionIdentifier = [aDecoder decodeIntegerForKey:kRegion];
-        _stopID = [aDecoder decodeObjectForKey:kStopID];
-        _tripID = [aDecoder decodeObjectForKey:kTripID];
-        _vehicleID = [aDecoder decodeObjectForKey:kVehicleID];
-        _serviceDate = [aDecoder decodeInt64ForKey:kServiceDate];
-        _stopSequence = [aDecoder decodeIntegerForKey:kStopSequence];
-        _createdAt = [aDecoder decodeObjectForKey:kCreatedAt];
+        _name = [aDecoder oba_decodeObject:@selector(name)];
+        _regionIdentifier = [aDecoder oba_decodeInteger:@selector(regionIdentifier)];
+        _stopID = [aDecoder oba_decodeObject:@selector(stopID)];
+        _tripID = [aDecoder oba_decodeObject:@selector(tripID)];
+        _vehicleID = [aDecoder oba_decodeObject:@selector(vehicleID)];
+        _serviceDate = [aDecoder oba_decodeInt64:@selector(serviceDate)];
+        _stopSequence = [aDecoder oba_decodeInteger:@selector(stopSequence)];
+        _createdAt = [aDecoder oba_decodeObject:@selector(createdAt)];
     }
     return self;
 }
 
 - (void)encodeWithCoder:(NSCoder *)aCoder {
-    [aCoder encodeObject:self.name forKey:kName];
-    [aCoder encodeInteger:self.regionIdentifier forKey:kRegion];
-    [aCoder encodeObject:self.stopID forKey:kStopID];
-    [aCoder encodeObject:self.tripID forKey:kTripID];
-    [aCoder encodeObject:self.vehicleID forKey:kVehicleID];
+    [aCoder oba_encodePropertyOnObject:self withSelector:@selector(name)];
+    [aCoder oba_encodeInteger:self.regionIdentifier forSelector:@selector(regionIdentifier)];
+    [aCoder oba_encodePropertyOnObject:self withSelector:@selector(stopID)];
+    [aCoder oba_encodePropertyOnObject:self withSelector:@selector(tripID)];
+    [aCoder oba_encodePropertyOnObject:self withSelector:@selector(vehicleID)];
     [aCoder encodeInt64:self.serviceDate forKey:kServiceDate];
     [aCoder encodeInteger:self.stopSequence forKey:kStopSequence];
     [aCoder encodeObject:self.createdAt forKey:kCreatedAt];

--- a/OBAKit/OBAKit.h
+++ b/OBAKit/OBAKit.h
@@ -18,6 +18,7 @@ FOUNDATION_EXPORT const unsigned char OBAKitVersionString[];
 // In this header, you should import all the public headers of your framework using statements like #import <OBAKit/PublicHeader.h>
 
 #import <OBAKit/NSArray+OBAAdditions.h>
+#import <OBAKit/NSCoder+OBAAdditions.h>
 #import <OBAKit/NSDate+DateTools.h>
 #import <OBAKit/NSObject+OBADescription.h>
 #import <OBAKit/NSURLQueryItem+OBAAdditions.h>

--- a/OBAKit/OBAKit.xcodeproj/project.pbxproj
+++ b/OBAKit/OBAKit.xcodeproj/project.pbxproj
@@ -202,6 +202,8 @@
 		934196CF1DB0B369004BBBB7 /* OBAKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 934196CD1DB0B369004BBBB7 /* OBAKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		934196D31DB0C02F004BBBB7 /* NSDate+DateTools.h in Headers */ = {isa = PBXBuildFile; fileRef = 934196D11DB0C02F004BBBB7 /* NSDate+DateTools.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		934196D41DB0C02F004BBBB7 /* NSDate+DateTools.m in Sources */ = {isa = PBXBuildFile; fileRef = 934196D21DB0C02F004BBBB7 /* NSDate+DateTools.m */; };
+		934C50951E2A1FB500DFDCA0 /* NSCoder+OBAAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 934C50931E2A1FB500DFDCA0 /* NSCoder+OBAAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		934C50961E2A1FB500DFDCA0 /* NSCoder+OBAAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 934C50941E2A1FB500DFDCA0 /* NSCoder+OBAAdditions.m */; };
 		9358CDAE1DEA1AB000132CDE /* OBADepartureCellHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 9358CDAC1DEA1AB000132CDE /* OBADepartureCellHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9358CDAF1DEA1AB000132CDE /* OBADepartureCellHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 9358CDAD1DEA1AB000132CDE /* OBADepartureCellHelpers.m */; };
 		9358CDB21DEA242B00132CDE /* OBAUpcomingDeparture.h in Headers */ = {isa = PBXBuildFile; fileRef = 9358CDB01DEA242B00132CDE /* OBAUpcomingDeparture.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -424,6 +426,8 @@
 		934196CD1DB0B369004BBBB7 /* OBAKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAKit.h; sourceTree = "<group>"; };
 		934196D11DB0C02F004BBBB7 /* NSDate+DateTools.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSDate+DateTools.h"; sourceTree = "<group>"; };
 		934196D21DB0C02F004BBBB7 /* NSDate+DateTools.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDate+DateTools.m"; sourceTree = "<group>"; };
+		934C50931E2A1FB500DFDCA0 /* NSCoder+OBAAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSCoder+OBAAdditions.h"; sourceTree = "<group>"; };
+		934C50941E2A1FB500DFDCA0 /* NSCoder+OBAAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSCoder+OBAAdditions.m"; sourceTree = "<group>"; };
 		9358CDAC1DEA1AB000132CDE /* OBADepartureCellHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBADepartureCellHelpers.h; sourceTree = "<group>"; };
 		9358CDAD1DEA1AB000132CDE /* OBADepartureCellHelpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBADepartureCellHelpers.m; sourceTree = "<group>"; };
 		9358CDB01DEA242B00132CDE /* OBAUpcomingDeparture.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAUpcomingDeparture.h; sourceTree = "<group>"; };
@@ -513,6 +517,8 @@
 				93B282C61DC68892005013D7 /* NSURLQueryItem+OBAAdditions.h */,
 				93B282C71DC68892005013D7 /* NSURLQueryItem+OBAAdditions.m */,
 				930AFE8F1DD0717A0092AE82 /* Array+Functional.swift */,
+				934C50931E2A1FB500DFDCA0 /* NSCoder+OBAAdditions.h */,
+				934C50941E2A1FB500DFDCA0 /* NSCoder+OBAAdditions.m */,
 			);
 			path = Categories;
 			sourceTree = "<group>";
@@ -871,6 +877,7 @@
 				934196241DB0B099004BBBB7 /* OBASphericalGeometryLibrary.h in Headers */,
 				934196651DB0B099004BBBB7 /* OBAPlacemarks.h in Headers */,
 				934196761DB0B099004BBBB7 /* OBASearchResult.h in Headers */,
+				934C50951E2A1FB500DFDCA0 /* NSCoder+OBAAdditions.h in Headers */,
 				9341960E1DB0B099004BBBB7 /* OBAMapHelpers.h in Headers */,
 				9341964F1DB0B099004BBBB7 /* OBAArrivalsAndDeparturesForStopV2.h in Headers */,
 				930AFE9E1DD183720092AE82 /* OBAWalkingDirections.h in Headers */,
@@ -1058,6 +1065,7 @@
 				9327DEF41E02306900502F06 /* OBACanvasView.m in Sources */,
 				9341963A1DB0B099004BBBB7 /* OBASelectorJsonDigesterRule.m in Sources */,
 				934196171DB0B099004BBBB7 /* OBAStrings.m in Sources */,
+				934C50961E2A1FB500DFDCA0 /* NSCoder+OBAAdditions.m in Sources */,
 				932CCEE31DC40221001C8405 /* OBADeepLinkRouter.m in Sources */,
 				934196401DB0B099004BBBB7 /* OBASetLocationPropertyJsonDigesterRule.m in Sources */,
 				934196B91DB0B0AF004BBBB7 /* OBATheme.m in Sources */,


### PR DESCRIPTION
Add a handful of category methods to NSCoder on OBAKit to make using it less onerous. These category methods allow the user to specify selectors instead of raw strings for reading and writing data, making things a bit less error prone.