### PR TITLE
Displays stops’ departure cell context menus from presenting button on iPad

### DIFF
--- a/OneBusAway/ui/stops/OBAStopViewController.m
+++ b/OneBusAway/ui/stops/OBAStopViewController.m
@@ -501,8 +501,8 @@ static NSInteger kStopsSectionTag = 101;
         row.bookmarkExists = [self hasBookmarkForArrivalAndDeparture:dep];
         row.alarmExists = [self hasAlarmForArrivalAndDeparture:dep];
 
-        [row setShowAlertController:^(UIAlertController *alert) {
-            [self presentViewController:alert animated:YES completion:nil];
+        [row setShowAlertController:^(UIView *presentingView, UIAlertController *alert) {
+            [self showAlertController:alert fromView:presentingView];
         }];
         [row setToggleBookmarkAction:^{
             [self toggleBookmarkActionForArrivalAndDeparture:dep];
@@ -531,6 +531,14 @@ static NSInteger kStopsSectionTag = 101;
     section.tag = kStopsSectionTag;
     
     return section;
+}
+
+- (void)showAlertController:(UIAlertController*)alert fromView:(UIView*)view {
+    if (self.traitCollection.userInterfaceIdiom == UIUserInterfaceIdiomPad) {
+        alert.popoverPresentationController.sourceView = view;
+        alert.popoverPresentationController.sourceRect = view.bounds;
+    }
+    [self presentViewController:alert animated:YES completion:nil];
 }
 
 - (OBATableSection*)createToggleDepartureFilterSection {
@@ -574,8 +582,8 @@ static NSInteger kStopsSectionTag = 101;
         row.bookmarkExists = [self hasBookmarkForArrivalAndDeparture:dep];
         row.alarmExists = [self hasAlarmForArrivalAndDeparture:dep];
 
-        [row setShowAlertController:^(UIAlertController *alert) {
-            [self presentViewController:alert animated:YES completion:nil];
+        [row setShowAlertController:^(UIView *presentingView, UIAlertController *alert) {
+            [self showAlertController:alert fromView:presentingView];
         }];
         [row setToggleBookmarkAction:^{
             [self toggleBookmarkActionForArrivalAndDeparture:dep];

--- a/OneBusAway/ui/stops/viewmodels/OBADepartureRow.h
+++ b/OneBusAway/ui/stops/viewmodels/OBADepartureRow.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic,copy,nullable) NSArray<OBAUpcomingDeparture*> *upcomingDepartures;
 @property(nonatomic,copy) NSString *statusText;
 @property(nonatomic,copy) NSString *routeName;
-@property(nonatomic,copy,nullable) void (^showAlertController)(UIAlertController *alertController);
+@property(nonatomic,copy,nullable) void (^showAlertController)(UIView *presentingView, UIAlertController *alertController);
 @property(nonatomic,copy,nullable) void (^toggleBookmarkAction)();
 @property(nonatomic,copy,nullable) void (^toggleAlarmAction)();
 @property(nonatomic,copy,nullable) void (^shareAction)();

--- a/OneBusAway/ui/stops/views/OBAClassicDepartureCell.m
+++ b/OneBusAway/ui/stops/views/OBAClassicDepartureCell.m
@@ -94,7 +94,7 @@
     [alert addAction:action];
 
     if ([self departureRow].showAlertController) {
-        [self departureRow].showAlertController(alert);
+        [self departureRow].showAlertController(self.contextMenuButton, alert);
     }
 }
 


### PR DESCRIPTION
Fixes #1107 - tapping a stop's '...' buttons crashes on iPad