### PR TITLE
Fix ‘invalid format’ error messages

### DIFF
--- a/OneBusAway/en.lproj/Localizable.strings
+++ b/OneBusAway/en.lproj/Localizable.strings
@@ -790,3 +790,6 @@
 
 /* Title for alert controller's Share Trip Status option. */
 "classic_departure_cell.context_alert.share_trip_status" = "Share Trip Status";
+
+/* Error message displayed when the user is connecting to a Wi-Fi captive portal landing page. */
+"alert_presenter.captive_wifi_portal_error_message" = "We didn't get the expected reply from the server.\r\n\r\nUsually this means that you are connected to a Wi-Fi network that requires you to do something to access the Internet.\r\n\r\nCheck your Wi-Fi connection and try again.";

--- a/OneBusAway/ui/alerts/AlertPresenter.swift
+++ b/OneBusAway/ui/alerts/AlertPresenter.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2016 OneBusAway. All rights reserved.
 //
 
+import OBAKit
 import UIKit
 import SwiftMessages
 
@@ -33,6 +34,22 @@ import SwiftMessages
     /// - parameter body:  The body of the alert
     open class func showError(_ title: String, body: String) {
         self.showMessage(withTheme: .error, title: title, body: body)
+    }
+
+    /// Displays an error alert on screen generated from an error object.
+    ///
+    /// - Parameter error: The error object from which the alert is generated.
+    open class func showError(_ error: NSError) {
+        var errorBody: String?
+
+        if (error.domain == NSCocoaErrorDomain && error.code == 3840) {
+            errorBody = NSLocalizedString("alert_presenter.captive_wifi_portal_error_message", comment: "Error message displayed when the user is connecting to a Wi-Fi captive portal landing page.")
+        }
+        else {
+            errorBody = error.localizedDescription;
+        }
+
+        self.showError(OBAStrings.error(), body: errorBody!)
     }
 
 

--- a/OneBusAway/ui/info/OBAAgenciesListViewController.m
+++ b/OneBusAway/ui/info/OBAAgenciesListViewController.m
@@ -54,7 +54,7 @@ typedef NS_ENUM (NSInteger, OBASectionType) {
     }).always(^{
         [SVProgressHUD dismiss];
     }).catch(^(NSError *error) {
-        [AlertPresenter showWarning:OBAStrings.error body:error.localizedDescription];
+        [AlertPresenter showError:error];
     });
 }
 

--- a/OneBusAway/ui/stop_details/OBAReportProblemWithRecentTripsViewController.m
+++ b/OneBusAway/ui/stop_details/OBAReportProblemWithRecentTripsViewController.m
@@ -49,7 +49,7 @@
     }).always(^{
         [SVProgressHUD dismiss];
     }).catch(^(NSError *error) {
-        [AlertPresenter showWarning:OBAStrings.error body:error.localizedDescription ?: NSLocalizedString(@"msg_error_min_connecting", @"requestDidFail")];
+        [AlertPresenter showError:error];
     });
 }
 
@@ -95,7 +95,7 @@
     }).always(^{
         [SVProgressHUD dismiss];
     }).catch(^(NSError *error) {
-        [AlertPresenter showWarning:OBAStrings.error body:error.localizedDescription ?: NSLocalizedString(@"msg_error_loading_trip",)];
+        [AlertPresenter showError:error];
     });
 }
 

--- a/OneBusAway/ui/stop_details/OBAReportProblemWithStopViewController.m
+++ b/OneBusAway/ui/stop_details/OBAReportProblemWithStopViewController.m
@@ -324,7 +324,7 @@ typedef NS_ENUM (NSInteger, OBASectionType) {
         [SVProgressHUD dismiss];
 
         if (error || !responseData) {
-            [AlertPresenter showWarning:OBAStrings.error body:error.localizedDescription];
+            [AlertPresenter showError:error];
             return;
         }
 

--- a/OneBusAway/ui/stops/OBAStopViewController.m
+++ b/OneBusAway/ui/stops/OBAStopViewController.m
@@ -200,7 +200,7 @@ static NSInteger kStopsSectionTag = 101;
         [self populateTableFromArrivalsAndDeparturesModel:self.arrivalsAndDepartures];
         [self.stopHeaderView populateTableHeaderFromArrivalsAndDeparturesModel:self.arrivalsAndDepartures];
     }).catch(^(NSError *error) {
-        [AlertPresenter showWarning:OBAStrings.error body:error.localizedDescription ?: NSLocalizedString(@"msg_error_min_connecting_dot", @"requestDidFail")];
+        [AlertPresenter showError:error];
         DDLogError(@"An error occurred while displaying a stop: %@", error);
         return error;
     }).always(^{
@@ -448,7 +448,7 @@ static NSInteger kStopsSectionTag = 101;
 
         [AlertPresenter showSuccess:NSLocalizedString(@"alarms.alarm_created_alert_title", @"The title of the non-modal alert displayed when a push notification alert is registered for a vehicle departure.") body:body];
     }).catch(^(NSError *error) {
-        [AlertPresenter showWarning:OBAStrings.error body:error.localizedDescription];
+        [AlertPresenter showError:error];
     }).always(^{
         [SVProgressHUD dismiss];
     });

--- a/OneBusAway/ui/trip_details/OBAArrivalAndDepartureViewController.m
+++ b/OneBusAway/ui/trip_details/OBAArrivalAndDepartureViewController.m
@@ -280,7 +280,7 @@ static NSTimeInterval const kRefreshTimeInterval = 30;
         self.mapController.tripDetails = tripDetails;
         [self populateTableWithArrivalAndDeparture:self.arrivalAndDeparture tripDetails:self.tripDetails];
     }).catch(^(NSError *error) {
-        [AlertPresenter showWarning:OBAStrings.error body:error.localizedDescription];
+        [AlertPresenter showError:error];
     }).always(^{
         [self.reloadLock unlock];
     });

--- a/OneBusAway/ui/trip_details/OBATripDetailsViewController.m
+++ b/OneBusAway/ui/trip_details/OBATripDetailsViewController.m
@@ -57,7 +57,7 @@
         self.navigationItem.rightBarButtonItem.enabled = YES;
         [SVProgressHUD dismiss];
     }).catch(^(NSError *error) {
-        [AlertPresenter showWarning:OBAStrings.error body:error.localizedDescription];
+        [AlertPresenter showError:error];
     });
 }
 

--- a/OneBusAway/ui/trip_details/OBAVehicleDetailsController.m
+++ b/OneBusAway/ui/trip_details/OBAVehicleDetailsController.m
@@ -52,7 +52,7 @@
         [SVProgressHUD dismiss];
         self.navigationItem.rightBarButtonItem.enabled = YES;
     }).catch(^(NSError *error) {
-        [AlertPresenter showWarning:OBAStrings.error body:error.localizedDescription];
+        [AlertPresenter showError:error];
     });
 }
 


### PR DESCRIPTION
Fixes #863 - User report: "data couldn't be read, incorrect format" error when disconnected from Internet

* Add a new AlertPresenter method to display error objects. Also, add a special case to this method to call out captive wifi networks as a potential source of trouble when a particular error code is received.
* Plumb in the new AlertPresenter method throughout the codebase.