### PR TITLE
Disables userInteractionEnabled on SVPulsingAnnotationView

### DIFF
--- a/OneBusAway/ui/map/OBAMapViewController.m
+++ b/OneBusAway/ui/map/OBAMapViewController.m
@@ -410,6 +410,7 @@ static const double kStopsInRegionRefreshDelayOnDrag = 0.1;
         _userLocationAnnotationView.annotationColor = [OBATheme userLocationFillColor];
         _userLocationAnnotationView.canShowCallout = NO;
         _userLocationAnnotationView.headingImage = [UIImage imageNamed:@"userHeading"];
+        _userLocationAnnotationView.userInteractionEnabled = NO;
     }
 
     BOOL showHeading = [OBAApplication.sharedApplication.userDefaults boolForKey:OBADisplayUserHeadingOnMapDefaultsKey];

--- a/OneBusAway/ui/trip_details/VehicleMapController.swift
+++ b/OneBusAway/ui/trip_details/VehicleMapController.swift
@@ -230,6 +230,7 @@ extension VehicleMapController {
             annotationView = SVPulsingAnnotationView.init(annotation: vehicle, reuseIdentifier: identifier, size: CGSize(width: 32, height: 32))
             annotationView?.canShowCallout = true
             annotationView?.headingImage = UIImage(named: "vehicleHeading")
+            annotationView?.isUserInteractionEnabled = false
         }
 
         if vehicle.predicted {


### PR DESCRIPTION
Fixes #1209 - User location annotation view is eating taps on the map

Disabling user interaction will ensure that this view doesn't eat taps.