### PR TITLE
Only download regions data once a week

### DIFF
--- a/OBAKit/Helpers/OBACommon.h
+++ b/OBAKit/Helpers/OBACommon.h
@@ -38,11 +38,14 @@ typedef NS_ENUM(NSInteger, OBANavigationTargetType) {
     OBANavigationTargetTypeContactUs,
 };
 
+typedef NS_ENUM(NSUInteger, OBAErrorCode) {
+    OBAErrorCodeLocationAuthorizationFailed = 1002,
+    OBAErrorCodeMissingFieldInData,
+};
+
 NSString * _Nullable NSStringFromOBASearchType(OBASearchType searchType);
 
 extern NSString * const OBAErrorDomain;
-extern const NSInteger kOBAErrorDuplicateEntity;
-extern const NSInteger kOBAErrorMissingFieldInData;
 
 // 3D Touch Quick Actions
 extern NSString * const kApplicationShortcutMap;

--- a/OBAKit/Helpers/OBACommon.m
+++ b/OBAKit/Helpers/OBACommon.m
@@ -33,9 +33,6 @@ NSString * const OBADebugModeUserDefaultsKey = @"OBADebugModeUserDefaultsKey";
 
 NSString * const OBADeepLinkServerAddress = @"https://www.onebusaway.co";
 
