### PR TITLE
Adds clearer location to write feedback in email form

### DIFF
--- a/OneBusAway/Resources/feedback_message_body.html
+++ b/OneBusAway/Resources/feedback_message_body.html
@@ -1,5 +1,10 @@
-<br>
-<br>
+<p>
+How can we help?
+</p>
+
+<p>
+
+</p>
 
 <hr>
 


### PR DESCRIPTION
I've noticed that lots of our users send us blank feedback emails. I think this will be ameliorated by a more clear place for them to put their feedback in the emails they send.