### PR TITLE
Update Spanish Translations

### DIFF
--- a/OBAKit/es.lproj/Localizable.strings
+++ b/OBAKit/es.lproj/Localizable.strings
@@ -159,3 +159,6 @@
 
 /* The text 'Read More…' (note that is an ellipsis, not three dots…) */
 "strings.read_more" = "Leer Más…";
+
+/* An error displayed to the user when their alarm can't be created. */
+"model_service.cant_register_alarm_missing_parameters" = "Lo siento, no pudimos crear una alarma para este próximo viaje. Puedes intentarlo de nuevo, pero probablemente no hará ninguna diferencia. Lo sentimos por eso :(";

--- a/OneBusAway/es.lproj/Localizable.strings
+++ b/OneBusAway/es.lproj/Localizable.strings
@@ -248,6 +248,9 @@
 /* self.listBarButtonItem.accessibilityLabel */
 "msg_nearby_stops_list" = "Lista de pardas cercanas";
 
+/* Title of the the Nearby Stops controller when it's in disambiguation mode. In English, this is just the word 'Disambiguate'. */
+"nearby_stops.disambiguation_title" = "Desambiguar";
+
 /* Out of range alert Cancel button */
 "msg_no" = "No";
 


### PR DESCRIPTION
Update Spanish Translations

* Based on commit 32a8cf8 - Tighten up handling of data around alarm registration
* Missing translation 'nearby_stops.disambiguation_title'