### PR TITLE
Stops double-encoding spaces in Trip Sharing URLs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: objective-c
-osx_image: xcode8.2
+osx_image: xcode8.3
 before_install:
-  - export IOS_SIMULATOR_UDID=`instruments -s devices | grep "iPhone SE (10.2" | ruby -e "puts gets.split('[')[1].split(']').first"`
+  - export IOS_SIMULATOR_UDID=`instruments -s devices | grep "iPhone SE (10.3" | ruby -e "puts gets.split('[')[1].split(']').first"`
   - echo $IOS_SIMULATOR_UDID
   - open -a "simulator" --args -CurrentDeviceUDID $IOS_SIMULATOR_UDID
 script: set -o pipefail && xcodebuild clean test CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO -project org.onebusaway.iphone.xcodeproj -scheme OneBusAway -sdk iphonesimulator -destination "platform=iOS Simulator,id=$IOS_SIMULATOR_UDID" ONLY_ACTIVE_ARCH=NO | xcpretty

--- a/OBAKit/Models/unmanaged/OBATripDeepLink.m
+++ b/OBAKit/Models/unmanaged/OBATripDeepLink.m
@@ -118,10 +118,8 @@
 #pragma mark - Public Methods
 
 - (NSURL*)deepLinkURL {
-    NSString *stopID = [OBAURLHelpers escapePathVariable:self.stopID];
-
     NSURLComponents *URLComponents = [NSURLComponents componentsWithString:OBADeepLinkServerAddress];
-    URLComponents.path = [NSString stringWithFormat:@"/regions/%@/stops/%@/trips", @(self.regionIdentifier), stopID];
+    URLComponents.path = [NSString stringWithFormat:@"/regions/%@/stops/%@/trips", @(self.regionIdentifier), self.stopID];
 
     URLComponents.queryItems = @[
                                  [NSURLQueryItem queryItemWithName:@"trip_id" value:self.tripID],

--- a/OneBusAway/OneBusAwayTests/OBAKitTests/helpers/OBAURLHelpers_Tests.m
+++ b/OneBusAway/OneBusAwayTests/OBAKitTests/helpers/OBAURLHelpers_Tests.m
@@ -101,4 +101,8 @@ static NSString * const kOBACurrentTimeURLPath = @"/where/current-time.json";
     XCTAssertEqualObjects([OBAURLHelpers normalizeURLPath:kOBACurrentTimeURLPath relativeToBaseURL:baseURLString parameters:@{@"key": @"org.onebusaway.iphone"}], [OBAURLHelpers_Tests portAndPathResultURL]);
 }
 
+- (void)testEscapePathVariableWithSpaces {
+    XCTAssertEqualObjects([OBAURLHelpers escapePathVariable:@"Hillsborough Area Regional Transit_3109"], @"Hillsborough%20Area%20Regional%20Transit_3109");
+}
+
 @end

--- a/OneBusAway/OneBusAwayTests/OBAKitTests/models/OBARegionalAlert_Tests.m
+++ b/OneBusAway/OneBusAwayTests/OBAKitTests/models/OBARegionalAlert_Tests.m
@@ -17,6 +17,12 @@
 
 @implementation OBARegionalAlert_Tests
 
+- (void)setUp {
+    [super setUp];
+
+    [OBATestHelpers configureDefaultTimeZone];
+}
+
 - (void)testDeserialization {
     NSString *sample = @"{\"id\":1330,\"alert_feed_id\":2,\"title\":\"Sounder Everett-Seattle - Delay - Train #1702 (4:33 pm Seattle departure) is delayed approximately 10 minutes\",\"url\":\"http://m.soundtransit.org/node/15271\",\"summary\":\"North Line Train #1702 (4:33 pm Seattle departure) is delayed approximately 10 minutes en route to Everett due to BNSF freight interference.\",\"published_at\":\"2017-03-16T23:49:00.000Z\",\"external_id\":\"15271\",\"created_at\":\"2017-03-16T23:52:25.947Z\",\"updated_at\":\"2017-03-16T23:52:25.947Z\"}";
     NSDictionary *dict = [OBATestHelpers jsonObjectFromString:sample];

--- a/OneBusAway/OneBusAwayTests/OBAKitTests/models/OBATripDeepLink_Tests.swift
+++ b/OneBusAway/OneBusAwayTests/OBAKitTests/models/OBATripDeepLink_Tests.swift
@@ -1,0 +1,57 @@
+//
+//  OBATripDeepLink_Tests.swift
+//  org.onebusaway.iphone
+//
+//  Created by Aaron Brethorst on 4/16/17.
+//  Copyright © 2017 OneBusAway. All rights reserved.
+//
+
+import Quick
+import Nimble
+import OBAKit
+
+class OBATripDeepLink_Tests: QuickSpec {
+    override func spec() {
+        context("in Tampa") {
+            let region = OBATestHelpers.tampaRegion
+
+            describe("a deep link") {
+                var deepLink: OBATripDeepLink!
+                beforeEach {
+                    deepLink = OBATripDeepLink.init()
+                    deepLink.regionIdentifier = region.identifier
+                    deepLink.stopID = "Hillsborough Area Regional Transit_4551"
+                    deepLink.tripID = "Hillsborough Area Regional Transit_232378"
+                    deepLink.serviceDate = 1486098000000
+                    deepLink.stopSequence = 8
+                }
+
+                it("has a properly encoded URL") {
+                    let deepLinkURL = URL.init(string: "https://www.onebusaway.co/regions/0/stops/Hillsborough%20Area%20Regional%20Transit_4551/trips?trip_id=Hillsborough%20Area%20Regional%20Transit_232378&service_date=1486098000000&stop_sequence=8")!
+                    expect(deepLink.deepLinkURL).to(equal(deepLinkURL))
+                }
+            }
+        }
+
+        context("in Puget Sound") {
+            let region = OBATestHelpers.pugetSoundRegion
+
+            describe("a deep link") {
+                var deepLink: OBATripDeepLink!
+                beforeEach {
+                    deepLink = OBATripDeepLink.init()
+                    deepLink.regionIdentifier = region.identifier
+                    deepLink.stopID = "1_1234567"
+                    deepLink.tripID = "1_232378"
+                    deepLink.serviceDate = 1486098000000
+                    deepLink.stopSequence = 8
+                }
+
+                it("has a properly encoded URL") {
+                    let deepLinkURL = URL.init(string: "https://www.onebusaway.co/regions/1/stops/1_1234567/trips?trip_id=1_232378&service_date=1486098000000&stop_sequence=8")!
+                    expect(deepLink.deepLinkURL).to(equal(deepLinkURL))
+                }
+            }
+        }
+    }
+}

--- a/OneBusAway/OneBusAwayTests/OneBusAwayTests-Bridging-Header.h
+++ b/OneBusAway/OneBusAwayTests/OneBusAwayTests-Bridging-Header.h
@@ -1,0 +1,6 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+
+#import "OBATestHarnessPersistenceLayer.h"
+#import "OBATestHelpers.h"

--- a/OneBusAway/OneBusAwayTests/helpers/OBATestHelpers.h
+++ b/OneBusAway/OneBusAwayTests/helpers/OBATestHelpers.h
@@ -10,6 +10,8 @@
 @import OBAKit;
 #import "OBATestHarnessPersistenceLayer.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class OBARegionV2;
 
 @interface OBATestHelpers : NSObject
@@ -67,8 +69,9 @@
 
 // Fixture Helpers
 
-+ (OBARegionV2*)pugetSoundRegion;
-
-+ (OBARegionV2*)tampaRegion;
+@property(class,nonatomic,readonly,copy) OBARegionV2 *pugetSoundRegion;
+@property(class,nonatomic,readonly,copy) OBARegionV2 *tampaRegion;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/OneBusAway/OneBusAwayTests/helpers/OBATestHelpers.h
+++ b/OneBusAway/OneBusAwayTests/helpers/OBATestHelpers.h
@@ -72,6 +72,12 @@ NS_ASSUME_NONNULL_BEGIN
 @property(class,nonatomic,readonly,copy) OBARegionV2 *pugetSoundRegion;
 @property(class,nonatomic,readonly,copy) OBARegionV2 *tampaRegion;
 
+// Time and Time Zones
+
+@property(class,nonatomic,readonly,assign) NSInteger timeZoneOffsetForTests;
+@property(class,nonatomic,readonly,copy) NSTimeZone *timeZoneForTests;
++ (void)configureDefaultTimeZone;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/OneBusAway/OneBusAwayTests/helpers/OBATestHelpers.m
+++ b/OneBusAway/OneBusAwayTests/helpers/OBATestHelpers.m
@@ -57,4 +57,19 @@
     return regions[0];
 }
 
+#pragma mark - Time and Time Zones
+
+// this is the number of seconds that Seattle is behind GMT during DST.
++ (NSInteger)timeZoneOffsetForTests {
+    return -25200;
+}
+
++ (NSTimeZone*)timeZoneForTests {
+    return [NSTimeZone timeZoneForSecondsFromGMT:[OBATestHelpers timeZoneOffsetForTests]];
+}
+
++ (void)configureDefaultTimeZone {
+    NSTimeZone.defaultTimeZone = [OBATestHelpers timeZoneForTests];
+}
+
 @end

--- a/org.onebusaway.iphone.xcodeproj/project.pbxproj
+++ b/org.onebusaway.iphone.xcodeproj/project.pbxproj
@@ -522,6 +522,7 @@
 		9368E5BF1DB1584900C329D0 /* OBAEmptyDataSetSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAEmptyDataSetSource.m; sourceTree = "<group>"; };
 		936EB1BF1E92F30C00F4F3A7 /* OnboardingViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnboardingViewController.swift; sourceTree = "<group>"; };
 		936F45D91C78D06600C61656 /* OneBusAwayTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OneBusAwayTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		9373E7101EA4087A0019C7CB /* OneBusAwayTests-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "OneBusAwayTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		9385EC391DCF14C60020CCB2 /* OBASettingsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBASettingsViewController.h; sourceTree = "<group>"; };
 		9385EC3A1DCF14C60020CCB2 /* OBASettingsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBASettingsViewController.m; sourceTree = "<group>"; };
 		9385EC3F1DCF1D910020CCB2 /* ServiceAlertDetailsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServiceAlertDetailsViewController.swift; sourceTree = "<group>"; };
@@ -1203,6 +1204,7 @@
 		934198441DB0C218004BBBB7 /* OneBusAwayTests */ = {
 			isa = PBXGroup;
 			children = (
+				9373E7101EA4087A0019C7CB /* OneBusAwayTests-Bridging-Header.h */,
 				9331E4141E56F662001E27C2 /* Frameworks */,
 				9358CD9F1DEA19BA00132CDE /* helpers */,
 				934198451DB0C218004BBBB7 /* Fixtures */,
@@ -1539,6 +1541,7 @@
 					};
 					936F45D81C78D06600C61656 = {
 						CreatedOnToolsVersion = 7.2.1;
+						LastSwiftMigration = 0830;
 						ProvisioningStyle = Manual;
 						TestTargetID = 1D6058900D05DD3D006BFB54;
 					};
@@ -1986,6 +1989,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
@@ -2022,6 +2026,9 @@
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = org.onebusaway.OneBusAwayTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "OneBusAway/OneBusAwayTests/OneBusAwayTests-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/OneBusAway.app/OneBusAway";
 			};
 			name = Debug;
@@ -2033,6 +2040,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
@@ -2064,6 +2072,8 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = org.onebusaway.OneBusAwayTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "OneBusAway/OneBusAwayTests/OneBusAwayTests-Bridging-Header.h";
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/OneBusAway.app/OneBusAway";
 				VALIDATE_PRODUCT = YES;
 			};
