### PR TITLE
Update Mark All as Read button text color to the obaGreen color.

### DIFF
--- a/OBAKit/UI/OBATheme.m
+++ b/OBAKit/UI/OBATheme.m
@@ -43,6 +43,7 @@ static UIFont *_italicFootnoteFont = nil;
     [[UITabBar appearance] setTintColor:tintColor];
     [[UITextField appearance] setTintColor:tintColor];
     [[UIButton appearance] setTintColor:tintColor];
+    [[UIBarButtonItem appearance] setTitleTextAttributes:@{ NSForegroundColorAttributeName: tintColor } forState:UIControlStateNormal];
     [[UISegmentedControl appearance] setTitleTextAttributes:@{ NSForegroundColorAttributeName: [UIColor whiteColor] } forState:UIControlStateNormal];
     [[UISegmentedControl appearance] setTitleTextAttributes:@{ NSForegroundColorAttributeName: [UIColor whiteColor] } forState:UIControlStateSelected];
     [[UISegmentedControl appearanceWhenContainedInInstancesOfClasses:@[UINavigationBar.class]] setTitleTextAttributes:@{ NSForegroundColorAttributeName: [UIColor blackColor] } forState:UIControlStateNormal];

--- a/OneBusAway/ui/regional_alerts/RegionalAlertsViewController.swift
+++ b/OneBusAway/ui/regional_alerts/RegionalAlertsViewController.swift
@@ -29,7 +29,6 @@ class RegionalAlertsViewController: OBAStaticTableViewController {
         self.hidesBottomBarWhenPushed = true
         let spacer = UIBarButtonItem.init(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
         let markReadButton = UIBarButtonItem.init(title:  NSLocalizedString("regional_alerts_controller.mark_all_as_read", comment: "Mark All as Read toolbar button title"), style: .plain, target: self, action: #selector(markAllAsRead))
-        markReadButton.setTitleTextAttributes([NSForegroundColorAttributeName: OBATheme.obaGreen], for: .normal)
         self.toolbarItems = [spacer, markReadButton]
     }
 

--- a/OneBusAway/ui/regional_alerts/RegionalAlertsViewController.swift
+++ b/OneBusAway/ui/regional_alerts/RegionalAlertsViewController.swift
@@ -29,6 +29,7 @@ class RegionalAlertsViewController: OBAStaticTableViewController {
         self.hidesBottomBarWhenPushed = true
         let spacer = UIBarButtonItem.init(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
         let markReadButton = UIBarButtonItem.init(title:  NSLocalizedString("regional_alerts_controller.mark_all_as_read", comment: "Mark All as Read toolbar button title"), style: .plain, target: self, action: #selector(markAllAsRead))
+        markReadButton.setTitleTextAttributes([NSForegroundColorAttributeName: OBATheme.obaGreen], for: .normal)
         self.toolbarItems = [spacer, markReadButton]
     }
 


### PR DESCRIPTION
Fixes https://github.com/OneBusAway/onebusaway-iphone/issues/1100 - Tint color of "Mark All" button is wrong

* Use setTitleTextAttribute to change the text color for markReadButton