-const NSInteger kOBAErrorDuplicateEntity = 1000;
-const NSInteger kOBAErrorMissingFieldInData = 1001;
-
 NSString * NSStringFromOBASearchType(OBASearchType searchType) {
     switch (searchType) {
         case OBASearchTypePending: {

--- a/OBAKit/Location/OBARegionHelper.h
+++ b/OBAKit/Location/OBARegionHelper.h
@@ -7,6 +7,7 @@
 //
 
 @import Foundation;
+@import PromiseKit;
 #import <OBAKit/OBAModelService.h>
 #import <OBAKit/OBARegionV2.h>
 #import <OBAKit/OBALocationManager.h>
@@ -17,6 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class OBARegionHelper;
 @protocol OBARegionHelperDelegate <NSObject>
 - (void)regionHelperShowRegionListController:(OBARegionHelper*)regionHelper;
+- (void)regionHelperDidRefreshRegions:(OBARegionHelper*)regionHelper;
 @end
 
 @interface OBARegionHelper : NSObject
@@ -24,12 +26,18 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic,strong) OBAModelDAO *modelDAO;
 @property(nonatomic,strong) OBAModelService *modelService;
 @property(nonatomic,weak) id<OBARegionHelperDelegate> delegate;
+@property(nonatomic,copy,readonly) NSArray<OBARegionV2*> *regionsWithin100Miles;
 
-- (instancetype)initWithLocationManager:(OBALocationManager*)locationManager NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithLocationManager:(OBALocationManager*)locationManager modelService:(OBAModelService*)modelService NS_DESIGNATED_INITIALIZER;
 - (instancetype)init NS_UNAVAILABLE;
 
-- (void)updateNearestRegion;
-- (void)updateRegion;
+- (void)setNearestRegion;
+/**
+ Refreshes the list of regions, and then finally returns the current authorization status. Or nil.
+
+ @return nil or a promise that resolves to the current authorization status.
+ */
+- (nullable AnyPromise*)refreshData;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/OBAKit/Location/OBARegionHelper.m
+++ b/OBAKit/Location/OBARegionHelper.m
@@ -10,86 +10,63 @@
 #import <OBAKit/OBAApplication.h>
 #import <OBAKit/OBAMacros.h>
 #import <OBAKit/OBALogging.h>
+#import <OBAKit/OBARegionStorage.h>
+#import <OBAKit/OBAKit-Swift.h>
 
 @interface OBARegionHelper ()
-@property(nonatomic,strong) NSMutableArray *regions;
+@property(nonatomic,copy) NSArray<OBARegionV2*> *regions;
+@property(nonatomic,strong) OBARegionStorage *regionStorage;
+@property(nonatomic,strong) NSLock *refreshLock;
 @end
 
 @implementation OBARegionHelper
 
-- (instancetype)initWithLocationManager:(OBALocationManager*)locationManager {
+- (instancetype)initWithLocationManager:(OBALocationManager*)locationManager modelService:(OBAModelService*)modelService {
     self = [super init];
 
     if (self) {
+        _refreshLock = [[NSLock alloc] init];
         _locationManager = locationManager;
-        [self registerForLocationNotifications];
+        _modelService = modelService;
+        _regionStorage = [[OBARegionStorage alloc] initWithModelFactory:modelService.modelFactory];
+        _regions = [_regionStorage regions];
     }
     return self;
 }
 
-- (void)updateNearestRegion {
-    [self updateRegion];
+- (void)start {
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(locationManagerDidUpdateLocation:) name:OBALocationDidUpdateNotification object:self.locationManager];
+
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(locationManagerDidFailWithError:) name:OBALocationManagerDidFailWithErrorNotification object:self.locationManager];
 }
 
-- (void)updateRegion {
-    [self.modelService requestRegions:^(id responseData, NSUInteger responseCode, NSError *error) {
-        if (error && !responseData) {
-            responseData = [self loadDefaultRegions];
+- (nullable AnyPromise*)refreshData {
+    if (![self.refreshLock tryLock]) {
+        return nil;
+    }
+
+    return [self.modelService requestRegions].then(^(NSArray<OBARegionV2*>* regions) {
+        self.regionStorage.regions = regions;
+        self.regions = [OBARegionHelper filterAcceptableRegions:regions];
+
+        if (self.modelDAO.automaticallySelectRegion && self.locationManager.locationServicesEnabled) {
+            [self setNearestRegion];
         }
-        [self processRegionData:responseData];
-     }];
-}
-
-- (OBAListWithRangeAndReferencesV2*)loadDefaultRegions {
-    DDLogWarn(@"Unable to retrieve regions file. Loading default regions from the app bundle.");
-
-    OBAModelFactory *factory = self.modelService.modelFactory;
-    NSError *error = nil;
-
-    NSData *data = [[NSData alloc] initWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"regions-v3" ofType:@"json"]];
-
-    OBAGuard(data.length > 0) else {
-        DDLogError(@"Unable to load regions from app bundle.");
-        return nil;
-    }
-
-    id defaultJSONData = [NSJSONSerialization JSONObjectWithData:data options:(NSJSONReadingOptions)0 error:&error];
-
-    if (!defaultJSONData) {
-        DDLogError(@"Unable to convert bundled regions into an object. %@", error);
-        return nil;
-    }
-
-    OBAListWithRangeAndReferencesV2 *references = [factory getRegionsV2FromJson:defaultJSONData error:&error];
-
-    if (error) {
-        DDLogError(@"Issue parsing bundled JSON data: %@", error);
-    }
-
-    return references;
-}
-
-- (void)processRegionData:(OBAListWithRangeAndReferencesV2*)regionData {
-    OBAGuard(regionData) else {
-        return;
-    }
-
-    self.regions = [[NSMutableArray alloc] initWithArray:regionData.values];
-
-    if (self.modelDAO.automaticallySelectRegion && self.locationManager.locationServicesEnabled) {
-        [self setNearestRegion];
-    }
-    else {
-        [self setRegion];
-    }
+        else {
+            [self refreshCurrentRegionData];
+        }
+        [self.delegate regionHelperDidRefreshRegions:self];
+    }).catch(^(NSError *error) {
+        DDLogError(@"Error occurred while updating regions: %@", error);
+    }).always(^{
+        [self.refreshLock unlock];
+    }).then(^{
+        return @([CLLocationManager authorizationStatus]);
+    });
 }
 
 - (void)setNearestRegion {
-    if (self.regions.count == 0) {
-        return;
-    }
-
-    CLLocation *newLocation = self.locationManager.currentLocation;
+    NSArray<OBARegionV2*> *candidateRegions = self.regionsWithin100Miles;
 
     // If the location manager is being lame and is refusing to
     // give us a location, then we need to proactively bail on the
@@ -97,49 +74,48 @@
     // non-clever treatment of nil will result in us unexpectedly
     // selecting Tampa. This happens because Tampa is the closest
     // region to lat long point (0,0).
-    //
-    // Once we're in the block, if we have a region already,
-    // then do nothing and bail. Otherwise, if we don't yet have a
-    // region, show the picker.
-    if (!newLocation) {
-        if (!self.modelDAO.currentRegion) {
-            self.modelDAO.automaticallySelectRegion = NO;
-            [self.delegate regionHelperShowRegionListController:self];
-        }
-        return;
-    }
-
-    NSMutableArray *notSupportedRegions = [NSMutableArray array];
-
-    for (OBARegionV2 *region in self.regions) {
-        if (!region.supportsObaRealtimeApis || !region.active) {
-            [notSupportedRegions addObject:region];
-        }
-    }
-
-    [self.regions removeObjectsInArray:notSupportedRegions];
-
-    NSMutableArray *regionsToRemove = [NSMutableArray array];
-
-    for (OBARegionV2 *region in self.regions) {
-        CLLocationDistance distance = [region distanceFromLocation:newLocation];
-
-        if (distance > 160934) { // 100 miles
-            [regionsToRemove addObject:region];
-        }
-    }
-
-    [self.regions removeObjectsInArray:regionsToRemove];
-
-    if (self.regions.count == 0) {
+    if (candidateRegions.count == 0) {
         self.modelDAO.automaticallySelectRegion = NO;
         [self.delegate regionHelperShowRegionListController:self];
         return;
     }
 
-    [self.regions sortUsingComparator:^(OBARegionV2 *region1, OBARegionV2 *region2) {
-        CLLocationDistance distance1 = [region1 distanceFromLocation:newLocation];
-        CLLocationDistance distance2 = [region2 distanceFromLocation:newLocation];
+    self.modelDAO.currentRegion = candidateRegions[0];
+    self.modelDAO.automaticallySelectRegion = YES;
+}
+
+- (void)refreshCurrentRegionData {
+    OBARegionV2 *currentRegion = self.modelDAO.currentRegion;
+
+    if (!currentRegion && self.locationManager.hasRequestedInUseAuthorization) {
+        [self.delegate regionHelperShowRegionListController:self];
+        return;
+    }
+
+    for (OBARegionV2 *region in self.regions) {
+        if (currentRegion.identifier == region.identifier) {
+            self.modelDAO.currentRegion = region;
+            break;
+        }
+    }
+}
+
+#pragma mark - Public Properties
+
+- (NSArray<OBARegionV2*>*)regionsWithin100Miles {
+    if (self.regions.count == 0) {
+        return @[];
+    }
+
+    CLLocation *currentLocation = self.locationManager.currentLocation;
+
+    if (!currentLocation) {
+        return @[];
+    }
+
+    return [[self.regions sortedArrayUsingComparator:^NSComparisonResult(OBARegionV2 *r1, OBARegionV2 *r2) {
+        CLLocationDistance distance1 = [r1 distanceFromLocation:currentLocation];
+        CLLocationDistance distance2 = [r2 distanceFromLocation:currentLocation];
 
         if (distance1 > distance2) {
             return NSOrderedDescending;
@@ -150,27 +126,9 @@
         else {
             return NSOrderedSame;
         }
-     }];
-
-    self.modelDAO.currentRegion = self.regions[0];
-    self.modelDAO.automaticallySelectRegion = YES;
-}
-
-- (void)setRegion {
-    NSString *regionName = self.modelDAO.currentRegion.regionName;
-
-    if (!regionName && self.locationManager.hasRequestedInUseAuthorization) {
-        [self.delegate regionHelperShowRegionListController:self];
-        return;
-    }
-
-    // TODO: instead of comparing name, the regions' identifiers should be used instead.
-    for (OBARegionV2 *region in self.regions) {
-        if ([region.regionName isEqual:regionName]) {
-            self.modelDAO.currentRegion = region;
-            break;
-        }
-    }
+    }] filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(OBARegionV2 *r, NSDictionary<NSString *,id> *bindings) {
+        return ([r distanceFromLocation:currentLocation] < 160934); // == 100 miles
+    }]];
 }
 
 #pragma mark - Lazy Loaders
@@ -182,20 +140,7 @@
     return _modelDAO;
 }
 
-- (OBAModelService*)modelService {
-    if (!_modelService) {
-        _modelService = [OBAApplication sharedApplication].modelService;
-    }
-    return _modelService;
-}
-
 #pragma mark - OBALocationManager Notifications
-
-- (void)registerForLocationNotifications {
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(locationManagerDidUpdateLocation:) name:OBALocationDidUpdateNotification object:self.locationManager];
-
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(locationManagerDidFailWithError:) name:OBALocationManagerDidFailWithErrorNotification object:self.locationManager];
-}
 
 - (void)locationManagerDidUpdateLocation:(NSNotification*)note {
     if (self.modelDAO.automaticallySelectRegion) {
@@ -208,6 +153,22 @@
         self.modelDAO.automaticallySelectRegion = NO;
         [self.delegate regionHelperShowRegionListController:self];
     }
+}
+
+#pragma mark - Data Munging
+
++ (NSArray<OBARegionV2*>*)filterAcceptableRegions:(NSArray<OBARegionV2*>*)regions {
+    return [regions filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(OBARegionV2 *region, NSDictionary<NSString *,id> * _Nullable bindings) {
+        if (!region.active) {
+            return NO;
+        }
+
+        if (!region.supportsObaRealtimeApis) {
+            return NO;
+        }
+
+        return YES;
+    }]];
 }
 
 @end

