### PR TITLE
Fixes display bug for Nearby Stops without specified direction

### DIFF
--- a/OneBusAway/en.lproj/Localizable.strings
+++ b/OneBusAway/en.lproj/Localizable.strings
@@ -845,3 +845,6 @@
 
 /* Empty data set description for regional alerts controller */
 "regional_alerts_controller.empty_description" = "No alerts reported for your area.";
+
+/* Title for a section that displays stops without a specified cardinal direction. Just 'Stops' in English. */
+"nearby_stops.stops_section_title" = "Stops";

--- a/OneBusAway/ui/stops/NearbyStopsViewController.swift
+++ b/OneBusAway/ui/stops/NearbyStopsViewController.swift
@@ -222,7 +222,7 @@ class NearbyStopsViewController: OBAStaticTableViewController {
         case "W":
             return NSLocalizedString("msg_westbound", comment: "As in 'going to the west.'")
         default:
-            return "\(abbreviation)-bound"
+            return NSLocalizedString("nearby_stops.stops_section_title", comment: "Title for a section that displays stops without a specified cardinal direction. Just 'Stops' in English.")
         }
     }
 }


### PR DESCRIPTION
Fixes #1005 - Nearby Stops shows stops with unspecified directions as '-bound'