### PR TITLE
Only show ‘captive portal’ error message if the user is on a Wifi network

### DIFF
--- a/OBAKit/Helpers/OBAReachability.h
+++ b/OBAKit/Helpers/OBAReachability.h
@@ -28,20 +28,7 @@
 @import Foundation;
 @import SystemConfiguration;
 
-//! Project version number for MacOSReachability.
-FOUNDATION_EXPORT double OBAReachabilityVersionNumber;
-
-//! Project version string for MacOSReachability.
-FOUNDATION_EXPORT const unsigned char OBAReachabilityVersionString[];
-
-/** 
- * Create NS_ENUM macro if it does not exist on the targeted version of iOS or OS X.
- *
- * @see http://nshipster.com/ns_enum-ns_options/
- **/
-#ifndef NS_ENUM
-#define NS_ENUM(_type, _name) enum _name : _type _name; enum _name : _type
-#endif
+NS_ASSUME_NONNULL_BEGIN
 
 extern NSString *const kReachabilityChangedNotification;
 
@@ -61,9 +48,9 @@ typedef void (^NetworkReachability)(OBAReachability * reachability, SCNetworkCon
 
 @interface OBAReachability : NSObject
 
-@property (nonatomic, copy) NetworkReachable    reachableBlock;
-@property (nonatomic, copy) NetworkUnreachable  unreachableBlock;
-@property (nonatomic, copy) NetworkReachability reachabilityBlock;
+@property (nonatomic,copy,nullable) NetworkReachable    reachableBlock;
+@property (nonatomic,copy,nullable) NetworkUnreachable  unreachableBlock;
+@property (nonatomic,copy,nullable) NetworkReachability reachabilityBlock;
 
 @property (nonatomic, assign) BOOL reachableOnWWAN;
 
@@ -98,4 +85,8 @@ typedef void (^NetworkReachability)(OBAReachability * reachability, SCNetworkCon
 -(NSString*)currentReachabilityString;
 -(NSString*)currentReachabilityFlags;
 
+@property(class,nonatomic,copy,readonly,nullable) NSString *wifiNetworkName;
+
 @end
+
+NS_ASSUME_NONNULL_END

--- a/OBAKit/Helpers/OBAReachability.m
+++ b/OBAKit/Helpers/OBAReachability.m
@@ -29,6 +29,7 @@
 #import <OBAKit/OBALogging.h>
 #import <OBAKit/OBAMacros.h>
 
+#import <SystemConfiguration/CaptiveNetwork.h>
 #import <sys/socket.h>
 #import <netinet/in.h>
 #import <netinet6/in6.h>
@@ -86,6 +87,33 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
 
 
 @implementation OBAReachability
+
+#pragma mark - Class Properties
+
++ (nullable NSString*)wifiNetworkName {
+    CFArrayRef supportedInterfaces = CNCopySupportedInterfaces();
+    if (!supportedInterfaces) {
+        return nil;
+    }
+
+    if (CFArrayGetCount(supportedInterfaces) == 0) {
+        CFRelease(supportedInterfaces);
+        return nil;
+    }
+
+    CFStringRef interfaceName = CFArrayGetValueAtIndex(supportedInterfaces, 0);
+
+    CFRelease(supportedInterfaces);
+
+    CFDictionaryRef networkInfoRef = CNCopyCurrentNetworkInfo(interfaceName);
+    NSDictionary *networkInfo = (__bridge_transfer NSDictionary*)networkInfoRef;
+
+    NSString *SSID = networkInfo[(NSString*)kCNNetworkInfoKeySSID];
+
+    CFRelease(networkInfoRef);
+
+    return SSID;
+}
 
 #pragma mark - Class Constructor Methods
 

--- a/OBAKit/OBAKit.xcodeproj/project.pbxproj
+++ b/OBAKit/OBAKit.xcodeproj/project.pbxproj
@@ -210,6 +210,7 @@
 		9358CDAF1DEA1AB000132CDE /* OBADepartureCellHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 9358CDAD1DEA1AB000132CDE /* OBADepartureCellHelpers.m */; };
 		9358CDB21DEA242B00132CDE /* OBAUpcomingDeparture.h in Headers */ = {isa = PBXBuildFile; fileRef = 9358CDB01DEA242B00132CDE /* OBAUpcomingDeparture.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9358CDB31DEA242B00132CDE /* OBAUpcomingDeparture.m in Sources */ = {isa = PBXBuildFile; fileRef = 9358CDB11DEA242B00132CDE /* OBAUpcomingDeparture.m */; };
+		936EB1B61E91746400F4F3A7 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 936EB1B51E91746400F4F3A7 /* SystemConfiguration.framework */; };
 		93B282C41DC664C7005013D7 /* OBATripDeepLink.h in Headers */ = {isa = PBXBuildFile; fileRef = 93B282C21DC664C7005013D7 /* OBATripDeepLink.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		93B282C51DC664C7005013D7 /* OBATripDeepLink.m in Sources */ = {isa = PBXBuildFile; fileRef = 93B282C31DC664C7005013D7 /* OBATripDeepLink.m */; };
 		93B282C81DC68892005013D7 /* NSURLQueryItem+OBAAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 93B282C61DC68892005013D7 /* NSURLQueryItem+OBAAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -442,6 +443,7 @@
 		9358CDAD1DEA1AB000132CDE /* OBADepartureCellHelpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBADepartureCellHelpers.m; sourceTree = "<group>"; };
 		9358CDB01DEA242B00132CDE /* OBAUpcomingDeparture.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAUpcomingDeparture.h; sourceTree = "<group>"; };
 		9358CDB11DEA242B00132CDE /* OBAUpcomingDeparture.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAUpcomingDeparture.m; sourceTree = "<group>"; };
+		936EB1B51E91746400F4F3A7 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		93B282C21DC664C7005013D7 /* OBATripDeepLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBATripDeepLink.h; sourceTree = "<group>"; };
 		93B282C31DC664C7005013D7 /* OBATripDeepLink.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBATripDeepLink.m; sourceTree = "<group>"; };
 		93B282C61DC68892005013D7 /* NSURLQueryItem+OBAAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURLQueryItem+OBAAdditions.h"; sourceTree = "<group>"; };
@@ -459,6 +461,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				936EB1B61E91746400F4F3A7 /* SystemConfiguration.framework in Frameworks */,
 				932CCED11DC3D315001C8405 /* CocoaLumberjackSwift.framework in Frameworks */,
 				932CCED21DC3D315001C8405 /* PMKCoreLocation.framework in Frameworks */,
 				93F3F8951E7AEE260025FC78 /* Mantle.framework in Frameworks */,
@@ -808,6 +811,7 @@
 		934196BC1DB0B274004BBBB7 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				936EB1B51E91746400F4F3A7 /* SystemConfiguration.framework */,
 				93F3F8941E7AEE260025FC78 /* Mantle.framework */,
 				932CCECA1DC3D315001C8405 /* CocoaLumberjack.framework */,
 				932CCECB1DC3D315001C8405 /* CocoaLumberjackSwift.framework */,

--- a/OneBusAway/ui/alerts/AlertPresenter.swift
+++ b/OneBusAway/ui/alerts/AlertPresenter.swift
@@ -40,18 +40,8 @@ import SwiftMessages
     ///
     /// - Parameter error: The error object from which the alert is generated.
     open class func showError(_ error: NSError) {
-        var errorBody: String?
-
-        if (error.domain == NSCocoaErrorDomain && error.code == 3840) {
-            errorBody = NSLocalizedString("alert_presenter.captive_wifi_portal_error_message", comment: "Error message displayed when the user is connecting to a Wi-Fi captive portal landing page.")
-        }
-        else {
-            errorBody = error.localizedDescription;
-        }
-
-        self.showError(OBAStrings.error(), body: errorBody!)
+        self.showError(OBAStrings.error(), body: errorMessage(from: error))
     }
-
 
     open class func showMessage(withTheme theme: Theme, title: String, body: String) {
         var config = SwiftMessages.Config()
@@ -71,5 +61,16 @@ import SwiftMessages
 
         // Show the message.
         SwiftMessages.show(config: config, view: view)
+    }
+
+    private class func errorMessage(from error: NSError) -> String {
+        let wifiName = OBAReachability.wifiNetworkName
+        let potentialWifiCaptivePortalError = (error.domain == NSCocoaErrorDomain && error.code == 3840)
+        if (potentialWifiCaptivePortalError && wifiName != nil) {
+            return NSLocalizedString("alert_presenter.captive_wifi_portal_error_message", comment: "Error message displayed when the user is connecting to a Wi-Fi captive portal landing page.")
+        }
+        else {
+            return error.localizedDescription
+        }
     }
 }


### PR DESCRIPTION
Fixes #1000 - Improve the messaging of the 'bad server response' alert

* Adds capability to retrieve the Wifi network name from OBAReachability. Notably, if the user is not on a Wifi network, this will return `nil`
* Adds NS_ASSUME_NONNULL wrapper to OBAReachability for the sake of modernity and Swift interop
* Only show the ‘captive portal’ error message if the user is on Wifi; otherwise just show the localized error description of the provided error message