--- a/OBAKit/Location/OBARegionStorage.h
+++ b/OBAKit/Location/OBARegionStorage.h
@@ -1,0 +1,23 @@
+//
+//  OBARegionStorage.h
+//  OBAKit
+//
+//  Created by Aaron Brethorst on 4/2/17.
+//  Copyright © 2017 OneBusAway. All rights reserved.
+//
+
+@import Foundation;
+#import <OBAKit/OBARegionV2.h>
+#import <OBAKit/OBAModelFactory.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface OBARegionStorage : NSObject
+@property(nonatomic,copy) NSArray<OBARegionV2*> *regions;
+
+- (instancetype)initWithModelFactory:(OBAModelFactory*)modelFactory NS_DESIGNATED_INITIALIZER;
+- (instancetype)init NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/OBAKit/Location/OBARegionStorage.m
+++ b/OBAKit/Location/OBARegionStorage.m
@@ -1,0 +1,91 @@
+//
+//  OBARegionStorage.m
+//  OBAKit
+//
+//  Created by Aaron Brethorst on 4/2/17.
+//  Copyright © 2017 OneBusAway. All rights reserved.
+//
+
+#import <OBAKit/OBARegionStorage.h>
+#import <OBAKit/OBAMacros.h>
+#import <OBAKit/OBALogging.h>
+#import <OBAKit/OBAKit-Swift.h>
+
+static NSString * const OBALocalRegionsFileName = @"regions.json";
+
+@interface OBARegionStorage()
+@property(nonatomic,strong) OBAModelFactory *modelFactory;
+@property(nonatomic,strong) dispatch_queue_t serialQueue;
+@end
+
+@implementation OBARegionStorage
+
+- (instancetype)initWithModelFactory:(OBAModelFactory*)modelFactory {
+    self = [super init];
+    if (self) {
+        _modelFactory = modelFactory;
+        _serialQueue = dispatch_queue_create("org.onebusaway.iphone.region_storage", DISPATCH_QUEUE_SERIAL);
+    }
+    return self;
+}
+
+#pragma mark - Public Properties
+
+- (void)setRegions:(NSArray<OBARegionV2*>*)regions {
+    _regions = regions ? [regions copy] : @[];
+
+    [self writeRegionsToDisk:_regions];
+}
+
+#pragma mark - Persistence
+
++ (NSString*)localRegionsFilePath {
+    return [FileHelpers pathToFileName:OBALocalRegionsFileName inDirectory:NSApplicationSupportDirectory];
+}
+
+- (void)writeRegionsToDisk:(NSArray<OBARegionV2*>*)regions {
+    OBAGuard(regions) else {
+        return;
+    }
+
+    dispatch_sync(self.serialQueue, ^{
+        NSData *data = [NSKeyedArchiver archivedDataWithRootObject:regions];
+        [data writeToFile:OBARegionStorage.localRegionsFilePath atomically:NO];
+    });
+}
+
+- (NSArray<OBARegionV2*>*)readRegionsFromDisk {
+    __block NSArray<OBARegionV2*>* regions = nil;
+    dispatch_sync(self.serialQueue, ^{
+        regions = [self persistedRegions] ?: [self bundledRegions];
+    });
+    return regions;
+}
+
+- (NSArray<OBARegionV2*>*)bundledRegions {
+    NSData *data = [[NSData alloc] initWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"regions-v3" ofType:@"json"]];
+    id JSON = [NSJSONSerialization JSONObjectWithData:data options:(NSJSONReadingOptions)0 error:nil];
+    OBAListWithRangeAndReferencesV2 *references = [self.modelFactory getRegionsV2FromJson:JSON error:nil];
+
+    return references.values;
+}
+
+- (nullable NSArray<OBARegionV2*>*)persistedRegions {
+    NSFileManager *fileManager = [[NSFileManager alloc] init];
+
+    if (![fileManager fileExistsAtPath:OBARegionStorage.localRegionsFilePath]) {
+        return nil;
+    }
+
+    NSArray<OBARegionV2*>* regions = nil;
+
+    @try {
+        regions = [NSKeyedUnarchiver unarchiveObjectWithFile:OBARegionStorage.localRegionsFilePath];
+    } @catch (NSException *exception) {
+        DDLogError(@"Failed to unarchive persisted regions: %@", exception);
+    }
+
+    return regions;
+}
+
+@end

