### PR TITLE
Adds a location services onboarding controller

### DIFF
--- a/OBAKit/Location/OBALocationManager.h
+++ b/OBAKit/Location/OBALocationManager.h
@@ -33,6 +33,7 @@ extern NSString * const OBAHeadingDidUpdateNotification;
 extern NSString * const OBAHeadingUserInfoKey;
 
 @interface OBALocationManager : NSObject <CLLocationManagerDelegate>
+@property(nonatomic,assign,readonly) BOOL hasRequestedInUseAuthorization;
 @property(nonatomic,copy,nullable,readonly) CLLocation *currentLocation;
 @property(nonatomic,copy,nullable,readonly) CLHeading *currentHeading;
 
@@ -53,10 +54,6 @@ extern NSString * const OBAHeadingUserInfoKey;
 
 - (void)startUpdatingHeading;
 - (void)stopUpdatingHeading;
-
-// iOS 8 Location Manager Support
-- (BOOL)hasRequestedInUseAuthorization;
-- (void)requestInUseAuthorization;
 
 @end
 

--- a/OBAKit/Location/OBALocationManager.m
+++ b/OBAKit/Location/OBALocationManager.m
@@ -66,10 +66,6 @@ NSString * const OBAHeadingUserInfoKey = @"OBAHeadingUserInfoKey";
         _locationManager = [[CLLocationManager alloc] init];
         _locationManager.delegate = self;
 
-        if (![self hasRequestedInUseAuthorization]) {
-            [self requestInUseAuthorization];
-        }
-
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationDidEnterBackground:) name:UIApplicationDidEnterBackgroundNotification object:nil];
     }
     return self;
