### PR TITLE
Hides an unnecessary, scary error message on the Nearby Stops controller

### DIFF
--- a/OneBusAway/ui/stops/NearbyStopsViewController.swift
+++ b/OneBusAway/ui/stops/NearbyStopsViewController.swift
@@ -75,9 +75,9 @@ class NearbyStopsViewController: OBAStaticTableViewController {
                 AlertPresenter.showWarning(OBAStrings.error(), body: error.localizedDescription)
             }
         }
-        else {
-            AlertPresenter.showError(OBAStrings.error(), body: OBAStrings.inexplicableErrorPleaseContactUs())
-        }
+
+        // otherwise, show nothing. If the data on the map
+        // hasn't loaded yet, then there's nothing to show here.
     }
 
     /// Builds a list of table sections, sets the view controller's `sections` property


### PR DESCRIPTION
Fixes #1013 - Supposedly 'impossible' error is occurring