@@ -2076,6 +2086,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
@@ -2107,6 +2118,8 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = org.onebusaway.OneBusAwayTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "OneBusAway/OneBusAwayTests/OneBusAwayTests-Bridging-Header.h";
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/OneBusAway.app/OneBusAway";
 				VALIDATE_PRODUCT = YES;
 			};
@@ -2119,6 +2132,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
@@ -2150,6 +2164,8 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = org.onebusaway.OneBusAwayTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "OneBusAway/OneBusAwayTests/OneBusAwayTests-Bridging-Header.h";
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/OneBusAway.app/OneBusAway";
 				VALIDATE_PRODUCT = YES;
 			};

--- a/org.onebusaway.iphone.xcodeproj/project.pbxproj
+++ b/org.onebusaway.iphone.xcodeproj/project.pbxproj
@@ -177,6 +177,7 @@
 		93631E4C1604F96800CB7209 /* OBAApplicationDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 93631E4B1604F96800CB7209 /* OBAApplicationDelegate.m */; };
 		9368E5C01DB1584900C329D0 /* OBAEmptyDataSetSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 9368E5BF1DB1584900C329D0 /* OBAEmptyDataSetSource.m */; };
 		936EB1C11E92F30C00F4F3A7 /* OnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 936EB1BF1E92F30C00F4F3A7 /* OnboardingViewController.swift */; };