--- a/OBAKit/OBAApplication.h
+++ b/OBAKit/OBAApplication.h
@@ -31,8 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  This notification is posted when the region changes and the app cannot generate an API URL from it.
  */
-// TODO: give it a better name.
-extern NSString *const kOBAApplicationSettingsRegionRefreshNotification;
+extern NSString *const OBARegionServerInvalidNotification;
 
 @interface OBAApplication : NSObject
 @property (nonatomic, strong, readonly) OBAReferencesV2 *references;

--- a/OBAKit/OBAApplication.m
+++ b/OBAKit/OBAApplication.m
@@ -14,7 +14,7 @@
 #import <OBAKit/OBACommon.h>
 
 static NSString *const kOBADefaultRegionApiServerName = @"http://regions.onebusaway.org";
-NSString *const kOBAApplicationSettingsRegionRefreshNotification = @"kOBAApplicationSettingsRegionRefreshNotification";
+NSString *const OBARegionServerInvalidNotification = @"OBARegionServerInvalidNotification";
 
 @interface OBAApplication ()
 @property (nonatomic, strong, readwrite) OBAReferencesV2 *references;
@@ -73,7 +73,7 @@ NSString *const kOBAApplicationSettingsRegionRefreshNotification = @"kOBAApplica
 
     self.modelService.locationManager = self.locationManager;
 
