### PR TITLE
Improves visual display of ‘Quick Search’ items at top of Search UI

### DIFF
--- a/OneBusAway/en.lproj/Localizable.strings
+++ b/OneBusAway/en.lproj/Localizable.strings
@@ -803,20 +803,21 @@
 /* The empty data set description for the search controller */
 "map_search.empty_data_set_description" = "Type in an address, route number, or stop number here to search.";
 
-/* Search for Route: <ROUTE NAME> */
-"map_search.search_for_route_format" = "Route Lookup: %@";
 
 /* The section title on the 'Nearby' controller that says 'Routes' */
 "nearby_stops.routes_section_title" = "Routes";
 
 /* Map Search: Quick Lookup Table Section */
-"map_search.quick_lookup_section_title" = "Quick Lookup";
+"map_search.quick_lookup_section_title" = "Quick Search";
 
-/* "Search for Address: <ADDRESS>" */
-"map_search.search_for_address_format" = "Search for address: %@";
+/* 'Search for Route:' */
+"map_search.search_for_route" = "Route:";
 
-/* Formatted string for Search for Stop Number: <STOP NUMBER> */
-"map_search.search_for_stop_number_format" = "Stop Number Lookup: %@";
+/* "Search for Address:" */
+"map_search.search_for_address" = "Address:";
+
+/* Formatted string for Search for Stop Number: */
+"map_search.search_for_stop_number" = "Stop Number:";
 
 /* Map Search: Recent Stops section title */
 "map_search.recent_stops_section_title" = "Recent Stops";

--- a/OneBusAway/ui/search/MapSearchViewController.swift
+++ b/OneBusAway/ui/search/MapSearchViewController.swift
@@ -85,25 +85,39 @@ class MapSearchViewController: OBAStaticTableViewController, UISearchResultsUpda
         return sections
     }
 
