### PR TITLE
Replace right call out button image with disclosure arrow image

### DIFF
--- a/OneBusAway/ui/map/OBAMapAnnotationViewBuilder.m
+++ b/OneBusAway/ui/map/OBAMapAnnotationViewBuilder.m
@@ -22,7 +22,10 @@
 
     view.canShowCallout = YES;
     view.rightCalloutAccessoryView = ({
-        UIButton *rightCalloutButton = [UIButton buttonWithType:UIButtonTypeDetailDisclosure];
+        UIButton *rightCalloutButton = [UIButton buttonWithType:UIButtonTypeCustom];
+        UIImage *image = [UIImage imageNamed:@"disclosure_arrow"];
+        rightCalloutButton.frame = CGRectMake(0, 0, image.size.width, image.size.height);
+        [rightCalloutButton setImage:image forState:UIControlStateNormal];
         if ([OBATheme useHighContrastUI]) {
             rightCalloutButton.tintColor = [UIColor blackColor];
         }


### PR DESCRIPTION
Fixes https://github.com/OneBusAway/onebusaway-iphone/issues/1015 - 'i' button on map callouts should be replaced with a disclosure indicator

* Replace the right call out button icon with a disclosure arrow icon in
OBAMapAnnotationViewBuilder