-    self.regionHelper = [[OBARegionHelper alloc] initWithLocationManager:self.locationManager];
+    self.regionHelper = [[OBARegionHelper alloc] initWithLocationManager:self.locationManager modelService:self.modelService];
 
     self.privacyBroker = [[PrivacyBroker alloc] initWithModelDAO:self.modelDao locationManager:self.locationManager];
 
@@ -164,9 +164,6 @@ NSString *const kOBAApplicationSettingsRegionRefreshNotification = @"kOBAApplica
 - (void)refreshSettings {
     if (self.modelDao.currentRegion.baseURL) {
         self.modelService.obaJsonDataSource = [OBAJsonDataSource JSONDataSourceWithBaseURL:self.modelDao.currentRegion.baseURL userID:[OBAUser userIdFromDefaults]];
-    }
-    else {
-        [[NSNotificationCenter defaultCenter] postNotificationName:kOBAApplicationSettingsRegionRefreshNotification object:nil];
     }
 
     self.modelService.googleMapsJsonDataSource = [OBAJsonDataSource googleMapsJSONDataSource];

--- a/OBAKit/OBAKit.xcodeproj/project.pbxproj
+++ b/OBAKit/OBAKit.xcodeproj/project.pbxproj
@@ -211,6 +211,8 @@
 		9358CDB21DEA242B00132CDE /* OBAUpcomingDeparture.h in Headers */ = {isa = PBXBuildFile; fileRef = 9358CDB01DEA242B00132CDE /* OBAUpcomingDeparture.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9358CDB31DEA242B00132CDE /* OBAUpcomingDeparture.m in Sources */ = {isa = PBXBuildFile; fileRef = 9358CDB11DEA242B00132CDE /* OBAUpcomingDeparture.m */; };
 		936EB1B61E91746400F4F3A7 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 936EB1B51E91746400F4F3A7 /* SystemConfiguration.framework */; };
+		936EB1B91E91A83700F4F3A7 /* OBARegionStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 936EB1B71E91A83700F4F3A7 /* OBARegionStorage.h */; };
+		936EB1BA1E91A83700F4F3A7 /* OBARegionStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 936EB1B81E91A83700F4F3A7 /* OBARegionStorage.m */; };
 		93B282C41DC664C7005013D7 /* OBATripDeepLink.h in Headers */ = {isa = PBXBuildFile; fileRef = 93B282C21DC664C7005013D7 /* OBATripDeepLink.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		93B282C51DC664C7005013D7 /* OBATripDeepLink.m in Sources */ = {isa = PBXBuildFile; fileRef = 93B282C31DC664C7005013D7 /* OBATripDeepLink.m */; };
 		93B282C81DC68892005013D7 /* NSURLQueryItem+OBAAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 93B282C61DC68892005013D7 /* NSURLQueryItem+OBAAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -444,6 +446,8 @@
 		9358CDB01DEA242B00132CDE /* OBAUpcomingDeparture.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAUpcomingDeparture.h; sourceTree = "<group>"; };
 		9358CDB11DEA242B00132CDE /* OBAUpcomingDeparture.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAUpcomingDeparture.m; sourceTree = "<group>"; };
 		936EB1B51E91746400F4F3A7 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
+		936EB1B71E91A83700F4F3A7 /* OBARegionStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBARegionStorage.h; sourceTree = "<group>"; };
+		936EB1B81E91A83700F4F3A7 /* OBARegionStorage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBARegionStorage.m; sourceTree = "<group>"; };
 		93B282C21DC664C7005013D7 /* OBATripDeepLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBATripDeepLink.h; sourceTree = "<group>"; };
 		93B282C31DC664C7005013D7 /* OBATripDeepLink.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBATripDeepLink.m; sourceTree = "<group>"; };
 		93B282C61DC68892005013D7 /* NSURLQueryItem+OBAAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURLQueryItem+OBAAdditions.h"; sourceTree = "<group>"; };
@@ -608,6 +612,8 @@
 				934195811DB0B099004BBBB7 /* OBARegionHelper.m */,
 				934195821DB0B099004BBBB7 /* OBASphericalGeometryLibrary.h */,
 				934195831DB0B099004BBBB7 /* OBASphericalGeometryLibrary.m */,
+				936EB1B71E91A83700F4F3A7 /* OBARegionStorage.h */,
+				936EB1B81E91A83700F4F3A7 /* OBARegionStorage.m */,
 			);
 			path = Location;
 			sourceTree = "<group>";
