### PR TITLE
Prevents user location callout from appearing on map

### DIFF
--- a/OneBusAway/ui/map/OBAMapViewController.m
+++ b/OneBusAway/ui/map/OBAMapViewController.m
@@ -406,7 +406,7 @@ static const double kStopsInRegionRefreshDelayOnDrag = 0.1;
     if (!_userLocationAnnotationView) {
         _userLocationAnnotationView = [[SVPulsingAnnotationView alloc] initWithAnnotation:annotation reuseIdentifier:@"SVPulsingAnnotationView" size:CGSizeMake(24, 24)];
         _userLocationAnnotationView.annotationColor = [OBATheme userLocationFillColor];
-        _userLocationAnnotationView.canShowCallout = YES;
+        _userLocationAnnotationView.canShowCallout = NO;
         _userLocationAnnotationView.headingImage = [UIImage imageNamed:@"userHeading"];
     }
 


### PR DESCRIPTION
Fixes #1053 - Disable the tap action on the map's user location annotation view