### PR TITLE
Adds walking directions options to the '...' button in the Stop page

### DIFF
--- a/OBAKit/Helpers/AppInterop.swift
+++ b/OBAKit/Helpers/AppInterop.swift
@@ -1,0 +1,50 @@
+//
+//  AppInterop.swift
+//  OBAKit
+//
+//  Created by Aaron Brethorst on 9/2/17.
+//  Copyright © 2017 OneBusAway. All rights reserved.
+//
+
+import Foundation
+import CoreLocation
+
+@objc class AppInterop: NSObject {
+
+    /// Creates an URL that can open the Google Maps app with the user's desired
+    /// destination in walking directions mode.
+    ///
+    /// - Parameter coordinate: The destination coordinate
+    /// - Returns: An URL that will launch Google Maps in walking directions mode
+    @objc public class func googleMapsWalkingDirectionsURL(coordinate: CLLocationCoordinate2D) -> URL? {
+        var params: [URLQueryItem] = []
+        params.append(URLQueryItem.init(name: "daddr", value: "\(coordinate.latitude),\(coordinate.longitude)"))
+        params.append(URLQueryItem.init(name: "directionsmode", value: "walking"))
+
+        guard let components = NSURLComponents.init(string: "comgooglemaps://") else {
+            return nil
+        }
+
+        components.queryItems = params
+        return components.url
+    }
+
+    /// Creates an URL that can open the Apple Maps app with the user's desired
+    /// destination in walking directions mode.
+    ///
+    /// - Parameter coordinate: The destination coordinate
+    /// - Returns: An URL that will launch Apple Maps in walking directions mode
+    @objc public class func appleMapsWalkingDirectionsURL(coordinate: CLLocationCoordinate2D) -> URL? {
+        var params: [URLQueryItem] = []
+        params.append(URLQueryItem.init(name: "daddr", value: "\(coordinate.latitude),\(coordinate.longitude)"))
+        params.append(URLQueryItem.init(name: "dirflg", value: "w"))
+
+        guard let components = NSURLComponents.init(string: "http://maps.apple.com/") else {
+            return nil
+        }
+
+        components.queryItems = params
+
+        return components.url
+    }
+}

--- a/OBAKit/OBAKit.xcodeproj/project.pbxproj
+++ b/OBAKit/OBAKit.xcodeproj/project.pbxproj
@@ -215,6 +215,7 @@
 		936EB1B91E91A83700F4F3A7 /* OBARegionStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 936EB1B71E91A83700F4F3A7 /* OBARegionStorage.h */; };
 		936EB1BA1E91A83700F4F3A7 /* OBARegionStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 936EB1B81E91A83700F4F3A7 /* OBARegionStorage.m */; };
 		9377DD531EE4682E00134AE8 /* BorderedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9377DD521EE4682E00134AE8 /* BorderedButton.swift */; };
+		93A6E9E21F5BC18B00AFA61C /* AppInterop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93A6E9E11F5BC18B00AFA61C /* AppInterop.swift */; };
 		93B282C41DC664C7005013D7 /* OBATripDeepLink.h in Headers */ = {isa = PBXBuildFile; fileRef = 93B282C21DC664C7005013D7 /* OBATripDeepLink.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		93B282C51DC664C7005013D7 /* OBATripDeepLink.m in Sources */ = {isa = PBXBuildFile; fileRef = 93B282C31DC664C7005013D7 /* OBATripDeepLink.m */; };
 		93B282C81DC68892005013D7 /* NSURLQueryItem+OBAAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 93B282C61DC68892005013D7 /* NSURLQueryItem+OBAAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -454,6 +455,7 @@
 		936EB1B71E91A83700F4F3A7 /* OBARegionStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBARegionStorage.h; sourceTree = "<group>"; };
 		936EB1B81E91A83700F4F3A7 /* OBARegionStorage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBARegionStorage.m; sourceTree = "<group>"; };
 		9377DD521EE4682E00134AE8 /* BorderedButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BorderedButton.swift; sourceTree = "<group>"; };
+		93A6E9E11F5BC18B00AFA61C /* AppInterop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInterop.swift; sourceTree = "<group>"; };
 		93B282C21DC664C7005013D7 /* OBATripDeepLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBATripDeepLink.h; sourceTree = "<group>"; };
 		93B282C31DC664C7005013D7 /* OBATripDeepLink.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBATripDeepLink.m; sourceTree = "<group>"; };
 		93B282C61DC68892005013D7 /* NSURLQueryItem+OBAAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURLQueryItem+OBAAdditions.h"; sourceTree = "<group>"; };
@@ -614,6 +616,7 @@
 				930AFE9D1DD183720092AE82 /* OBAWalkingDirections.m */,
 				CCD30CFA1E30564600080EFF /* OBAHandoff.swift */,
 				93F3F8A11E7BCA8C0025FC78 /* FileHelpers.swift */,
+				93A6E9E11F5BC18B00AFA61C /* AppInterop.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -1109,6 +1112,7 @@
 				934196701DB0B099004BBBB7 /* OBAReportProblemWithTripV2.m in Sources */,
 				934196271DB0B099004BBBB7 /* OBANavigationTargetAnnotation.m in Sources */,
 				934196311DB0B099004BBBB7 /* OBAModelDAOUserPreferencesImpl.m in Sources */,
+				93A6E9E21F5BC18B00AFA61C /* AppInterop.swift in Sources */,
 				9341968B1DB0B099004BBBB7 /* OBATripScheduleV2.m in Sources */,
 				9358CDB31DEA242B00132CDE /* OBAUpcomingDeparture.m in Sources */,
 				934196011DB0B099004BBBB7 /* OBACommon.m in Sources */,

--- a/OneBusAway/Info.plist
+++ b/OneBusAway/Info.plist
@@ -53,6 +53,7 @@
 	<array>
 		<string>fb</string>
 		<string>twitter</string>
+		<string>comgooglemaps</string>
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>

--- a/OneBusAway/en.lproj/Localizable.strings
+++ b/OneBusAway/en.lproj/Localizable.strings
@@ -782,7 +782,6 @@
 /* The empty data set description for the search controller */
 "map_search.empty_data_set_description" = "Type in an address, route number, or stop number here to search.";
 
-
 /* The section title on the 'Nearby' controller that says 'Routes' */
 "nearby_stops.routes_section_title" = "Routes";
 
@@ -887,3 +886,9 @@
 
 /* No comment provided by engineer. */
 "msg_scheduled_explanatory" = "*'Scheduled': no vehicle location data available";
+
+/* Title of the 'Walking Directions (Apple Maps)' option in the action sheet. */
+"stop.walking_directions_apple_action_title" = "Walking Directions (Apple Maps)";
+
+/* Title of the 'Walking Directions (Apple Maps)' option in the action sheet. */
+"stop.walking_directions_google_action_title" = "Walking Directions (Google Maps)";


### PR DESCRIPTION
Fixes #1139 - Add back stop-gap walking directions feature

Adds an Apple Maps walking directions option to the '...' menu and optionally a Google Maps walking directions option if the user has Google Maps installed.