### PR TITLE
Renames search keyboard return key type to ‘Done’

### DIFF
--- a/OneBusAway/ui/map/OBAMapViewController.m
+++ b/OneBusAway/ui/map/OBAMapViewController.m
@@ -171,6 +171,7 @@ static const double kStopsInRegionRefreshDelayOnDrag = 0.1;
     self.searchController.hidesNavigationBarDuringPresentation = NO;
 
     // Search Bar
+    self.searchController.searchBar.returnKeyType = UIReturnKeyDone;
     self.searchController.searchBar.searchBarStyle = UISearchBarStyleMinimal;
     self.searchController.searchBar.delegate = self;
     self.navigationItem.titleView = self.searchController.searchBar;


### PR DESCRIPTION
Fixes #1028 - Behavior of the new Search UI when you tap the Search button doesn't make sense