@@ -116,10 +112,6 @@ NSString * const OBAHeadingUserInfoKey = @"OBAHeadingUserInfoKey";
 
 - (BOOL)hasRequestedInUseAuthorization {
     return [CLLocationManager authorizationStatus] != kCLAuthorizationStatusNotDetermined;
-}
-
-- (void)requestInUseAuthorization {
-    [self.locationManager requestWhenInUseAuthorization];
 }
 
 - (CLAuthorizationStatus)authorizationStatus {

--- a/OneBusAway/categories/UIWindow+OBAAdditions.h
+++ b/OneBusAway/categories/UIWindow+OBAAdditions.h
@@ -1,0 +1,13 @@
+//
+//  UIWindow+OBAAdditions.h
+//  org.onebusaway.iphone
+//
+//  Created by Aaron Brethorst on 4/9/17.
+//  Copyright © 2017 OneBusAway. All rights reserved.
+//
+
+@import UIKit;
+
+@interface UIWindow (OBAAdditions)
+- (void)oba_setRootViewController:(UIViewController *)rootViewController animated:(BOOL)animated;
+@end

--- a/OneBusAway/categories/UIWindow+OBAAdditions.m
+++ b/OneBusAway/categories/UIWindow+OBAAdditions.m
@@ -1,0 +1,33 @@
+//
+//  UIWindow+OBAAdditions.m
+//  org.onebusaway.iphone
+//
+//  Created by Aaron Brethorst on 4/9/17.
+//  Copyright © 2017 OneBusAway. All rights reserved.
+//
+
+#import "UIWindow+OBAAdditions.h"
+
+@implementation UIWindow (OBAAdditions)
+
+- (void)oba_setRootViewController:(UIViewController *)rootViewController animated:(BOOL)animated {
+    UIView *snapshot = nil;
+
+    if (animated) {
+        snapshot = [self snapshotViewAfterScreenUpdates:YES];
+        [rootViewController.view addSubview:snapshot];
+    }
+
+    [self setRootViewController: rootViewController];
+
+    if (animated) {
+        [UIView animateWithDuration:[UIView inheritedAnimationDuration] animations:^{
+            snapshot.layer.opacity = 0;
+            snapshot.layer.transform = CATransform3DMakeScale(1.5, 1.5, 1.5);
+        } completion:^(BOOL finished) {
+            [snapshot removeFromSuperview];
+        }];
+    }
+}
+
+@end

--- a/OneBusAway/en.lproj/Localizable.strings
+++ b/OneBusAway/en.lproj/Localizable.strings
@@ -854,3 +854,12 @@
 
 /* Segmented control item title: 'Sort by Proximity' */
 "bookmarks_controller.sort_by_proximity_item" = "Sort by Proximity";
+
+/* "Title of the Onboarding Controller. 'Welcome to OneBusAway!' */
+"onboarding_controller.title" = "Welcome to OneBusAway!";
+
+/* Body text of the Onboarding Controller. */
+"onboarding_controller.body_text" = "OneBusAway is an open source, volunteer-run app that helps you find out where your buses, trains, ferries, and more are in real time.\r\n\r\nThe app works best when it can find your location.\r\n\r\nPlease tap the button below to get started.";
+
+/* Bottom button on the Onboarding Controller */
+"onboarding_controller.request_location_permissions_button" = "Get Started";

--- a/OneBusAway/ui/onboarding/OnboardingViewController.swift
+++ b/OneBusAway/ui/onboarding/OnboardingViewController.swift
@@ -1,0 +1,87 @@
+//
+//  OnboardingViewController.swift
+//  org.onebusaway.iphone
+//
+//  Created by Aaron Brethorst on 4/3/17.
+//  Copyright © 2017 OneBusAway. All rights reserved.
+//
+
+import PMKCoreLocation
+import UIKit
+import SnapKit
+
+@objc protocol OnboardingDelegate {
+    func onboardingControllerRequestedAuthorization(_ onboardingController: OnboardingViewController)
+}
+
+@objc class OnboardingViewController: UIViewController {
+
+    let stackView = UIStackView.init()
+    weak var delegate: OnboardingDelegate?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        self.title = NSLocalizedString("onboarding_controller.title", comment: "Title of the Onboarding Controller. 'Welcome to OneBusAway!'")
+
+        self.view.backgroundColor = UIColor.white
+        self.stackView.axis = .vertical
+        self.stackView.spacing = OBATheme.defaultPadding()
+
+        let imageView = UIImageView.init(image: #imageLiteral(resourceName: "infoheader"))
+        let topView = UIView.init()
+        self.stackView.addArrangedSubview(topView)
+        topView.backgroundColor = OBATheme.obaGreen()
+
+        topView.addSubview(imageView)
+
+        imageView.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+        }
+
+        topView.snp.makeConstraints { make in
+            make.height.equalTo(160)
+        }
+
+        let titleLabel = UILabel.init()
+        titleLabel.textAlignment = .center
+        titleLabel.text = self.title
+        titleLabel.font = OBATheme.subtitleFont()
+        self.stackView.addArrangedSubview(titleLabel)
+
+        let bodyTextView = UITextView.init()
+        self.stackView.addArrangedSubview(bodyTextView)
+        bodyTextView.text = NSLocalizedString("onboarding_controller.body_text", comment: "Body text of the Onboarding Controller.")
+        bodyTextView.isSelectable = false
+        bodyTextView.isEditable = false
+        bodyTextView.textAlignment = .left
+        bodyTextView.font = OBATheme.bodyFont()
+        bodyTextView.snp.makeConstraints { make in
+            make.left.equalTo(20)
+            make.right.equalTo(-20)
+        }
+
+        let button = UIButton.init()
+        button.setTitleColor(OBATheme.obaGreen(), for: .normal)
+        button.addTarget(self, action: #selector(showLocationPrompt), for: .touchUpInside)
+        self.stackView.addArrangedSubview(button)
+        button.setTitle(NSLocalizedString("onboarding_controller.request_location_permissions_button", comment: "Bottom button on the Onboarding Controller"), for: .normal)
+        button.titleLabel?.font = OBATheme.titleFont()
+        button.snp.makeConstraints { make in
+            make.height.greaterThanOrEqualTo(44)
+            make.width.equalToSuperview()
+        }
+
+        self.view.addSubview(self.stackView)
+        self.stackView.snp.makeConstraints { make in
+            make.top.right.left.equalToSuperview()
+            make.bottom.equalToSuperview().offset(-60)
+        }
+    }
+
+    @objc func showLocationPrompt() {
+        CLLocationManager.requestAuthorization(type: .whenInUse).always {
+            self.delegate?.onboardingControllerRequestedAuthorization(self)
+        }
+    }
+}

--- a/OneBusAway/ui/situations/OBAServiceAlertsViewController.m
+++ b/OneBusAway/ui/situations/OBAServiceAlertsViewController.m
@@ -9,7 +9,6 @@
 #import "OBAServiceAlertsViewController.h"
 #import "OBAAnalytics.h"
 #import "OBAEmptyDataSetSource.h"
-#import "EXTScope.h"
 #import "OneBusAway-Swift.h"
 
 @interface OBAServiceAlertsViewController ()

--- a/org.onebusaway.iphone.xcodeproj/project.pbxproj
+++ b/org.onebusaway.iphone.xcodeproj/project.pbxproj
@@ -175,6 +175,7 @@
 		9359D1281DB92B4200CABFBD /* OBAModelService_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9359D1271DB92B4200CABFBD /* OBAModelService_Tests.m */; };
 		93631E4C1604F96800CB7209 /* OBAApplicationDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 93631E4B1604F96800CB7209 /* OBAApplicationDelegate.m */; };
 		9368E5C01DB1584900C329D0 /* OBAEmptyDataSetSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 9368E5BF1DB1584900C329D0 /* OBAEmptyDataSetSource.m */; };
