### PR TITLE
Update Spanish Translations

### DIFF
--- a/OBAKit/es.lproj/Localizable.strings
+++ b/OBAKit/es.lproj/Localizable.strings
@@ -153,3 +153,6 @@
 
 /* OBASearchTypeStopId. Rendered as 'Stop ID' in English. */
 "search_type.stop_id" = "ID de Parada";
+
+/* The word 'yesterday' */
+"strings.yesterday" = "Ayer";

--- a/OneBusAway/es.lproj/Localizable.strings
+++ b/OneBusAway/es.lproj/Localizable.strings
@@ -795,7 +795,7 @@
 "trip_status.no_realtime_data_message" = "Datos en Tiempo Real no disponibles.";
 
 /* e.g. Last report: 2m 43s ago */
-"trip_status.last_update_format" = "Último reporte: %@m %@s ago";
+"trip_status.last_report_format" = "Último reporte: hace %@m %@s";
 
 /* The empty data set description for the search controller */
 "map_search.empty_data_set_description" = "Escriba una dirección, número de ruta o número de parada aquí para buscar.";
@@ -824,3 +824,33 @@
 
 /* Clear Search button text */
 "toast_view.clear_search" = "Limpiar Búsqueda";
+
+/* Message shown when debug mode is turned on */
+"info_controller.debug_mode_enabled" = "Modo de depuración activado.";
+
+/* Message shown when debug mode is turned off */
+"info_controller.debug_mode_disabled" = "Modo de depuración desactivado.";
+
+/* Title of the Experimental Regions section in the Region List view controller. */
+"region_list_controller.experimental_section_title" = "Regiones Experimentales";
+
+/* Title for the Updates & Alerts section */
+"info_controller.updates_alerts_section_title" = "Actualizaciones & Alertas";
+
+/* Title for Updates & Alerts row. e.g. Alerts for <Region Name> */
+"info_controller.updates_alerts_row_format" = "Alertas para %@";
+
+/* Alerts for <REGION NAME> */
+"regional_alerts_controller.title_format" = "Alertas para %@";
+
+/* Empty data set description for regional alerts controller */
+"regional_alerts_controller.empty_description" = "Sin alertas reportada para tu área.";
+
+/* Title for a section that displays stops without a specified cardinal direction. Just 'Stops' in English. */
+"nearby_stops.stops_section_title" = "Paradas";
+
+/* Segmented control item title: 'Sort by Group' */
+"bookmarks_controller.sort_by_group_item" = "Ordenar por Grupo";
+
+/* Segmented control item title: 'Sort by Proximity' */
+"bookmarks_controller.sort_by_proximity_item" = "Ordenar por Proximidad";


### PR DESCRIPTION
Update Spanish Translations

* Based on commit c47898b - Fixes format string appearing in vehicle map popover
* Based on commit ecac56f - Adds ‘secret’ debug mode to the app
* Based on commit 6ad30a7 - Only show experimental regions on the Region List controller when debug mode is enabled
* Based on commit 2cceef0 - Adds Regional Alerts
* Based on commit 8d852f8 - Fixes display bug for Nearby Stops without specified direction
* Based on commit 18f790a - Allows sorting bookmarks by proximity