### PR TITLE
Manually trigger reloadData to update alarm button title in alert sheet

### DIFF
--- a/OneBusAway/ui/static_table/OBAStaticTableViewController.m
+++ b/OneBusAway/ui/static_table/OBAStaticTableViewController.m
@@ -148,8 +148,7 @@
         OBATableSection *section = self.sections[i];
         for (NSInteger j=0; j<section.rows.count; j++) {
             OBABaseRow *candidate = section.rows[j];
-
-            if ([candidate.model isEqual:model]) {
+            if (candidate.model == model) { // Need to compare the pointers to get the correct indexPath
                 return [NSIndexPath indexPathForRow:j inSection:i];
             }
         }

--- a/OneBusAway/ui/stops/OBAStopViewController.m
+++ b/OneBusAway/ui/stops/OBAStopViewController.m
@@ -363,6 +363,7 @@ static NSInteger kStopsSectionTag = 101;
     NSURLRequest *request = [self.modelService.obaJsonDataSource requestWithURL:alarm.alarmURL HTTPMethod:@"DELETE"];
     [self.modelService.obaJsonDataSource performRequest:request completionBlock:^(id responseData, NSUInteger responseCode, NSError *error) {
         [self.modelDAO removeAlarmWithKey:dep.alarmKey];
+        [self reloadDataAnimated:NO];
     }];
 }
 
@@ -375,7 +376,7 @@ static NSInteger kStopsSectionTag = 101;
     }).then(^(NSDictionary *serverResponse) {
         alarm.alarmURL = [NSURL URLWithString:serverResponse[@"url"]];
         [self.modelDAO addAlarm:alarm];
-
+        [self reloadDataAnimated:NO];
         NSString *title = NSLocalizedString(@"alarms.alarm_created_alert_title", @"The title of the non-modal alert displayed when a push notification alert is registered for a vehicle departure.");
         NSString *body = [NSString stringWithFormat:NSLocalizedString(@"alarms.alarm_created_alert_body", @"The body of the non-modal alert that appears when a push notification alarm is registered."), @((NSUInteger)timeInterval / 60)];
 

--- a/OneBusAway/ui/stops/OBAStopViewController.m
+++ b/OneBusAway/ui/stops/OBAStopViewController.m
@@ -363,8 +363,17 @@ static NSInteger kStopsSectionTag = 101;
     NSURLRequest *request = [self.modelService.obaJsonDataSource requestWithURL:alarm.alarmURL HTTPMethod:@"DELETE"];
     [self.modelService.obaJsonDataSource performRequest:request completionBlock:^(id responseData, NSUInteger responseCode, NSError *error) {
         [self.modelDAO removeAlarmWithKey:dep.alarmKey];
-        [self reloadDataAnimated:NO];
+        // Replace with a new row and update it.
+        [self updateAlarmStateForRowAtIndexPath:[self indexPathForModel:dep]];
     }];
+}
+
+- (void)updateAlarmStateForRowAtIndexPath:(NSIndexPath *)indexPath {
+    OBADepartureRow *row = (OBADepartureRow *)[self rowAtIndexPath:indexPath];
+    OBADepartureRow *newRow = row;
+    newRow.alarmExists = !row.alarmExists;
+    [self replaceRowAtIndexPath:indexPath withRow:newRow];
+    [self.tableView reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationNone];
 }
 
 - (void)registerAlarmForArrivalAndDeparture:(OBAArrivalAndDepartureV2*)arrivalDeparture timeInterval:(NSTimeInterval)timeInterval {
@@ -376,7 +385,9 @@ static NSInteger kStopsSectionTag = 101;
     }).then(^(NSDictionary *serverResponse) {
         alarm.alarmURL = [NSURL URLWithString:serverResponse[@"url"]];
         [self.modelDAO addAlarm:alarm];
-        [self reloadDataAnimated:NO];
+        // Replace with a new row and update it.
+        [self updateAlarmStateForRowAtIndexPath:[self indexPathForModel:arrivalDeparture]];
+
         NSString *title = NSLocalizedString(@"alarms.alarm_created_alert_title", @"The title of the non-modal alert displayed when a push notification alert is registered for a vehicle departure.");
         NSString *body = [NSString stringWithFormat:NSLocalizedString(@"alarms.alarm_created_alert_body", @"The body of the non-modal alert that appears when a push notification alarm is registered."), @((NSUInteger)timeInterval / 60)];
 

--- a/OneBusAway/ui/stops/OBAStopViewController.m
+++ b/OneBusAway/ui/stops/OBAStopViewController.m
@@ -370,9 +370,7 @@ static NSInteger kStopsSectionTag = 101;
 
 - (void)updateAlarmStateForRowAtIndexPath:(NSIndexPath *)indexPath {
     OBADepartureRow *row = (OBADepartureRow *)[self rowAtIndexPath:indexPath];
-    OBADepartureRow *newRow = row;
-    newRow.alarmExists = !row.alarmExists;
-    [self replaceRowAtIndexPath:indexPath withRow:newRow];
+    row.alarmExists = !row.alarmExists;    
     [self.tableView reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationNone];
 }
 


### PR DESCRIPTION
Fixes https://github.com/OneBusAway/onebusaway-iphone/issues/1120 - Alarm button title doesn't get updated after it gets removed

* After setting or removing alarm, call `updateAlarmStateForRowAtIndexPath:indexPath` to update the alarm state. (i.e if `alarmExists` is `NO`, set it to`YES`; if `alarmExists` is `YES`, then set it to `NO`)

* Update `indexPathForModel:model`. When comparing two `model` objects, instead of using `isEqual`, use `==` to compare their pointers (deep comparison) to get the correct `indexPath`.


Steps for reloading the row with given model:
1. When user adds/removes an alarm, we only know the model, so we will call `indexPathForModel:(id)model` to get the `indexPath`
2. With the correct `indexPath` we can get the row of type `OBADepartureRow` calling `rowAtIndexPath:`
3. Having the selected row, we need to update its current alarm state. `row.alarmExists = !row.alarmExists;`
4. Call `reloadRowsAtIndexPaths: withRowAnimation` to reload just one row.