### PR TITLE
Disable the option "Set Alarm" when the bus is arriving or departed.

### DIFF
--- a/OneBusAway/ui/stops/OBAStopViewController.m
+++ b/OneBusAway/ui/stops/OBAStopViewController.m
@@ -500,7 +500,7 @@ static NSInteger kStopsSectionTag = 101;
         row.statusText = [OBADepartureCellHelpers statusTextForArrivalAndDeparture:dep];
         row.bookmarkExists = [self hasBookmarkForArrivalAndDeparture:dep];
         row.alarmExists = [self hasAlarmForArrivalAndDeparture:dep];
-
+        row.hasLeft = dep.minutesUntilBestDeparture <= 0;
         [row setShowAlertController:^(UIView *presentingView, UIAlertController *alert) {
             [self showAlertController:alert fromView:presentingView];
         }];
@@ -581,7 +581,7 @@ static NSInteger kStopsSectionTag = 101;
         row.model = dep;
         row.bookmarkExists = [self hasBookmarkForArrivalAndDeparture:dep];
         row.alarmExists = [self hasAlarmForArrivalAndDeparture:dep];
-
+        row.hasLeft = dep.minutesUntilBestDeparture <= 0;
         [row setShowAlertController:^(UIView *presentingView, UIAlertController *alert) {
             [self showAlertController:alert fromView:presentingView];
         }];

--- a/OneBusAway/ui/stops/OBAStopViewController.m
+++ b/OneBusAway/ui/stops/OBAStopViewController.m
@@ -500,7 +500,7 @@ static NSInteger kStopsSectionTag = 101;
         row.statusText = [OBADepartureCellHelpers statusTextForArrivalAndDeparture:dep];
         row.bookmarkExists = [self hasBookmarkForArrivalAndDeparture:dep];
         row.alarmExists = [self hasAlarmForArrivalAndDeparture:dep];
-        row.hasLeft = dep.minutesUntilBestDeparture <= 0;
+        row.hasArrived = dep.minutesUntilBestDeparture > 0;
         [row setShowAlertController:^(UIView *presentingView, UIAlertController *alert) {
             [self showAlertController:alert fromView:presentingView];
         }];
@@ -581,7 +581,7 @@ static NSInteger kStopsSectionTag = 101;
         row.model = dep;
         row.bookmarkExists = [self hasBookmarkForArrivalAndDeparture:dep];
         row.alarmExists = [self hasAlarmForArrivalAndDeparture:dep];
-        row.hasLeft = dep.minutesUntilBestDeparture <= 0;
+        row.hasArrived = dep.minutesUntilBestDeparture > 0;
         [row setShowAlertController:^(UIView *presentingView, UIAlertController *alert) {
             [self showAlertController:alert fromView:presentingView];
         }];

--- a/OneBusAway/ui/stops/viewmodels/OBADepartureRow.h
+++ b/OneBusAway/ui/stops/viewmodels/OBADepartureRow.h
@@ -22,6 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic,copy,nullable) void (^shareAction)();
 @property(nonatomic,assign) BOOL bookmarkExists;
 @property(nonatomic,assign) BOOL alarmExists;
+@property(nonatomic,assign) BOOL hasLeft;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/OneBusAway/ui/stops/viewmodels/OBADepartureRow.h
+++ b/OneBusAway/ui/stops/viewmodels/OBADepartureRow.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic,copy,nullable) void (^shareAction)();
 @property(nonatomic,assign) BOOL bookmarkExists;
 @property(nonatomic,assign) BOOL alarmExists;
-@property(nonatomic,assign) BOOL hasLeft;
+@property(nonatomic,assign) BOOL hasArrived;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/OneBusAway/ui/stops/viewmodels/OBADepartureRow.m
+++ b/OneBusAway/ui/stops/viewmodels/OBADepartureRow.m
@@ -28,7 +28,7 @@
     row->_showAlertController = [_showAlertController copyWithZone:zone];
     row->_bookmarkExists = _bookmarkExists;
     row->_alarmExists = _alarmExists;
-    row->_hasLeft = _hasLeft;
+    row->_hasArrived = _hasArrived;
 
     return row;
 }

--- a/OneBusAway/ui/stops/viewmodels/OBADepartureRow.m
+++ b/OneBusAway/ui/stops/viewmodels/OBADepartureRow.m
@@ -28,6 +28,7 @@
     row->_showAlertController = [_showAlertController copyWithZone:zone];
     row->_bookmarkExists = _bookmarkExists;
     row->_alarmExists = _alarmExists;
+    row->_hasLeft = _hasLeft;
 
     return row;
 }

--- a/OneBusAway/ui/stops/views/OBAClassicDepartureCell.m
+++ b/OneBusAway/ui/stops/views/OBAClassicDepartureCell.m
@@ -81,11 +81,13 @@
     [alert addAction:action];
 
     // Set Alarm
-    action = [UIAlertAction actionWithTitle:[self alarmButtonTitle] style:UIAlertActionStyleDefault handler:^(UIAlertAction *a) {
-        [self toggleAlarm];
-    }];
-    [action setValue:[UIImage imageNamed:@"bell"] forKey:@"image"];
-    [alert addAction:action];
+    if (![self departureRow].hasLeft) {
+        action = [UIAlertAction actionWithTitle:[self alarmButtonTitle] style:UIAlertActionStyleDefault handler:^(UIAlertAction *a) {
+            [self toggleAlarm];
+        }];
+        [action setValue:[UIImage imageNamed:@"bell"] forKey:@"image"];
+        [alert addAction:action];
+    }
 
     action = [UIAlertAction actionWithTitle:NSLocalizedString(@"classic_departure_cell.context_alert.share_trip_status", @"Title for alert controller's Share Trip Status option.") style:UIAlertActionStyleDefault handler:^(UIAlertAction *a) {
         [self shareDeparture];

--- a/OneBusAway/ui/stops/views/OBAClassicDepartureCell.m
+++ b/OneBusAway/ui/stops/views/OBAClassicDepartureCell.m
@@ -81,7 +81,7 @@
     [alert addAction:action];
 
     // Set Alarm
-    if (![self departureRow].hasLeft) {
+    if ([self departureRow].hasArrived) {
         action = [UIAlertAction actionWithTitle:[self alarmButtonTitle] style:UIAlertActionStyleDefault handler:^(UIAlertAction *a) {
             [self toggleAlarm];
         }];


### PR DESCRIPTION
Fixes https://github.com/OneBusAway/onebusaway-iphone/issues/1121 - Setting alarm for a past/arriving now bus causes hard crash

* Create a Boolean to check if the bus is arriving/departed (including Arriving now) by setting `minutesUntilBestDeparture > 0`.

* If `hasArrived` is `YES` for the current `row`, then disable `Set Alarm` option.