+    private static func quickLookupRowText(title: String, searchText: String) -> NSAttributedString {
+        let str = NSMutableAttributedString.init()
+
+        let attributedTitle = NSAttributedString.init(string: title, attributes: [NSForegroundColorAttributeName: UIColor.darkGray])
+        str.append(attributedTitle)
+
+        // Needs a space tokeepwordsfromrunningtogether
+        str.append(NSAttributedString.init(string: " "))
+
+        let attributedSearchText = NSAttributedString.init(string: searchText, attributes: [NSFontAttributeName: OBATheme.boldBodyFont()])
+        str.append(attributedSearchText)
+
+        return str
+    }
+
     private func buildQuickLookupSection(searchText: String) -> OBATableSection {
 
-        // Route Row
-        let searchForRouteText = String.init(format: NSLocalizedString("map_search.search_for_route_format", comment: "Search for Route: <ROUTE NAME>"), searchText)
-        let routeRow = OBATableRow.init(title: searchForRouteText) {
+        let routeText = MapSearchViewController.quickLookupRowText(title: NSLocalizedString("map_search.search_for_route", comment: "Route Number: <ROUTE NUMBER>"), searchText: searchText)
+        let routeRow = OBATableRow.init(attributedTitle: routeText) {
             let target = OBANavigationTarget(forSearchRoute: searchText)
             self.delegate?.mapSearch(self, selectedNavigationTarget: target)
         }
 
         // Address Row
-        let searchAddressText = String.init(format: NSLocalizedString("map_search.search_for_address_format", comment: "Search for Address: <ADDRESS>"), searchText)
-        let addressRow = OBATableRow.init(title: searchAddressText) {
+        let searchAddressText = MapSearchViewController.quickLookupRowText(title: NSLocalizedString("map_search.search_for_address", comment: "Address: <ADDRESS>"), searchText: searchText)
+        let addressRow = OBATableRow.init(attributedTitle: searchAddressText) {
             let target = OBANavigationTarget(forSearchAddress: searchText)
             self.delegate?.mapSearch(self, selectedNavigationTarget: target)
         }
 
         // Stop Number Row
-        let stopNumberText = String.init(format: NSLocalizedString("map_search.search_for_stop_number_format", comment: "Formatted string for Search for Stop Number: <STOP NUMBER>"), searchText)
-        let stopNumberRow = OBATableRow.init(title: stopNumberText) {
+        let stopNumberText = MapSearchViewController.quickLookupRowText(title: NSLocalizedString("map_search.search_for_stop_number", comment: "Stop Number: <STOP NUMBER>"), searchText: searchText)
+        let stopNumberRow = OBATableRow.init(attributedTitle: stopNumberText) {
             let target = OBANavigationTarget(forStopID: searchText)
             self.delegate?.mapSearch(self, selectedNavigationTarget: target)
         }

--- a/OneBusAway/ui/static_table/cells/OBATableViewCell.m
+++ b/OneBusAway/ui/static_table/cells/OBATableViewCell.m
@@ -43,7 +43,13 @@
     _tableRow = [tableRow copy];
 
     self.textLabel.font = [self tableDataRow].titleFont;
-    self.textLabel.text = [self tableDataRow].title;
+
+    if ([self tableDataRow].attributedTitle) {
+        self.textLabel.attributedText = [self tableDataRow].attributedTitle;
+    }
+    else {
+        self.textLabel.text = [self tableDataRow].title;
+    }
     self.textLabel.textColor = [self tableDataRow].titleColor;
     self.textLabel.textAlignment = [self tableDataRow].textAlignment;
     self.detailTextLabel.text = [self tableDataRow].subtitle;

--- a/OneBusAway/ui/static_table/viewmodels/OBATableRow.h
+++ b/OneBusAway/ui/static_table/viewmodels/OBATableRow.h
@@ -21,6 +21,13 @@ NS_ASSUME_NONNULL_BEGIN
 @interface OBATableRow : OBABaseRow
 @property(nonatomic,copy,nullable) UIColor *titleColor;
 @property(nonatomic,copy,nullable) NSString *title;
+
+/**
+ An attributed string that will be used to draw the title label. This takes
+ precedence over `title` if it is available.
+ */
+@property(nonatomic,copy,nullable) NSAttributedString *attributedTitle;
+
 @property(nonatomic,copy,nullable) NSString *subtitle;
 @property(nonatomic,copy,nullable) UIFont *titleFont;
 @property(nonatomic,assign) UITableViewCellStyle style;
@@ -30,6 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic,strong,nullable) UIView *accessoryView;
 
 - (instancetype)initWithTitle:(NSString*)title action:( void (^ _Nullable )())action;
+- (instancetype)initWithAttributedTitle:(NSAttributedString*)attributedTitle action:( void (^ _Nullable )())action;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/OneBusAway/ui/static_table/viewmodels/OBATableRow.m
+++ b/OneBusAway/ui/static_table/viewmodels/OBATableRow.m
@@ -31,9 +31,20 @@ static NSString * const OBACellStyleSubtitleReuseIdentifier = @"OBACellStyleSubt
     return self;
 }
 
+- (instancetype)initWithAttributedTitle:(NSAttributedString*)attributedTitle action:( void (^ _Nullable )())action {
+    self = [super initWithAction:action];
+
+    if (self) {
+        _attributedTitle = [attributedTitle copy];
+        _selectionStyle = UITableViewCellSelectionStyleDefault;
+    }
+    return self;
+}
+
 - (id)copyWithZone:(NSZone *)zone {
     OBATableRow *newRow = [super copyWithZone:zone];
     newRow->_title = [_title copyWithZone:zone];
+    newRow->_attributedTitle = [_attributedTitle copyWithZone:zone];
     newRow->_subtitle = [_subtitle copyWithZone:zone];
     newRow->_style = _style;
     newRow->_image = _image;


### PR DESCRIPTION
These strings now have this style:

```
<muted>Route:</muted> <bold>545</bold>
```

* Adds ability to render attributed strings in OBATableViewCells.