+		936EB1C11E92F30C00F4F3A7 /* OnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 936EB1BF1E92F30C00F4F3A7 /* OnboardingViewController.swift */; };
 		9385EC3B1DCF14C60020CCB2 /* OBASettingsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 9385EC3A1DCF14C60020CCB2 /* OBASettingsViewController.m */; };
 		9385EC401DCF1D910020CCB2 /* ServiceAlertDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9385EC3F1DCF1D910020CCB2 /* ServiceAlertDetailsViewController.swift */; };
 		93876DFB1E68AD3900B4343F /* OBAMapAnnotationViewBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 93876DFA1E68AD3900B4343F /* OBAMapAnnotationViewBuilder.m */; };
@@ -197,6 +198,7 @@
 		93F3F88E1E7A7B2D0025FC78 /* RegionalAlertsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93F3F88D1E7A7B2D0025FC78 /* RegionalAlertsViewController.swift */; };
 		93F3F8971E7AEE560025FC78 /* Mantle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 93F3F8961E7AEE560025FC78 /* Mantle.framework */; };
 		93F3F89F1E7BAC510025FC78 /* OBARegionalAlert_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 93F3F89E1E7BAC510025FC78 /* OBARegionalAlert_Tests.m */; };
+		93F9574A1E9AFB020022586B /* UIWindow+OBAAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 93F957491E9AFB020022586B /* UIWindow+OBAAdditions.m */; };
 		93FE60261E0B2F34006EC9FB /* SVPulsingAnnotationView.m in Sources */ = {isa = PBXBuildFile; fileRef = 93FE60251E0B2F34006EC9FB /* SVPulsingAnnotationView.m */; };
 		93FE60291E0C8F62006EC9FB /* SnapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 93FE60281E0C8F62006EC9FB /* SnapKit.framework */; };
 		D6575AEC0FEE13CF00D6D987 /* Entitlements.plist in Resources */ = {isa = PBXBuildFile; fileRef = D6575AEB0FEE13CF00D6D987 /* Entitlements.plist */; };
@@ -516,6 +518,7 @@
 		9363D5911D6ADE6600A7021A /* yorkca.gpx */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = yorkca.gpx; sourceTree = "<group>"; };
 		9368E5BE1DB1584900C329D0 /* OBAEmptyDataSetSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAEmptyDataSetSource.h; sourceTree = "<group>"; };
 		9368E5BF1DB1584900C329D0 /* OBAEmptyDataSetSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAEmptyDataSetSource.m; sourceTree = "<group>"; };
+		936EB1BF1E92F30C00F4F3A7 /* OnboardingViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnboardingViewController.swift; sourceTree = "<group>"; };
 		936F45D91C78D06600C61656 /* OneBusAwayTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OneBusAwayTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		9385EC391DCF14C60020CCB2 /* OBASettingsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBASettingsViewController.h; sourceTree = "<group>"; };
 		9385EC3A1DCF14C60020CCB2 /* OBASettingsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBASettingsViewController.m; sourceTree = "<group>"; };
@@ -548,6 +551,8 @@
 		93F3F8961E7AEE560025FC78 /* Mantle.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Mantle.framework; path = Carthage/Build/iOS/Mantle.framework; sourceTree = "<group>"; };
 		93F3F89E1E7BAC510025FC78 /* OBARegionalAlert_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBARegionalAlert_Tests.m; sourceTree = "<group>"; };
 		93F5CF8E1DA820A4003947A8 /* boston.gpx */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = boston.gpx; sourceTree = "<group>"; };
