### PR TITLE
Moves the empty data set UI on search up so it isn’t clipped

### DIFF
--- a/OneBusAway/ui/search/MapSearchViewController.swift
+++ b/OneBusAway/ui/search/MapSearchViewController.swift
@@ -28,7 +28,7 @@ class MapSearchViewController: OBAStaticTableViewController, UISearchResultsUpda
         super.viewDidLoad()
 
         let image = UIImage(named: "search_placeholder")
-        self.emptyDataSetVerticalOffset = -88.0
+        self.emptyDataSetVerticalOffset = -135.0
         self.emptyDataSetImage = image
         self.emptyDataSetTitle = NSLocalizedString("map_search.empty_data_set_description", comment: "The empty data set description for the search controller")
     }


### PR DESCRIPTION
Fixes #1034 - Search UI's 'empty set' description is clipped on smaller screens