### PR TITLE
Update README.md to reference xcode 9.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You are welcome to work on any bug or feature you would like, but we know that g
 
 ### Development environment setup
 
-1. Install the latest released version of Xcode 8.x from the Mac App Store
+1. Install the latest released version of Xcode 9.x from the Mac App Store
 2. `git clone` your fork
 3. [Install Carthage](https://github.com/Carthage/Carthage#installing-carthage)
 4. `open org.onebusaway.iphone.xcodeproj`


### PR DESCRIPTION
OBAKit uses Swift 4, so OBA needs xcode 9.