### PR TITLE
Show the user’s selected stop on the vehicle map controller in a different color

### DIFF
--- a/OBAKit/Helpers/OBAImageHelpers.h
+++ b/OBAKit/Helpers/OBAImageHelpers.h
@@ -53,15 +53,15 @@ NS_ASSUME_NONNULL_BEGIN
 + (UIImage*)circleImageWithSize:(CGSize)size contents:(nullable UIImage*)image;
 
 /**
- Creates a circle of the specified size in light gray color, optionally compositing an
+ Creates a circle of the specified size in the specified color, optionally compositing an
  image in to the center.
 
  @param size Size of the circle
  @param image The image to composite into the center
- @param backgroundColor The interior color of the circle. Defaults to white if nil.
+ @param strokeColor The interior color of the circle. Defaults to light gray if nil.
  @return A circle with an optionally composited image
  */
-+ (UIImage*)circleImageWithSize:(CGSize)size contents:(nullable UIImage*)image backgroundColor:(nullable UIColor*)backgroundColor;
++ (UIImage*)circleImageWithSize:(CGSize)size contents:(nullable UIImage*)image strokeColor:(nullable UIColor*)strokeColor;
 
 /**
  Rotates the supplied UIImage by the specified number of degrees.

--- a/OBAKit/Helpers/OBAImageHelpers.m
+++ b/OBAKit/Helpers/OBAImageHelpers.m
@@ -59,24 +59,23 @@ CGFloat DegreesToRadians(CGFloat degrees) {
 }
 
 + (UIImage*)circleImageWithSize:(CGSize)size contents:(nullable UIImage*)image {
-    return [self circleImageWithSize:size contents:image backgroundColor:nil];
+    return [self circleImageWithSize:size contents:image strokeColor:nil];
 }
 
-+ (UIImage*)circleImageWithSize:(CGSize)size contents:(nullable UIImage*)image backgroundColor:(nullable UIColor*)backgroundColor {
++ (UIImage*)circleImageWithSize:(CGSize)size contents:(nullable UIImage*)image strokeColor:(nullable UIColor*)strokeColor {
     BOOL opaque = NO;
     CGFloat kStrokeWidth = 2.f;
     CGRect circleRect = CGRectMake(1, 1, size.width - 2, size.height - 2);
-    backgroundColor = backgroundColor ?: [UIColor whiteColor];
 
     UIGraphicsBeginImageContextWithOptions(size, opaque, [UIScreen mainScreen].scale);
     CGContextRef ctx = UIGraphicsGetCurrentContext();
 
     CGContextSetLineWidth(ctx, kStrokeWidth);
 
-    [backgroundColor set];
+    [[UIColor whiteColor] set]; //background color
     CGContextFillEllipseInRect(ctx, circleRect);
 
-    [[UIColor lightGrayColor] set];
+    [(strokeColor ?: [UIColor lightGrayColor]) set];
     CGContextStrokeEllipseInRect(ctx, circleRect);
 
     if (image) {

--- a/OBAKit/Models/annotations/OBATripStopTimeMapAnnotation.h
+++ b/OBAKit/Models/annotations/OBATripStopTimeMapAnnotation.h
@@ -19,13 +19,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface OBATripStopTimeMapAnnotation : NSObject <MKAnnotation> {
-    OBATripDetailsV2 * _tripDetails;
-}
+@interface OBATripStopTimeMapAnnotation : NSObject <MKAnnotation>
+@property(nonatomic,strong) OBATripDetailsV2 *tripDetails;
+@property(nonatomic,strong) OBATripStopTimeV2 * stopTime;
+@property(nonatomic,copy,readonly) NSString *stopID;
 
-- (id) initWithTripDetails:(OBATripDetailsV2*)tripDetails stopTime:(OBATripStopTimeV2*)stopTime;
-
-@property (nonatomic,strong) OBATripStopTimeV2 * stopTime;
+- (instancetype)initWithTripDetails:(OBATripDetailsV2*)tripDetails stopTime:(OBATripStopTimeV2*)stopTime;
 
 @end
 

--- a/OBAKit/Models/annotations/OBATripStopTimeMapAnnotation.m
+++ b/OBAKit/Models/annotations/OBATripStopTimeMapAnnotation.m
@@ -63,4 +63,8 @@
     return _stopTime.stop.coordinate;
 }
 
+- (NSString*)stopID {
+    return self.stopTime.stopId;
+}
+
 @end

--- a/OneBusAway/ui/trip_details/VehicleMapController.swift
+++ b/OneBusAway/ui/trip_details/VehicleMapController.swift
@@ -188,7 +188,15 @@ class VehicleMapController: UIViewController, MKMapViewDelegate {
             annotationView = MKAnnotationView.init(annotation: annotation, reuseIdentifier: identifier)
         }
 
-        annotationView?.image = OBAImageHelpers.circleImage(with: CGSize.init(width: 12, height: 12), contents: nil)
+        var color: UIColor
+        if self.arrivalAndDeparture?.stopId == annotation.stopID {
+            color = OBATheme.userLocationFillColor()
+        }
+        else {
+            color = UIColor.lightGray
+        }
+
+        annotationView?.image = OBAImageHelpers.circleImage(with: CGSize.init(width: 12, height: 12), contents: nil, stroke: color)
 
         return annotationView
     }
@@ -202,7 +210,15 @@ class VehicleMapController: UIViewController, MKMapViewDelegate {
             annotationView = MKAnnotationView.init(annotation: stop, reuseIdentifier: identifier)
         }
 
-        annotationView?.image = OBAImageHelpers.circleImage(with: CGSize.init(width: 12, height: 12), contents: nil)
+        var color: UIColor
+        if self.arrivalAndDeparture?.stopId == stop.stopId {
+            color = OBATheme.userLocationFillColor()
+        }
+        else {
+            color = UIColor.lightGray
+        }
+
+        annotationView?.image = OBAImageHelpers.circleImage(with: CGSize.init(width: 12, height: 12), contents: nil, stroke: color)
 
         return annotationView
     }

--- a/OneBusAway/ui/trip_details/table_cells/OBAArrivalDepartureCell.m
+++ b/OneBusAway/ui/trip_details/table_cells/OBAArrivalDepartureCell.m
@@ -92,14 +92,14 @@ static CGFloat const kTimelineWidth = 1.f;
 
     if ([self departureRow].closestStopToVehicle) {
         UIImage *image = [OBAStopIconFactory imageForRouteType:[self departureRow].routeType];
-        self.value1ContentsView.imageView.image = [OBAImageHelpers circleImageWithSize:CGSizeMake(kImageViewSize, kImageViewSize) contents:image backgroundColor:[OBATheme OBADarkGreen]];
+        self.value1ContentsView.imageView.image = [OBAImageHelpers circleImageWithSize:CGSizeMake(kImageViewSize, kImageViewSize) contents:image strokeColor:[OBATheme OBADarkGreen]];
 
         NSString *accessibilityLabel = [NSString stringWithFormat:NSLocalizedString(@"arrival_departure_cell.closest_stop", @"The vehicle is currently closest to <STOP NAME>"), [self departureRow].title];
         self.value1ContentsView.imageView.accessibilityLabel = accessibilityLabel;
     }
     else if ([self departureRow].selectedStopForRider) {
         UIImage *walkImage = [UIImage imageNamed:@"walkTransport"];
-        self.value1ContentsView.imageView.image = [OBAImageHelpers circleImageWithSize:CGSizeMake(kImageViewSize, kImageViewSize) contents:walkImage backgroundColor:OBATheme.mapUserLocationColor];
+        self.value1ContentsView.imageView.image = [OBAImageHelpers circleImageWithSize:CGSizeMake(kImageViewSize, kImageViewSize) contents:walkImage strokeColor:OBATheme.mapUserLocationColor];
     }
     else {
         self.value1ContentsView.imageView.image = [OBAImageHelpers circleImageWithSize:CGSizeMake(kImageViewSize, kImageViewSize) contents:nil];


### PR DESCRIPTION
Fixes #914

* Allow customization of stroke color instead of background color in `OBAImageHelpers`’s `-circleImage` methods
* Modernize header of OBATripStopTimeMapAnnotation and make it easier to get at the stop ID.
* Improve display of user’s selected stop on the arrival and departure controller and vehicle map controller