### PR TITLE
Allows sorting bookmarks by proximity

### DIFF
--- a/OBAKit/Location/OBALocationManager.h
+++ b/OBAKit/Location/OBALocationManager.h
@@ -49,6 +49,7 @@ extern NSString * const OBAHeadingUserInfoKey;
 - (instancetype)initWithModelDAO:(OBAModelDAO*)modelDAO;
 
 - (void)startUpdatingLocation;
+- (void)stopUpdatingLocation;
 
 - (void)startUpdatingHeading;
 - (void)stopUpdatingHeading;

--- a/OBAKit/Location/OBALocationManager.m
+++ b/OBAKit/Location/OBALocationManager.m
@@ -87,6 +87,12 @@ NSString * const OBAHeadingUserInfoKey = @"OBAHeadingUserInfoKey";
     }
 }
 
+- (void)stopUpdatingLocation {
+    if ([CLLocationManager locationServicesEnabled]) {
+        [self.locationManager stopUpdatingLocation];
+    }
+}
+
 - (void)startUpdatingHeading {
     if ([CLLocationManager headingAvailable]) {
         [self.locationManager startUpdatingHeading];

--- a/OBAKit/Location/OBARegionHelper.m
+++ b/OBAKit/Location/OBARegionHelper.m
@@ -29,7 +29,6 @@
 
 - (void)updateNearestRegion {
     [self updateRegion];
-    [self.locationManager startUpdatingLocation];
 }
 
 - (void)updateRegion {

--- a/OneBusAway/OBAApplicationDelegate.m
+++ b/OneBusAway/OBAApplicationDelegate.m
@@ -134,11 +134,14 @@
     if (location) {
         [OBAApplication sharedApplication].modelDao.mostRecentLocation = location;
     }
+
+    [[OBAApplication sharedApplication].locationManager stopUpdatingLocation];
 }
 
 - (void)applicationDidBecomeActive:(UIApplication *)application {
     DDLogInfo(@"Application became active");
 
+    [[OBAApplication sharedApplication].locationManager startUpdatingLocation];
     [[OBAApplication sharedApplication] startReachabilityNotifier];
     [[OBAApplication sharedApplication].regionalAlertsManager update];
 

--- a/OneBusAway/en.lproj/Localizable.strings
+++ b/OneBusAway/en.lproj/Localizable.strings
@@ -848,3 +848,9 @@
 
 /* Title for a section that displays stops without a specified cardinal direction. Just 'Stops' in English. */
 "nearby_stops.stops_section_title" = "Stops";
+
+/* Segmented control item title: 'Sort by Group' */
+"bookmarks_controller.sort_by_group_item" = "Sort by Group";
+
+/* Segmented control item title: 'Sort by Proximity' */
+"bookmarks_controller.sort_by_proximity_item" = "Sort by Proximity";

--- a/OneBusAway/ui/bookmarks/OBABookmarksViewController.h
+++ b/OneBusAway/ui/bookmarks/OBABookmarksViewController.h
@@ -15,4 +15,5 @@
 @interface OBABookmarksViewController : OBAStaticTableViewController<OBANavigationTargetAware>
 @property(nonatomic,strong) OBAModelDAO *modelDAO;
 @property(nonatomic,strong) OBAModelService *modelService;
+@property(nonatomic,strong) OBALocationManager *locationManager;
 @end

--- a/OneBusAway/ui/bookmarks/OBABookmarksViewController.m
+++ b/OneBusAway/ui/bookmarks/OBABookmarksViewController.m
@@ -14,9 +14,12 @@
 #import "OBACollapsingHeaderView.h"
 #import "OBABookmarkGroupsViewController.h"
 #import "OBATableCell.h"
+#import "OBASegmentedRow.h"
 
 static NSTimeInterval const kRefreshTimerInterval = 30.0;
 static NSUInteger const kMinutes = 30;
+
+static NSString * const OBABookmarkSortUserDefaultsKey = @"OBABookmarkSortUserDefaultsKey";
 
 @interface OBABookmarksViewController ()
 @property(nonatomic,strong) NSTimer *refreshBookmarksTimer;
@@ -67,6 +70,8 @@ static NSUInteger const kMinutes = 30;
 
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(reachabilityChanged:) name:kReachabilityChangedNotification object:nil];
 
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(locationChanged:) name:OBALocationDidUpdateNotification object:self.locationManager];
+
     NSMutableString *title = [NSMutableString stringWithString:NSLocalizedString(@"msg_bookmarks", @"")];
     if (self.currentRegion) {
         [title appendFormat:@" - %@", self.currentRegion.regionName];
@@ -81,6 +86,7 @@ static NSUInteger const kMinutes = 30;
 - (void)viewWillDisappear:(BOOL)animated {
     [super viewWillDisappear:animated];
 
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:OBALocationDidUpdateNotification object:self.locationManager];
     [[NSNotificationCenter defaultCenter] removeObserver:self name:kReachabilityChangedNotification object:nil];
 
     [self cancelTimer];
@@ -98,6 +104,10 @@ static NSUInteger const kMinutes = 30;
     // Wipe out the 'scheduled arrival/departure' footer message when the
     // application is backgrounded to ensure that it doesn't hang out forever.
     self.tableFooterView = nil;
+}
+
+- (void)locationChanged:(NSNotification*)note {
+    [self loadDataWithTableReload:YES];
 }
 
 #pragma mark - Refresh Bookmarks
@@ -231,13 +241,21 @@ static NSUInteger const kMinutes = 30;
     // If there are no bookmarks anywhere in the system, ungrouped or otherwise, then skip
     // over this code and instead show the empty table message.
     if (self.modelDAO.bookmarkGroups.count != 0 || self.modelDAO.ungroupedBookmarks.count != 0) {
-        for (OBABookmarkGroup *group in [self.modelDAO.bookmarkGroups sortedArrayUsingSelector:@selector(compare:)]) {
-            OBATableSection *section = [self tableSectionFromBookmarks:group.bookmarks group:group];
-            [sections addObject:section];
-        }
+        [sections addObject:[self buildSegmentedControlSection]];
 
-        OBATableSection *looseBookmarks = [self tableSectionFromBookmarks:self.modelDAO.ungroupedBookmarks group:nil];
-        [sections addObject:looseBookmarks];
+        if ([OBABookmarksViewController sortBookmarksByProximity]) {
+            OBATableSection *section = [self proximitySortedTableSection];
+
+            if (section) {
+                [sections addObject:section];
+            }
+            else {
+                [sections addObjectsFromArray:[self buildGroupedTableSections]];
+            }
+        }
+        else {
+            [sections addObjectsFromArray:[self buildGroupedTableSections]];
+        }
     }
 
     self.sections = sections;
@@ -245,6 +263,59 @@ static NSUInteger const kMinutes = 30;
     if (tableReload) {
         [self.tableView reloadData];
     }
+}
+
+- (NSArray<OBATableSection*>*)buildGroupedTableSections {
+    NSMutableArray *sections = [[NSMutableArray alloc] init];
+    for (OBABookmarkGroup *group in [self.modelDAO.bookmarkGroups sortedArrayUsingSelector:@selector(compare:)]) {
+        OBATableSection *section = [self tableSectionFromBookmarks:group.bookmarks group:group];
+        [sections addObject:section];
+    }
+
+    OBATableSection *looseBookmarks = [self tableSectionFromBookmarks:self.modelDAO.ungroupedBookmarks group:nil];
+    [sections addObject:looseBookmarks];
+
+    return [NSArray arrayWithArray:sections];
+}
+
+- (OBATableSection*)buildSegmentedControlSection {
+    OBASegmentedRow *segmentedControl = [[OBASegmentedRow alloc] initWithSelectionChange:^(NSUInteger selectedIndex) {
+        [[NSUserDefaults standardUserDefaults] setInteger:selectedIndex forKey:OBABookmarkSortUserDefaultsKey];
+        [[NSUserDefaults standardUserDefaults] synchronize];
+        [self loadDataWithTableReload:YES];
+    }];
+
+    segmentedControl.selectedItemIndex = [[NSUserDefaults standardUserDefaults] integerForKey:OBABookmarkSortUserDefaultsKey];
+
+    NSString *sortGroup = NSLocalizedString(@"bookmarks_controller.sort_by_group_item", @"Segmented control item title: 'Sort by Group'");
+    NSString *sortProximity = NSLocalizedString(@"bookmarks_controller.sort_by_proximity_item", @"Segmented control item title: 'Sort by Proximity'");
+    segmentedControl.items = @[sortGroup, sortProximity];
+
+    OBATableSection *segmentedControlSection = [[OBATableSection alloc] initWithTitle:nil rows:@[segmentedControl]];
+
+    return segmentedControlSection;
+}
+
++ (BOOL)sortBookmarksByProximity {
+    // 1 is the index of the proximity sort item on the segmented control.
+    return [[NSUserDefaults standardUserDefaults] integerForKey:OBABookmarkSortUserDefaultsKey] == 1;
+}
+
+- (nullable OBATableSection*)proximitySortedTableSection {
+    CLLocation *location = self.locationManager.currentLocation;
+
+    if (!location) {
+        return nil;
+    }
+
+    NSArray<OBABookmarkV2*> *bookmarks = [self.modelDAO.bookmarksForCurrentRegion sortedArrayUsingComparator:^NSComparisonResult(OBABookmarkV2 *bm1, OBABookmarkV2 *bm2) {
+        return [OBAMapHelpers getDistanceFrom:bm1.coordinate to:location.coordinate] > [OBAMapHelpers getDistanceFrom:bm2.coordinate to:location.coordinate];
+    }];
+
+    NSArray *rows = [self tableRowsFromBookmarks:bookmarks];
+    OBATableSection *section = [[OBATableSection alloc] initWithTitle:nil rows:rows];
+
+    return section;
 }
 
 #pragma mark - Actions
