### PR TITLE
Prevents the bookmarks controller from reloading while editing

### DIFF
--- a/OneBusAway/ui/bookmarks/OBABookmarksViewController.m
+++ b/OneBusAway/ui/bookmarks/OBABookmarksViewController.m
@@ -92,6 +92,17 @@ static NSString * const OBABookmarkSortUserDefaultsKey = @"OBABookmarkSortUserDe
     [self cancelTimer];
 }
 
+- (void)setEditing:(BOOL)editing animated:(BOOL)animated {
+    [super setEditing:editing animated:animated];
+
+    if (editing) {
+        [self cancelTimer];
+    }
+    else {
+        [self startTimer];
+    }
+}
+
 #pragma mark - OBANavigationTargetAware
 
 - (OBANavigationTarget*)navigationTarget {
@@ -107,7 +118,24 @@ static NSString * const OBABookmarkSortUserDefaultsKey = @"OBABookmarkSortUserDe
 }
 
 - (void)locationChanged:(NSNotification*)note {
+    if (self.editing) {
+        return;
+    };
     [self loadDataWithTableReload:YES];
+}
+
+- (void)reachabilityChanged:(NSNotification*)note {
+    if (self.editing) {
+        return;
+    };
+
+    // Automatically refresh whenever the connection goes from offline -> online
+    if ([OBAApplication sharedApplication].isServerReachable) {
+        [self startTimer];
+    }
+    else {
+        [self cancelTimer];
+    }
 }
 
 #pragma mark - Refresh Bookmarks
@@ -215,18 +243,6 @@ static NSString * const OBABookmarkSortUserDefaultsKey = @"OBABookmarkSortUserDe
             [self.tableView reloadData];
         }
     });
-}
-
-#pragma mark - Reachability
-
-- (void)reachabilityChanged:(NSNotification*)note {
-    // Automatically refresh whenever the connection goes from offline -> online
-    if ([OBAApplication sharedApplication].isServerReachable) {
-        [self startTimer];
-    }
-    else {
-        [self cancelTimer];
-    }
 }
 
 #pragma mark - Data Loading


### PR DESCRIPTION
Fixes #1037 - Weird bookmark-editing display bug

If the bookmarks controller is in edit mode (where you can drag bookmarks around), then prevent it from reloading on a location change, or automatically reloading on a timer. This way, the user can continue editing data without weird hiccups. I’m pretty certain this was causing the content ‘blanking’ issue described in #1037.