### PR TITLE
Update app version to 17.2.0

### DIFF
--- a/OBAKit/Info.plist
+++ b/OBAKit/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>17.1.1</string>
+	<string>17.2.0</string>
 	<key>CFBundleVersion</key>
-	<string>20170105.12</string>
+	<string>20170116.23</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/OneBusAway/Info.plist
+++ b/OneBusAway/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>17.1.1</string>
+	<string>17.2.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>20170105.12</string>
+	<string>20170116.23</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>


### PR DESCRIPTION
The next version of the app is going to require some bake-time. There’s no way it ships before Feb 1.