@@ -869,6 +875,7 @@
 				934196861DB0B099004BBBB7 /* OBATripDetailsV2.h in Headers */,
 				9341966B1DB0B099004BBBB7 /* OBARegionV2.h in Headers */,
 				9341964B1DB0B099004BBBB7 /* OBAArrivalAndDepartureInstanceRef.h in Headers */,
+				936EB1B91E91A83700F4F3A7 /* OBARegionStorage.h in Headers */,
 				9341965E1DB0B099004BBBB7 /* OBAHasServiceAlerts.h in Headers */,
 				934195FA1DB0B099004BBBB7 /* NSObject+OBADescription.h in Headers */,
 				9358CDB21DEA242B00132CDE /* OBAUpcomingDeparture.h in Headers */,
@@ -1129,6 +1136,7 @@
 				934196041DB0B099004BBBB7 /* OBAConsoleLogger.m in Sources */,
 				934196591DB0B099004BBBB7 /* OBAEntryWithReferencesV2.m in Sources */,
 				934196291DB0B099004BBBB7 /* OBATripContinuationMapAnnotation.m in Sources */,
+				936EB1BA1E91A83700F4F3A7 /* OBARegionStorage.m in Sources */,
 				934196BB1DB0B0AF004BBBB7 /* OBAUIBuilder.m in Sources */,
 				934196851DB0B099004BBBB7 /* OBAStopV2.m in Sources */,
 				9341967B1DB0B099004BBBB7 /* OBASituationConsequenceV2.m in Sources */,

