### PR TITLE
Display the correct map image in Stop Controller

### DIFF
--- a/OneBusAway/ui/stops/views/OBAStopTableHeaderView.m
+++ b/OneBusAway/ui/stops/views/OBAStopTableHeaderView.m
@@ -112,6 +112,7 @@
             options.region = [OBAMapHelpers coordinateRegionWithCenterCoordinate:self.stop.coordinate zoomLevel:15 viewSize:squareSize];
             options.size = squareSize;
             options.scale = [[UIScreen mainScreen] scale];
+            options.mapType = [[NSUserDefaults standardUserDefaults] integerForKey:OBAMapSelectedTypeDefaultsKey];
             [[MKMapSnapshotter alloc] initWithOptions:options];
         });
 


### PR DESCRIPTION
Fixes https://github.com/OneBusAway/onebusaway-iphone/issues/1017 - Map type in header on the stop controller should match map's map type

* Get the stored mapType from NSUserDefault to show the correct header image in Stop Controller.