### PR TITLE
Calculates walking distance to stops by absolute distance

### DIFF
--- a/OBAKit/Helpers/OBAWalkingDirections.h
+++ b/OBAKit/Helpers/OBAWalkingDirections.h
@@ -14,6 +14,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface OBAWalkingDirections : NSObject
 + (MKDirections*)directionsFromCoordinate:(CLLocationCoordinate2D)from toCoordinate:(CLLocationCoordinate2D)to;
+
+/**
+ Calculates the travel time in seconds from one location to another, assuming a normal human 
+ walking speed of 1.4 meters per second (about 3.1 miles per hour).
+
+ @param from From location
+ @param to To location
+ @return Walking time in seconds
+ */
++ (NSTimeInterval)walkingTravelTimeFromLocation:(CLLocation*)from toLocation:(CLLocation*)to;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/OBAKit/Helpers/OBAWalkingDirections.m
+++ b/OBAKit/Helpers/OBAWalkingDirections.m
@@ -11,6 +11,8 @@
 #import <OBAKit/OBALogging.h>
 #import <OBAKit/OBACommon.h>
 
+const NSTimeInterval OBAWalkingMetersPerSecond = 1.4;
+
 @implementation OBAWalkingDirections
 
 + (MKDirections*)directionsFromCoordinate:(CLLocationCoordinate2D)from toCoordinate:(CLLocationCoordinate2D)to {
@@ -33,6 +35,11 @@
         r.transportType = MKDirectionsTransportTypeWalking;
         r;
     })];
+}
+
++ (NSTimeInterval)walkingTravelTimeFromLocation:(CLLocation*)from toLocation:(CLLocation*)to {
+    CLLocationDistance distance = [from distanceFromLocation:to];
+    return distance / OBAWalkingMetersPerSecond;
 }
 
 @end

--- a/OBAKit/Models/unmanaged/OBAStopV2.h
+++ b/OBAKit/Models/unmanaged/OBAStopV2.h
@@ -41,6 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic,assign) double lat;
 @property(nonatomic,assign) double lon;
 @property(nonatomic,readonly) CLLocationCoordinate2D coordinate;
+@property(nonatomic,readonly,copy) CLLocation *location;
 
 - (NSComparisonResult)compareUsingName:(OBAStopV2*)aStop;
 

--- a/OBAKit/Models/unmanaged/OBAStopV2.m
+++ b/OBAKit/Models/unmanaged/OBAStopV2.m
@@ -165,6 +165,10 @@
     return c;
 }
 
+- (CLLocation*)location {
+    return [[CLLocation alloc] initWithLatitude:self.lat longitude:self.lon];
+}
+
 #pragma mark NSObject
 
 - (BOOL)isEqual:(OBAStopV2*)object {


### PR DESCRIPTION
Fixes #1027 - The 'walkable' indicator on the stop controller doesn't update location any longer

Doing 'as the crow flies' distance calculations to stops isn't as accurate as getting walking directions and taking the distance from that, but it means that this operation can be done synchronously. That means it'll be updated every time the stop data is reloaded, and it also means that those awful insertion animations will no longer be used.