### PR TITLE
Removes misleading text from walkable row when user is near the stop

### DIFF
--- a/OBAKit/Categories/NSDate+DateTools.h
+++ b/OBAKit/Categories/NSDate+DateTools.h
@@ -25,7 +25,7 @@
 
  @return representiation of minutes
  */
-- (double)minutesUntil;
+- (NSUInteger)minutesUntil;
 
 - (BOOL)isToday;
 - (BOOL)isTomorrow;

--- a/OBAKit/Categories/NSDate+DateTools.m
+++ b/OBAKit/Categories/NSDate+DateTools.m
@@ -16,8 +16,8 @@
     return ([self timeIntervalSinceDate:date])/SECONDS_IN_MINUTE;
 }
 
-- (double)minutesUntil; {
-    return [self minutesLaterThan:[NSDate date]];
+- (NSUInteger)minutesUntil {
+    return (NSUInteger)[self minutesLaterThan:[NSDate date]];
 }
 
 /**

--- a/OneBusAway/OneBusAwayTests/Fixtures/Emails/testMessageBodyForModelDAO.html
+++ b/OneBusAway/OneBusAwayTests/Fixtures/Emails/testMessageBodyForModelDAO.html
@@ -1,12 +1,17 @@
-<br>
-<br>
+<p>
+How can we help?
+</p>
+
+<p>
+
+</p>
 
 <hr>
 
 <p>The following information is provided for troubleshooting purposes. If you are uncomfortable sharing any of the following information you may remove it, however it may affect our ability to assist you.</p>
 
 <ul>
-    <li>App Version = 2.6.OBA_SIM</li>
+<li>App Version = 2.6.OBA_SIM</li>
 <li>Device = x86_64</li>
 <li>iOS Version = 10.0.OBA_SIM</li>
 <li>VoiceOver enabled = NO</li>

--- a/OneBusAway/en.lproj/Localizable.strings
+++ b/OneBusAway/en.lproj/Localizable.strings
@@ -610,7 +610,7 @@
 "msg_visit_us" = "Visit Us";
 
 /* No comment provided by engineer. */
-"text_walk_to_stop_info_params" = "%@, %.0f min: arriving at %@";
+"text_walk_to_stop_info_params" = "%@, %@ min: arriving at %@";
 
 /* No comment provided by engineer. */
 "msg_explanatory_no_agencies" = "We could not find any transit agencies near your current location.";

--- a/OneBusAway/es.lproj/Localizable.strings
+++ b/OneBusAway/es.lproj/Localizable.strings
@@ -604,7 +604,7 @@
 "msg_visit_us" = "Visitanos";
 
 /* No comment provided by engineer. */
-"text_walk_to_stop_info_params" = "%@, %.0f min: llegando a las %@";
+"text_walk_to_stop_info_params" = "%@, %@ min: llegando a las %@";
 
 /* No comment provided by engineer. */
 "msg_explanatory_no_agencies" = "No hemos podido encontrar agencias de transporte público cerca de tu ubicación actual.";

--- a/OneBusAway/ui/stops/OBAStopViewController.m
+++ b/OneBusAway/ui/stops/OBAStopViewController.m
@@ -297,9 +297,18 @@ static NSInteger kNegligibleWalkingTimeToStop = 25;
 
     NSString *distanceString = [OBAMapHelpers stringFromDistance:[location distanceFromLocation:stop.location]];
     NSDate *expectedArrivalDate = [NSDate dateWithTimeIntervalSinceNow:walkingTime];
+    NSUInteger minutesToArrivalAtStop = expectedArrivalDate.minutesUntil;
 
     OBAWalkableRow *walkableRow = [[OBAWalkableRow alloc] init];
-    walkableRow.text = [NSString stringWithFormat:NSLocalizedString(@"text_walk_to_stop_info_params",), distanceString,expectedArrivalDate.minutesUntil,[OBADateHelpers formatShortTimeNoDate:expectedArrivalDate]];
+
+    // Only show the user's distance from the stop
+    // if they are a negligible distance from it.
+    if (minutesToArrivalAtStop == 0) {
+        walkableRow.text = distanceString;
+    }
+    else {
+        walkableRow.text = [NSString stringWithFormat:NSLocalizedString(@"text_walk_to_stop_info_params",), distanceString, @(minutesToArrivalAtStop), [OBADateHelpers formatShortTimeNoDate:expectedArrivalDate]];
+    }
 
     NSMutableArray<OBABaseRow*> *mRows = [[NSMutableArray alloc] initWithArray:rows];
     [mRows insertObject:walkableRow atIndex:insertionIndex];

--- a/OneBusAway/zh-Hant.lproj/Localizable.strings
+++ b/OneBusAway/zh-Hant.lproj/Localizable.strings
@@ -587,7 +587,7 @@
 "msg_visit_us" = "參觀我們";
 
 /* No comment provided by engineer. */
-"text_walk_to_stop_info_params" = "%@, %.0f 分鐘: 抵達 %@";
+"text_walk_to_stop_info_params" = "%@, %@ 分鐘: 抵達 %@";
 
 /* No comment provided by engineer. */
 "msg_explanatory_no_agencies" = "我們無法在你的地區找到任何交通運輸機構。";


### PR DESCRIPTION
Fixes #935 - The walk indicator can be wrong when you're standing at the bus stop