@@ -350,6 +421,13 @@ static NSUInteger const kMinutes = 30;
     return _modelService;
 }
 
+- (OBALocationManager*)locationManager {
+    if (!_locationManager) {
+        _locationManager = [OBAApplication sharedApplication].locationManager;
+    }
+    return _locationManager;
+}
+
 #pragma mark - Private
 
 /*
@@ -399,7 +477,7 @@ static NSUInteger const kMinutes = 30;
     return section;
 }
 
-- (NSArray*)tableRowsFromBookmarks:(NSArray<OBABookmarkV2*>*)bookmarks {
+- (NSArray<OBABaseRow*>*)tableRowsFromBookmarks:(NSArray<OBABookmarkV2*>*)bookmarks {
     NSMutableArray *rows = [NSMutableArray new];
 
     for (OBABookmarkV2 *bm in bookmarks) {

--- a/OneBusAway/ui/map/OBAMapViewController.m
+++ b/OneBusAway/ui/map/OBAMapViewController.m
@@ -137,7 +137,6 @@ static const double kStopsInRegionRefreshDelayOnDrag = 0.1;
     OBALogFunction();
 
     [self registerForLocationNotifications];
-    [self.locationManager startUpdatingLocation];
     [self.locationManager startUpdatingHeading];
 
     if (self.mapDataLoader.unfilteredSearch) {


### PR DESCRIPTION
Fixes #942 - Allow sorting of bookmarks by proximity

Add a segmented control to the top of the bookmarks controller that allows the user to sort bookmarks either by group or by proximity.
