### PR TITLE
Pause reloading bookmark cell when in editing mode

### DIFF
--- a/OneBusAway/ui/bookmarks/OBABookmarksViewController.m
+++ b/OneBusAway/ui/bookmarks/OBABookmarksViewController.m
@@ -365,6 +365,10 @@ static NSString * const OBABookmarkSortUserDefaultsKey = @"OBABookmarkSortUserDe
     }
 }
 
+- (void)tableView:(UITableView *)tableView didEndEditingRowAtIndexPath:(NSIndexPath *)indexPath {
+    self.editing = NO;
+}
+
 #pragma mark - Table Row Actions (context menu thingy)
 
 - (NSArray<UITableViewRowAction *> *)tableView:(UITableView *)tableView editActionsForRowAtIndexPath:(NSIndexPath *)indexPath {
@@ -375,6 +379,7 @@ static NSString * const OBABookmarkSortUserDefaultsKey = @"OBABookmarkSortUserDe
         // rows not backed by models don't get actions.
         return nil;
     }
+    self.editing = YES;
 
     NSMutableArray<UITableViewRowAction *> *actions = [NSMutableArray array];
 


### PR DESCRIPTION
Fixes https://github.com/OneBusAway/onebusaway-iphone/issues/1124 - Bookmark tab's table cell actions disappear when table reloads

* When user is in editing mode, set `self.editing = YES` to pause reloading data.

* When user `didEndEditing`, set `self.editing = NO` to resume reloading data.