+		93F957481E9AFB020022586B /* UIWindow+OBAAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIWindow+OBAAdditions.h"; sourceTree = "<group>"; };
+		93F957491E9AFB020022586B /* UIWindow+OBAAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIWindow+OBAAdditions.m"; sourceTree = "<group>"; };
 		93FE60241E0B2F34006EC9FB /* SVPulsingAnnotationView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SVPulsingAnnotationView.h; sourceTree = "<group>"; };
 		93FE60251E0B2F34006EC9FB /* SVPulsingAnnotationView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SVPulsingAnnotationView.m; sourceTree = "<group>"; };
 		93FE60281E0C8F62006EC9FB /* SnapKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SnapKit.framework; path = Carthage/Build/iOS/SnapKit.framework; sourceTree = "<group>"; };
@@ -735,6 +740,8 @@
 				934196DF1DB0C124004BBBB7 /* UIViewController+OBAAnalytics.m */,
 				934196E01DB0C124004BBBB7 /* UIViewController+OBAContainment.h */,
 				934196E11DB0C124004BBBB7 /* UIViewController+OBAContainment.m */,
+				93F957481E9AFB020022586B /* UIWindow+OBAAdditions.h */,
+				93F957491E9AFB020022586B /* UIWindow+OBAAdditions.m */,
 			);
 			name = categories;
 			path = OneBusAway/categories;
@@ -743,6 +750,7 @@
 		934196E81DB0C13F004BBBB7 /* ui */ = {
 			isa = PBXGroup;
 			children = (
+				936EB1BB1E92F27400F4F3A7 /* onboarding */,
 				93F3F88C1E7A7B160025FC78 /* regional_alerts */,
 				93B781A21E64BA7800F2C38D /* map */,
 				934196E91DB0C13F004BBBB7 /* alerts */,
@@ -1398,6 +1406,14 @@
 			path = empty_data_sets;
 			sourceTree = "<group>";
 		};
+		936EB1BB1E92F27400F4F3A7 /* onboarding */ = {
+			isa = PBXGroup;
+			children = (
+				936EB1BF1E92F30C00F4F3A7 /* OnboardingViewController.swift */,
+			);
+			path = onboarding;
+			sourceTree = "<group>";
+		};
 		93A6E5211E6CB23500BEFECE /* ISHHoverBar */ = {
 			isa = PBXGroup;
 			children = (
@@ -1759,12 +1775,14 @@
 				93FE60261E0B2F34006EC9FB /* SVPulsingAnnotationView.m in Sources */,
 				934197A81DB0C140004BBBB7 /* OBAReportProblemWithRecentTripsViewController.m in Sources */,
 				930AFE991DD11EF90092AE82 /* OBAWalkableCell.m in Sources */,
+				936EB1C11E92F30C00F4F3A7 /* OnboardingViewController.swift in Sources */,
 				934197B71DB0C140004BBBB7 /* OBAArrivalAndDepartureSectionBuilder.m in Sources */,
 				9341981F1DB0C1BA004BBBB7 /* OBALabelAndTextFieldTableViewCell.m in Sources */,
 				934197A61DB0C140004BBBB7 /* OBAViewModelRegistry.m in Sources */,
 				9368E5C01DB1584900C329D0 /* OBAEmptyDataSetSource.m in Sources */,
 				934197A41DB0C140004BBBB7 /* OBATableSection.m in Sources */,
 				934198241DB0C1BA004BBBB7 /* OBATextEditViewController.m in Sources */,
+				93F9574A1E9AFB020022586B /* UIWindow+OBAAdditions.m in Sources */,
 				93A6E5241E6CB23500BEFECE /* ISHHoverBar.m in Sources */,
 				9341977F1DB0C140004BBBB7 /* OBABookmarkGroupsViewController.m in Sources */,
 				934197831DB0C140004BBBB7 /* OBABookmarkedRouteCell.m in Sources */,


### PR DESCRIPTION
Ensure that the user must either accept or reject location services before the main application UI is ever displayed. This will help prevent frustrating and hard-to-track-down race conditions throughout other parts of the app.