### PR TITLE
Alarm time update

### DIFF
--- a/OBAKit/Models/unmanaged/OBAAlarm.h
+++ b/OBAKit/Models/unmanaged/OBAAlarm.h
@@ -44,6 +44,8 @@ extern NSInteger const OBAAlarmIncrementsInMinutes;
 
 @property(nonatomic,copy) NSDate *scheduledDeparture;
 
+@property(nonatomic,copy) NSDate *estimatedDeparture;
+
 @property(nonatomic,assign) long long serviceDate;
 
 @property(nonatomic,copy) NSString *vehicleID;

--- a/OBAKit/Models/unmanaged/OBAAlarm.m
+++ b/OBAKit/Models/unmanaged/OBAAlarm.m
@@ -26,6 +26,7 @@ NSInteger const OBAAlarmIncrementsInMinutes = 5;
         _stopSequence = arrivalAndDeparture.stopSequence;
         _title = [arrivalAndDeparture.bestAvailableNameWithHeadsign copy];
         _scheduledDeparture = [arrivalAndDeparture.scheduledDepartureDate copy];
+        _estimatedDeparture = [arrivalAndDeparture.bestArrivalDepartureDate copy];
     }
 
     return self;
@@ -47,6 +48,7 @@ NSInteger const OBAAlarmIncrementsInMinutes = 5;
         _stopSequence = [aDecoder oba_decodeInteger:@selector(stopSequence)];
         _title = [aDecoder oba_decodeObject:@selector(title)];
         _scheduledDeparture = [aDecoder oba_decodeObject:@selector(scheduledDeparture)];
+        _estimatedDeparture = [aDecoder oba_decodeObject:@selector(estimatedDeparture)];
     }
 
     return self;
@@ -63,6 +65,7 @@ NSInteger const OBAAlarmIncrementsInMinutes = 5;
     [aCoder oba_encodeInteger:_stopSequence forSelector:@selector(stopSequence)];
     [aCoder oba_encodePropertyOnObject:self withSelector:@selector(title)];
     [aCoder oba_encodePropertyOnObject:self withSelector:@selector(scheduledDeparture)];
+    [aCoder oba_encodePropertyOnObject:self withSelector:@selector(estimatedDeparture)];
 }
 
 #pragma mark - NSCopying
@@ -79,7 +82,7 @@ NSInteger const OBAAlarmIncrementsInMinutes = 5;
     alarm->_stopSequence = _stopSequence;
     alarm->_title = [_title copy];
     alarm->_scheduledDeparture = [_scheduledDeparture copyWithZone:zone];
-
+    alarm->_estimatedDeparture = [_estimatedDeparture copyWithZone:zone];
     return alarm;
 }
 

--- a/OneBusAway/ui/recent_stops/OBARecentStopsViewController.m
+++ b/OneBusAway/ui/recent_stops/OBARecentStopsViewController.m
@@ -125,7 +125,7 @@
             [self.navigationController pushViewController:controller animated:YES];
         }];
         NSInteger minutes = (NSInteger)(alarm.timeIntervalBeforeDeparture / 60);
-        NSString *formattedTime = [OBADateHelpers formatShortTimeNoDate:alarm.scheduledDeparture];
+        NSString *formattedTime = [OBADateHelpers formatShortTimeNoDate:alarm.estimatedDeparture];
 
         row.subtitle = [NSString stringWithFormat:NSLocalizedString(@"recent_stops.alarms.subtitle", @"e.g. <10> minutes before <5:02PM> departure (scheduled)"), @(minutes), formattedTime];
         row.style = UITableViewCellStyleSubtitle;


### PR DESCRIPTION
Fixes https://github.com/OneBusAway/onebusaway-iphone/issues/1008 - Alarm times don't update on the Recents tab

* Add estimatedDeparture `NSDate` property for displaying on `OBARecentStopsViewController`
