### PR TITLE
v17.4.1

### DIFF
--- a/OBAKit/Helpers/OBACommon.h
+++ b/OBAKit/Helpers/OBACommon.h
@@ -42,6 +42,7 @@ typedef NS_ENUM(NSInteger, OBANavigationTargetType) {
 typedef NS_ENUM(NSUInteger, OBAErrorCode) {
     OBAErrorCodeLocationAuthorizationFailed = 1002,
     OBAErrorCodePushNotificationAuthorizationDenied,
+    OABErrorCodeMissingMethodParameters,
 };
 
 NSString * _Nullable NSStringFromOBASearchType(OBASearchType searchType);

--- a/OBAKit/Helpers/OBAReachability.m
+++ b/OBAKit/Helpers/OBAReachability.m
@@ -108,7 +108,11 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
 
     NSString *SSID = nil;
     if (networkInfo) {
-        SSID = [NSString stringWithString:networkInfo[(NSString*)kCNNetworkInfoKeySSID]];
+        NSString *SSIDTheirs = networkInfo[(NSString*)kCNNetworkInfoKeySSID];
+
+        if (SSIDTheirs) {
+            SSID = [NSString stringWithString:SSIDTheirs];
+        }
     }
 
     CFRelease(supportedInterfaces);

--- a/OBAKit/Info.plist
+++ b/OBAKit/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>17.4.0</string>
+	<string>17.4.1</string>
 	<key>CFBundleVersion</key>
-	<string>20170503.23</string>
+	<string>20170507.19</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/OBAKit/Models/mantle/OBARegionalAlert.h
+++ b/OBAKit/Models/mantle/OBARegionalAlert.h
@@ -9,6 +9,8 @@
 @import Foundation;
 @import Mantle;
 
+NS_ASSUME_NONNULL_BEGIN
+
 typedef NS_ENUM(NSUInteger, OBARegionalAlertPriority) {
     OBARegionalAlertPriorityNormal=0,
     OBARegionalAlertPriorityHigh
@@ -23,6 +25,8 @@ typedef NS_ENUM(NSUInteger, OBARegionalAlertPriority) {
 @property(nonatomic,copy) NSString *summary;
 @property(nonatomic,copy) NSURL *URL;
 @property(nonatomic,assign) NSUInteger alertFeedID;
-@property(nonatomic,copy) NSDate *publishedAt;
+@property(nonatomic,copy,nullable) NSDate *publishedAt;
 @property(nonatomic,copy) NSString *externalID;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/OBAKit/Services/OBAModelService.h
+++ b/OBAKit/Services/OBAModelService.h
@@ -89,7 +89,7 @@ extern NSString * const OBAAgenciesWithCoverageAPIPath;
 
 #pragma mark - Alarms
 
-- (id<OBAModelServiceRequest>)requestAlarm:(OBAAlarm*)alarm userPushNotificationID:(NSString*)userPushNotificationID completionBlock:(OBADataSourceCompletion)completion;
+- (nullable id<OBAModelServiceRequest>)requestAlarm:(OBAAlarm*)alarm userPushNotificationID:(NSString*)userPushNotificationID completionBlock:(OBADataSourceCompletion)completion;
 
 - (AnyPromise*)requestAlarm:(OBAAlarm*)alarm userPushNotificationID:(NSString*)userPushNotificationID;
 

--- a/OBAKit/Services/OBAModelService.m
+++ b/OBAKit/Services/OBAModelService.m
@@ -213,7 +213,8 @@ static const CLLocationAccuracy kRegionalRadius = 40000;
 
 - (AnyPromise*)requestAlarm:(OBAAlarm*)alarm userPushNotificationID:(NSString*)userPushNotificationID {
     return [AnyPromise promiseWithResolverBlock:^(PMKResolver resolve) {
-        [self requestAlarm:alarm userPushNotificationID:userPushNotificationID completionBlock:^(id responseData, NSUInteger responseCode, NSError *error) {
+
+        id request = [self requestAlarm:alarm userPushNotificationID:userPushNotificationID completionBlock:^(id responseData, NSUInteger responseCode, NSError *error) {
             if (responseData) {
                 resolve(responseData);
             }
@@ -221,10 +222,38 @@ static const CLLocationAccuracy kRegionalRadius = 40000;
                 resolve(error);
             }
         }];
+
+        if (!request) {
+            resolve([NSError errorWithDomain:OBAErrorDomain code:OABErrorCodeMissingMethodParameters userInfo:@{NSLocalizedDescriptionKey: OBALocalized(@"model_service.cant_register_alarm_missing_parameters", @"An error displayed to the user when their alarm can't be created.")}]);
+        }
     }];
 }
 
-- (id<OBAModelServiceRequest>)requestAlarm:(OBAAlarm*)alarm userPushNotificationID:(NSString*)userPushNotificationID completionBlock:(OBADataSourceCompletion)completion {
+- (nullable id<OBAModelServiceRequest>)requestAlarm:(OBAAlarm*)alarm userPushNotificationID:(NSString*)userPushNotificationID completionBlock:(OBADataSourceCompletion)completion {
+
+    OBAGuard(alarm.timeIntervalBeforeDeparture > 0) else {
+        return nil;
+    }
+
+    OBAGuard(alarm.stopID) else {
+        return nil;
+    }
+
+    OBAGuard(alarm.tripID) else {
+        return nil;
+    }
+
+    OBAGuard(alarm.serviceDate != 0) else {
+        return nil;
+    }
+
+    OBAGuard(alarm.vehicleID) else {
+        return nil;
+    }
+
+    OBAGuard(userPushNotificationID) else {
+        return nil;
+    }
 
     NSDictionary *params = @{
                              @"seconds_before": @(alarm.timeIntervalBeforeDeparture),

--- a/OBAKit/en.lproj/Localizable.strings
+++ b/OBAKit/en.lproj/Localizable.strings
@@ -159,3 +159,6 @@
 
 /* The text 'Read More…' (note that is an ellipsis, not three dots…) */
 "strings.read_more" = "Read More…";
+
+/* An error displayed to the user when their alarm can't be created. */
+"model_service.cant_register_alarm_missing_parameters" = "Sorry, we can't create an alarm for this upcoming trip. You're welcome to try again, but it probably won't make any difference. Sorry about that :(";

--- a/OBAKit/regional_alerts/RegionalAlertsManager.swift
+++ b/OBAKit/regional_alerts/RegionalAlertsManager.swift
@@ -132,7 +132,10 @@ import CocoaLumberjackSwift
         mergedModels.append(contentsOf: modelMap.values)
 
         mergedModels.sort { (alert1, alert2) -> Bool in
-            return (alert1.publishedAt >= alert2.publishedAt)
+            let date1 = alert1.publishedAt ?? Date()
+            let date2 = alert2.publishedAt ?? Date()
+
+            return date1 >= date2
         }
 
         return mergedModels

--- a/OneBusAway/Info.plist
+++ b/OneBusAway/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>17.4.0</string>
+	<string>17.4.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>20170503.23</string>
+	<string>20170507.19</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>

--- a/OneBusAway/Resources/Launch Screen.storyboard
+++ b/OneBusAway/Resources/Launch Screen.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11542" systemVersion="16B2555" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
-    <device id="retina4_7" orientation="portrait">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12120" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <device id="retina4_0" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11524"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -18,11 +18,11 @@
                         <viewControllerLayoutGuide type="bottom" id="xb3-aO-Qok"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tabBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Qqv-oa-8Ro">
-                                <rect key="frame" x="0.0" y="618" width="375" height="49"/>
+                                <rect key="frame" x="0.0" y="519" width="320" height="49"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <items>
                                     <tabBarItem title="" image="Map" id="ZEy-hw-S0U"/>

--- a/OneBusAway/externals/GKActionSheetPicker/GKActionSheetPicker.m
+++ b/OneBusAway/externals/GKActionSheetPicker/GKActionSheetPicker.m
@@ -653,13 +653,14 @@ typedef NS_ENUM(NSUInteger, GKActionSheetPickerType) {
 - (void)updateSelection
 {
     if (self.pickerType == GKActionSheetPickerTypeString) {
-        
         NSUInteger index = [self.pickerView selectedRowInComponent:0];
-        GKActionSheetPickerItem *item = [self.items objectAtIndex:index];
-        self.selection = item.value;
-        
-    } else if (self.pickerType == GKActionSheetPickerTypeMultiColumnString) {
 
+        if (self.items.count > index) {
+            GKActionSheetPickerItem *item = self.items[index];
+            self.selection = item.value;
+        }
+    }
+    else if (self.pickerType == GKActionSheetPickerTypeMultiColumnString) {
         NSMutableArray *selections = [NSMutableArray new];
         
         for (NSUInteger i=0; i<self.components.count; i++) {
@@ -670,11 +671,9 @@ typedef NS_ENUM(NSUInteger, GKActionSheetPickerType) {
         }
         
         self.selections = selections;
-
-    } else if (self.pickerType == GKActionSheetPickerTypeDate) {
-    
+    }
+    else if (self.pickerType == GKActionSheetPickerTypeDate) {
         self.selectedDate = self.datePicker.date;
-        
     }
 }
 

--- a/OneBusAway/ui/static_table/cells/OBAMessageCell.m
+++ b/OneBusAway/ui/static_table/cells/OBAMessageCell.m
@@ -112,15 +112,7 @@ static CGFloat const kAccessoryWidth = 12.f;
     self.senderLabel.text = [self messageRow].sender;
     self.subjectLabel.text = [self messageRow].subject;
 
-    if ([self messageRow].date.isToday) {
-        self.dateLabel.text = [OBADateHelpers formatShortTimeNoDate:[self messageRow].date];
-    }
-    else if ([self messageRow].date.isYesterday) {
-        self.dateLabel.text = OBAStrings.yesterday;
-    }
-    else {
-        self.dateLabel.text = [OBADateHelpers formatNoTimeShortDate:self.messageRow.date];
-    }
+    [self configureDateLabelForDate:self.messageRow.date];
 
     self.unreadImageView.alpha = [self messageRow].unread ? 1.f : 0.f;
 
@@ -132,6 +124,23 @@ static CGFloat const kAccessoryWidth = 12.f;
     if ([self messageRow].highPriority) {
         self.priorityLabel.text = @"!";
         self.priorityLabel.accessibilityLabel = NSLocalizedString(@"message_cell.high_priority", @"accessibility label with the text 'high priority'.");
+    }
+}
+
+- (void)configureDateLabelForDate:(nullable NSDate*)date {
+    if (![self messageRow].date) {
+        self.dateLabel.text = nil;
+        return;
+    }
+
+    if ([self messageRow].date.isToday) {
+        self.dateLabel.text = [OBADateHelpers formatShortTimeNoDate:[self messageRow].date];
+    }
+    else if ([self messageRow].date.isYesterday) {
+        self.dateLabel.text = OBAStrings.yesterday;
+    }
+    else {
+        self.dateLabel.text = [OBADateHelpers formatNoTimeShortDate:self.messageRow.date];
     }
 }
 

--- a/OneBusAway/ui/static_table/viewmodels/OBAMessageRow.h
+++ b/OneBusAway/ui/static_table/viewmodels/OBAMessageRow.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface OBAMessageRow : OBABaseRow
 @property(nonatomic,copy) NSString *sender;
 @property(nonatomic,copy) NSString *subject;
-@property(nonatomic,copy) NSDate *date;
+@property(nonatomic,copy,nullable) NSDate *date;
 @property(nonatomic,assign) BOOL unread;
 @property(nonatomic,assign) BOOL highPriority;
 @end


### PR DESCRIPTION
Hey folks - I hope you're enjoying the new features of this release! (They are detailed below in excruciating detail in case you missed them before.)

This is a bug fix release that addresses the top crashing issues reported for 17.4.0:

* A completely unexpected, seemingly unpreventable crash on app launch is now fixed. I assumed that the data we were getting from the server was going to always make sense. This was clearly a mistake.
* Apparently there are some buses that simply will not allow alarms to be created for them. I hope to figure out what commonalities they share in order to avoid giving you false hope around registering an alarm. But, for now, at least you won't experience a crash.

<3,
Aaron

-----

Release notes for 17.4.0:

This release took longer than expected, mostly because I kept adding stuff to it. But, I think it's worth the wait! OneBusAway 17.4.0 adds alarms to tell you when your bus is a certain number of minutes away, a new search experience, and a huge amount of polish.

Additionally, in Puget Sound only for now, you'll be able to get alerts about major failures in the bus system, like when an overturned fish truck snarls the evening commute! Hey transit agencies, feel free to get in touch with me about adding your data to this new system.

<3,
Aaron

Map:

* See the direction you're pointing in on the map
* New search experience. Check it out, it's way better!
* New icons (thanks Alan)
* Toggle between standard map and hybrid satellite views (thanks Alan)
* Quickly access nearby stops from the toolbar butons on the map

Regional Alerts:

I want to give a huge thank you to Ben, who designed and built out the backend system that this new feature relies on. His expertise was invaluable in making this happen. <3

* When a serious issue happens with the bus system, you'll receive an alert as soon as you open the app that gives you more information about it. This way, you'll never get caught off guard by salmon trucks or snow days again. Please note: I am currently manually adding this data to the system, so early morning commuters might not get to take advantage of it. Just a head's up.
* You can view more alerts from the Info tab. These are things like one-off cancellations of routes.

Alarms:

* Set an alarm for a particular bus and get a push notification on your iPhone or Apple Watch when your bus is your specified number of minutes away.
* View your active alarms on the 'Recent' tab

Stops:

* Tap on a '...' button to access bookmarking, trip sharing, and alarms.
* Move walking distance and time into the stops table so you can see exactly which buses you'll be able to catch.

Trip Sharing:

* Better behavior on copying the URL
* Trip sharing should work properly in Tampa again

Inter-app communication:

* onebusaway:// URLs will now launch OneBusAway

Bookmarks:

* Fixes bug with bookmark name editing (thanks Alan)
* Sort bookmarks by proximity to your current location

Handoff:

* Adds Handoff support for working with OBA across different devices

Other changes:

* A huge "thank you" to Edgar, who continues to volunteer his time to localize OneBusAway into Spanish.
* Lots of behind-the-scenes upgrades to OBA, including model and networking layers.
* Upgrade third party libraries (thanks for your help with this, Victor)