### PR TITLE
Lines up ‘walking guy’ with ellipsis buttons on stop controller

### DIFF
--- a/OneBusAway/ui/stops/views/OBAWalkableCell.m
+++ b/OneBusAway/ui/stops/views/OBAWalkableCell.m
@@ -32,7 +32,7 @@
         CGFloat barHeight = [@"jJmyg89" sizeWithAttributes:@{NSFontAttributeName: distanceLabelFont}].height + 2;
         CGFloat triangleHeight = 8.f;
         CGFloat triangleWidth = 20.f;
-        CGFloat triangleOffsetFromRight = 23.f;
+        CGFloat triangleOffsetFromRight = 18.f;
 
         [self.contentView mas_makeConstraints:^(MASConstraintMaker *make) {
             make.height.equalTo(@(barHeight+triangleHeight));


### PR DESCRIPTION
Fixes #1086 - Center of walkable cell arrow no longer lines up with '...' button