### PR TITLE
Make -openURL: calls in other apps work

### DIFF
--- a/OneBusAway/OBAApplicationDelegate.m
+++ b/OneBusAway/OBAApplicationDelegate.m
@@ -226,6 +226,13 @@
     return [self.deepLinkRouter performActionForURL:URL];
 }
 
+/*
+ Necessary for onebusaway:// URLs to work.
+ */
+- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options {
+    return YES;
+}
+
 #pragma mark - Shortcut Items
 
 - (void)application:(UIApplication *)application performActionForShortcutItem:(UIApplicationShortcutItem *)shortcutItem completionHandler:(void (^)(BOOL))completionHandler {


### PR DESCRIPTION
From a bug report from another app developer: onebusaway:// URLs don't launch the app, even though they should. Adding a stub implementation of `-application:openURL:options:` to the app delegate fixes the issue.