--- a/OneBusAway/ui/onboarding/OnboardingViewController.swift
+++ b/OneBusAway/ui/onboarding/OnboardingViewController.swift
@@ -15,7 +15,6 @@ import SnapKit
 }
 
 @objc class OnboardingViewController: UIViewController {
-
     let stackView = UIStackView.init()
     weak var delegate: OnboardingDelegate?
 
@@ -80,8 +79,6 @@ import SnapKit
     }
 
     @objc func showLocationPrompt() {
-        CLLocationManager.requestAuthorization(type: .whenInUse).always {
-            self.delegate?.onboardingControllerRequestedAuthorization(self)
-        }
+        self.delegate?.onboardingControllerRequestedAuthorization(self)
     }
 }

--- a/OneBusAway/ui/regions/RegionListViewController.swift
+++ b/OneBusAway/ui/regions/RegionListViewController.swift
@@ -160,7 +160,7 @@ class RegionListViewController: OBAStaticTableViewController, RegionBuilderDeleg
             self.modelDAO.automaticallySelectRegion = !self.modelDAO.automaticallySelectRegion
 
             if (self.modelDAO.automaticallySelectRegion) {
-                OBAApplication.shared().regionHelper.updateNearestRegion()
+                OBAApplication.shared().regionHelper.refreshData()
                 SVProgressHUD.show()
             }
             else {


### PR DESCRIPTION
Fixes #678 - Reduce frequency of region updates to once per week
Fixes #873 - Redesign the Region Manager

The app now checks at startup to see how long it has been since the last region download, and will only download region data if it has been a week or more.

This commit also improves the first launch experience for users who decline to give the app access to their location.