+		9373E70F1EA4084C0019C7CB /* OBATripDeepLink_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9373E70E1EA4084C0019C7CB /* OBATripDeepLink_Tests.swift */; };
 		9385EC3B1DCF14C60020CCB2 /* OBASettingsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 9385EC3A1DCF14C60020CCB2 /* OBASettingsViewController.m */; };
 		9385EC401DCF1D910020CCB2 /* ServiceAlertDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9385EC3F1DCF1D910020CCB2 /* ServiceAlertDetailsViewController.swift */; };
 		93876DFB1E68AD3900B4343F /* OBAMapAnnotationViewBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 93876DFA1E68AD3900B4343F /* OBAMapAnnotationViewBuilder.m */; };
@@ -522,6 +523,7 @@
 		9368E5BF1DB1584900C329D0 /* OBAEmptyDataSetSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAEmptyDataSetSource.m; sourceTree = "<group>"; };
 		936EB1BF1E92F30C00F4F3A7 /* OnboardingViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnboardingViewController.swift; sourceTree = "<group>"; };
 		936F45D91C78D06600C61656 /* OneBusAwayTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OneBusAwayTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		9373E70E1EA4084C0019C7CB /* OBATripDeepLink_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OBATripDeepLink_Tests.swift; sourceTree = "<group>"; };
 		9373E7101EA4087A0019C7CB /* OneBusAwayTests-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "OneBusAwayTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		9385EC391DCF14C60020CCB2 /* OBASettingsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBASettingsViewController.h; sourceTree = "<group>"; };
 		9385EC3A1DCF14C60020CCB2 /* OBASettingsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBASettingsViewController.m; sourceTree = "<group>"; };
@@ -1331,6 +1333,7 @@
 				9341987C1DB0C219004BBBB7 /* OBATripV2_Tests.m */,
 				9341987D1DB0C219004BBBB7 /* OBAVehicleStatusV2_Tests.m */,
 				93F3F89E1E7BAC510025FC78 /* OBARegionalAlert_Tests.m */,
+				9373E70E1EA4084C0019C7CB /* OBATripDeepLink_Tests.swift */,
 			);
 			path = models;
 			sourceTree = "<group>";
@@ -1832,6 +1835,7 @@
 				934198AE1DB0C219004BBBB7 /* OBAStopV2_Tests.m in Sources */,
 				934198A31DB0C219004BBBB7 /* OBAReportProblemWithStopV2_Tests.m in Sources */,
 				934198A51DB0C219004BBBB7 /* OBARouteV2_Tests.m in Sources */,
+				9373E70F1EA4084C0019C7CB /* OBATripDeepLink_Tests.swift in Sources */,
 				934198981DB0C219004BBBB7 /* OBAEntryWithReferencesV2_Tests.m in Sources */,
 				93F3F89F1E7BAC510025FC78 /* OBARegionalAlert_Tests.m in Sources */,
 				934198B31DB0C219004BBBB7 /* OBATripStopTimeV2_Tests.m in Sources */,


### PR DESCRIPTION
Fixes #959 - Agency names in first part of trip sharing URL are double-encoded