### PR TITLE
Moves Trip Details API calls onto PromiseWrapper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: objective-c
-osx_image: xcode9
+osx_image: xcode9.2
 before_install:
-  - export IOS_SIMULATOR_UDID=`instruments -s devices | grep "iPhone SE (11.0" | ruby -e "puts gets.split('[')[1].split(']').first"`
+  - export IOS_SIMULATOR_UDID=`instruments -s devices | grep "iPhone SE (11.2" | ruby -e "puts gets.split('[')[1].split(']').first"`
   - echo $IOS_SIMULATOR_UDID
   - open -a "simulator" --args -CurrentDeviceUDID $IOS_SIMULATOR_UDID
 script: set -o pipefail && xcodebuild clean test CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO -project org.onebusaway.iphone.xcodeproj -scheme OneBusAway -sdk iphonesimulator -destination "platform=iOS Simulator,id=$IOS_SIMULATOR_UDID" ONLY_ACTIVE_ARCH=NO | xcpretty

--- a/OBAKit/Helpers/OBAErrorMessages.h
+++ b/OBAKit/Helpers/OBAErrorMessages.h
@@ -16,6 +16,8 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSError*)connectionError:(NSHTTPURLResponse*)response;
 @property(nonatomic,copy,class,readonly) NSError *cannotRegisterAlarm;
 
++ (nullable NSError*)errorFromHttpResponse:(NSHTTPURLResponse*)httpResponse;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/OBAKit/Helpers/OBAErrorMessages.m
+++ b/OBAKit/Helpers/OBAErrorMessages.m
@@ -11,6 +11,17 @@
 
 @implementation OBAErrorMessages
 
++ (NSError*)errorFromHttpResponse:(NSHTTPURLResponse*)httpResponse {
+    if (httpResponse.statusCode == 404) {
+        return OBAErrorMessages.stopNotFoundError;
+    }
+    else if (httpResponse.statusCode >= 300 && httpResponse.statusCode <= 399) {
+        return [OBAErrorMessages connectionError:httpResponse];
+    }
+
+    return nil;
+}
+
 + (NSError*)stopNotFoundError {
     return [NSError errorWithDomain:NSURLErrorDomain code:404 userInfo:@{NSLocalizedDescriptionKey: OBALocalized(@"mgs_stop_not_found", @"code == 404")}];
 }

--- a/OBAKit/Models/unmanaged/NetworkResponse.swift
+++ b/OBAKit/Models/unmanaged/NetworkResponse.swift
@@ -11,9 +11,11 @@ import Foundation
 @objc public class NetworkResponse: NSObject {
     @objc public var object: Any
     @objc public var URLResponse: HTTPURLResponse
+    @objc public var urlRequest: OBAURLRequest
 
-    init(object: Any, URLResponse: HTTPURLResponse) {
+    init(object: Any, URLResponse: HTTPURLResponse, urlRequest: OBAURLRequest) {
         self.object = object
         self.URLResponse = URLResponse
+        self.urlRequest = urlRequest
     }
 }

--- a/OBAKit/Models/unmanaged/OBATripInstanceRef.h
+++ b/OBAKit/Models/unmanaged/OBATripInstanceRef.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface OBATripInstanceRef : NSObject
 @property(nonatomic,copy) NSString *tripId;
 @property(nonatomic,assign) long long serviceDate;
-@property(nonatomic,copy) NSString *vehicleId;
+@property(nonatomic,copy,nullable) NSString *vehicleId;
 
 - (instancetype)initWithTripId:(NSString*)tripId serviceDate:(long long)serviceDate vehicleId:(NSString*)vehicleId;
 

--- a/OBAKit/OBAKit.xcodeproj/project.pbxproj
+++ b/OBAKit/OBAKit.xcodeproj/project.pbxproj
@@ -242,6 +242,7 @@
 		93BC49F91FB8D697008B710D /* PMKCoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 93BC49F61FB8D697008B710D /* PMKCoreLocation.framework */; };
 		93BC49FB1FB8D6A3008B710D /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 93BC49FA1FB8D6A3008B710D /* PromiseKit.framework */; };
 		93BC49FD1FB8D6F4008B710D /* Mantle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 93BC49FC1FB8D6F4008B710D /* Mantle.framework */; };
+		93D5F3671FF1900700800132 /* OBAURLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93D5F3661FF1900700800132 /* OBAURLRequest.swift */; };
 		93E592931F8CA6260079A2D8 /* OBATableRow.h in Headers */ = {isa = PBXBuildFile; fileRef = 93E592911F8CA6260079A2D8 /* OBATableRow.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		93E592941F8CA6260079A2D8 /* OBATableRow.m in Sources */ = {isa = PBXBuildFile; fileRef = 93E592921F8CA6260079A2D8 /* OBATableRow.m */; };
 		93E592971F8CA6870079A2D8 /* OBATableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 93E592951F8CA6870079A2D8 /* OBATableViewCell.m */; };
@@ -523,6 +524,7 @@
 		93BC49F61FB8D697008B710D /* PMKCoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PMKCoreLocation.framework; path = ../Carthage/Build/iOS/PMKCoreLocation.framework; sourceTree = "<group>"; };
 		93BC49FA1FB8D6A3008B710D /* PromiseKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PromiseKit.framework; path = ../Carthage/Build/iOS/PromiseKit.framework; sourceTree = "<group>"; };
 		93BC49FC1FB8D6F4008B710D /* Mantle.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Mantle.framework; path = ../Carthage/Build/iOS/Mantle.framework; sourceTree = "<group>"; };
+		93D5F3661FF1900700800132 /* OBAURLRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OBAURLRequest.swift; sourceTree = "<group>"; };
 		93E592911F8CA6260079A2D8 /* OBATableRow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBATableRow.h; sourceTree = "<group>"; };
 		93E592921F8CA6260079A2D8 /* OBATableRow.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBATableRow.m; sourceTree = "<group>"; };
 		93E592951F8CA6870079A2D8 /* OBATableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBATableViewCell.m; sourceTree = "<group>"; };
@@ -918,6 +920,7 @@
 				934196A51DB0B0AF004BBBB7 /* OBAModelServiceRequest.m */,
 				9385BED61FAFA07D00D122D1 /* PromisedModelService.swift */,
 				933A47151FDCCB81009EB332 /* PromiseWrapper.swift */,
+				93D5F3661FF1900700800132 /* OBAURLRequest.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -1348,6 +1351,7 @@
 				9341968D1DB0B099004BBBB7 /* OBATripStatusV2.m in Sources */,
 				93F3F89D1E7B02400025FC78 /* OBARegionalAlert.m in Sources */,
 				934196B71DB0B0AF004BBBB7 /* OBAModelServiceRequest.m in Sources */,
+				93D5F3671FF1900700800132 /* OBAURLRequest.swift in Sources */,
 				93FF1AB21EC39270006C883D /* OBALogging.m in Sources */,
 				93E592971F8CA6870079A2D8 /* OBATableViewCell.m in Sources */,
 				9327DEF41E02306900502F06 /* OBACanvasView.m in Sources */,

--- a/OBAKit/Services/OBAJsonDataSource.h
+++ b/OBAKit/Services/OBAJsonDataSource.h
@@ -18,6 +18,8 @@
 #import <OBAKit/OBADataSourceConfig.h>
 #import <OBAKit/OBAModelServiceRequest.h>
 
+@class OBAURLRequest;
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface OBAJsonDataSource : NSObject
@@ -43,7 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param queryParameters An optional list of query parameters to append to the URL. Turned into: `?key1=value&key2=value`.
  @return An URLRequest suitable for loading data.
  */
-- (NSURLRequest*)buildGETRequestWithPath:(NSString*)path queryParameters:(nullable NSDictionary*)queryParameters;
+- (OBAURLRequest*)buildGETRequestWithPath:(NSString*)path queryParameters:(nullable NSDictionary*)queryParameters;
 
 /**
  Creates an URL request based upon the supplied path and HTTP method, configuring other parameters, like a GZIP header.
@@ -54,7 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param formBody Optional form body contents.
  @return An URLRequest suitable for loading data.
  */
-- (NSURLRequest*)buildRequestWithPath:(NSString*)path HTTPMethod:(NSString*)httpMethod queryParameters:(nullable NSDictionary*)queryParameters formBody:(nullable NSDictionary*)formBody;
+- (OBAURLRequest*)buildRequestWithPath:(NSString*)path HTTPMethod:(NSString*)httpMethod queryParameters:(nullable NSDictionary*)queryParameters formBody:(nullable NSDictionary*)formBody;
 
 /**
  Creates an URL request based upon the supplied URL and HTTP method, configuring other parameters, like a GZIP header.
@@ -64,7 +66,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param formBody Optional form body contents.
  @return An URLRequest suitable for loading data.
  */
-- (NSURLRequest*)buildRequestWithURL:(NSURL*)URL HTTPMethod:(NSString*)httpMethod formBody:(nullable NSDictionary*)formBody;
+- (OBAURLRequest*)buildRequestWithURL:(NSURL*)URL HTTPMethod:(NSString*)httpMethod formBody:(nullable NSDictionary*)formBody;
 
 /**
  Creates an NSURLSessionTask from the supplied URL request that will execute the completion block when it finishes.

--- a/OBAKit/Services/OBAJsonDataSource.m
+++ b/OBAKit/Services/OBAJsonDataSource.m
@@ -18,6 +18,7 @@
 #import <OBAKit/OBACommon.h>
 #import <OBAKit/NSDictionary+OBAAdditions.h>
 #import <OBAKit/NSObject+OBADescription.h>
+#import <OBAKit/OBAKit-Swift.h>
 
 @interface OBAJsonDataSource ()
 @property(nonatomic,strong) NSHashTable *openConnections;
@@ -67,21 +68,18 @@
 
 #pragma mark - Public Methods
 
-- (NSURLRequest*)buildGETRequestWithPath:(NSString*)path queryParameters:(nullable NSDictionary*)queryParameters {
+- (OBAURLRequest*)buildGETRequestWithPath:(NSString*)path queryParameters:(nullable NSDictionary*)queryParameters {
     return [self buildRequestWithPath:path HTTPMethod:@"GET" queryParameters:queryParameters formBody:nil];
 }
 
-- (NSURLRequest*)buildRequestWithPath:(NSString*)path HTTPMethod:(NSString*)httpMethod queryParameters:(nullable NSDictionary*)queryParameters formBody:(nullable NSDictionary*)formBody {
+- (OBAURLRequest*)buildRequestWithPath:(NSString*)path HTTPMethod:(NSString*)httpMethod queryParameters:(nullable NSDictionary*)queryParameters formBody:(nullable NSDictionary*)formBody {
     return [self buildRequestWithURL:[self.config constructURL:path withArgs:queryParameters] HTTPMethod:httpMethod formBody:formBody];
 }
 
-- (NSURLRequest*)buildRequestWithURL:(NSURL*)URL HTTPMethod:(NSString*)httpMethod formBody:(nullable NSDictionary*)formBody {
-    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:URL cachePolicy:NSURLRequestUseProtocolCachePolicy timeoutInterval:15];
-    [request setValue:@"gzip" forHTTPHeaderField:@"Accept-Encoding"];
-    request.HTTPMethod = httpMethod;
+- (OBAURLRequest*)buildRequestWithURL:(NSURL*)URL HTTPMethod:(NSString*)httpMethod formBody:(nullable NSDictionary*)formBody {
+    OBAURLRequest *request = [OBAURLRequest requestWithURL:URL httpMethod:httpMethod checkStatusCodeInBody:self.checkStatusCodeInBody];
 
     BOOL requestSupportsHTTPBody = [@[@"post", @"patch", @"put"] containsObject:httpMethod.lowercaseString];
-
     if (formBody && requestSupportsHTTPBody) {
         request.HTTPBody = [formBody oba_toHTTPBodyData];
     }
@@ -95,7 +93,7 @@
                             formBody:(nullable NSDictionary*)formBody
                      completionBlock:(OBADataSourceCompletion)completion {
 
-    NSURLRequest *request = [self buildRequestWithPath:path
+    OBAURLRequest *request = [self buildRequestWithPath:path
                                             HTTPMethod:httpMethod
                                        queryParameters:queryParameters
                                               formBody:formBody];

--- a/OBAKit/Services/OBAModelService.h
+++ b/OBAKit/Services/OBAModelService.h
@@ -50,19 +50,6 @@ extern NSString * const OBAAgenciesWithCoverageAPIPath;
  */
 + (instancetype)modelServiceWithBaseURL:(NSURL*)URL;
 
-#pragma mark - OBATripInstanceRef -> OBATripDetailsV2
-
-/**
- *  Makes an asynchronous request to fetch trip details
- *
- *  @param tripInstance An intance of a trip
- *  @param completion   The block to be called once the request completes, this is always executed on the main thread.
- *
- *  @return The OBAModelServiceRequest object that allows request cancellation
- */
-- (OBAModelServiceRequest*)requestTripDetailsForTripInstance:(OBATripInstanceRef *)tripInstance
-                                                completionBlock:(OBADataSourceCompletion)completion;
-
 #pragma mark - OBAArrivalAndDepartureInstanceRef -> OBAArrivalAndDepartureV2
 
 /**

--- a/OBAKit/Services/OBAModelService.m
+++ b/OBAKit/Services/OBAModelService.m
@@ -319,24 +319,6 @@ static const CLLocationAccuracy kRegionalRadius = 40000;
          completionBlock:completion];
 }
 
-- (OBAModelServiceRequest*)requestTripDetailsForTripInstance:(OBATripInstanceRef *)tripInstance completionBlock:(OBADataSourceCompletion)completion {
-    NSMutableDictionary *args = [[NSMutableDictionary alloc] init];
-
-    if (tripInstance.serviceDate > 0) {
-        args[@"serviceDate"] = @(tripInstance.serviceDate);
-    }
-
-    if (tripInstance.vehicleId) {
-        args[@"vehicleId"] = tripInstance.vehicleId;
-    }
-
-    return [self request:self.obaJsonDataSource
-                     url:[NSString stringWithFormat:@"/api/where/trip-details/%@.json", [OBAURLHelpers escapePathVariable:tripInstance.tripId]]
-                    args:args
-                selector:@selector(getTripDetailsV2FromJSON:error:)
-         completionBlock:completion];
-}
-
 - (OBAModelServiceRequest*)requestVehicleForId:(NSString *)vehicleId completionBlock:(OBADataSourceCompletion)completion {
     return [self request:self.obaJsonDataSource
                      url:[NSString stringWithFormat:@"/api/where/vehicle/%@.json", [OBAURLHelpers escapePathVariable:vehicleId]]

--- a/OBAKit/Services/OBAURLRequest.swift
+++ b/OBAKit/Services/OBAURLRequest.swift
@@ -1,0 +1,22 @@
+//
+//  OBAURLRequest.swift
+//  OBAKit
+//
+//  Created by Aaron Brethorst on 12/25/17.
+//  Copyright © 2017 OneBusAway. All rights reserved.
+//
+
+import Foundation
+
+@objc public class OBAURLRequest: NSMutableURLRequest {
+    @objc public var checkStatusCodeInBody: Bool = false
+
+    @objc public class func request(URL: URL, httpMethod: String, checkStatusCodeInBody: Bool) -> OBAURLRequest {
+        let request = OBAURLRequest.init(url: URL, cachePolicy: .useProtocolCachePolicy, timeoutInterval: 15)
+        request.checkStatusCodeInBody = checkStatusCodeInBody
+        request.setValue("gzip", forHTTPHeaderField: "Accept-Encoding")
+        request.httpMethod = httpMethod
+
+        return request
+    }
+}

--- a/OneBusAway/OneBusAwayTests/OBAKitTests/location/OBARegionHelper_Tests.m
+++ b/OneBusAway/OneBusAwayTests/OBAKitTests/location/OBARegionHelper_Tests.m
@@ -21,7 +21,7 @@
 @interface OBARegionHelper_Tests : XCTestCase
 @property(nonatomic,strong) OBATestHarnessPersistenceLayer *persistenceLayer;
 @property(nonatomic,strong) OBAModelDAO *modelDAO;
-@property(nonatomic,strong) OBAModelService *modelService;
+@property(nonatomic,strong) PromisedModelService *modelService;
 @property(nonatomic,strong) OBALocationManager *locationManager;
 @end
 

--- a/OneBusAway/ui/trip_details/OBAArrivalAndDepartureViewController.m
+++ b/OneBusAway/ui/trip_details/OBAArrivalAndDepartureViewController.m
@@ -297,8 +297,10 @@ static NSTimeInterval const kRefreshTimeInterval = 30;
         self.mapController.routeType = self.arrivalAndDeparture.stop.firstAvailableRouteTypeForStop;
         [self updateTitleViewWithArrivalAndDeparture:self.arrivalAndDeparture];
 
-        return [self.modelService promiseTripDetailsFor:self.arrivalAndDeparture.tripInstance];
-    }).then(^(OBATripDetailsV2 *tripDetails) {
+        PromiseWrapper *wrapper = [self.modelService requestTripDetailsWithTripInstance:self.arrivalAndDeparture.tripInstance];
+        return wrapper.anyPromise;
+    }).then(^(NetworkResponse *response) {
+        OBATripDetailsV2 *tripDetails = response.object;
         self.tripDetails = tripDetails;
         self.mapController.tripDetails = tripDetails;
         [self populateTableWithArrivalAndDeparture:self.arrivalAndDeparture tripDetails:self.tripDetails];

--- a/OneBusAway/ui/trip_details/OBATripDetailsViewController.m
+++ b/OneBusAway/ui/trip_details/OBATripDetailsViewController.m
@@ -25,6 +25,7 @@
 @property(nonatomic,strong) OBATripInstanceRef *tripInstance;
 @property(nonatomic,strong) OBATripDetailsV2 *tripDetails;
 @property(nonatomic,copy) NSString *currentStopId;
+@property(nonatomic,strong) PromiseWrapper *promiseWrapper;
 @end
 
 @implementation OBATripDetailsViewController
@@ -35,6 +36,10 @@
     }
 
     return self;
+}
+
+- (void)dealloc {
+    [self.promiseWrapper cancel];
 }
 
 - (void)viewDidLoad {
@@ -49,8 +54,9 @@
     self.navigationItem.rightBarButtonItem.enabled = NO;
     [SVProgressHUD show];
 
-    [self.modelService promiseTripDetailsFor:self.tripInstance].then(^(OBATripDetailsV2 *tripDetails) {
-        self.tripDetails = tripDetails;
+    self.promiseWrapper = [self.modelService requestTripDetailsWithTripInstance:self.tripInstance];
+    self.promiseWrapper.anyPromise.then(^(NetworkResponse *response) {
+        self.tripDetails = response.object;
         [self buildSections];
     }).always(^{
         self.navigationItem.rightBarButtonItem.enabled = YES;


### PR DESCRIPTION
Finishes up work for #1227 - Convert non-PromiseWrapper-based promises to PromiseWrapper

* Generates error objects from HTTPURLResponse status codes
* Adds URLRequest objects to NetworkResponse so that we can figure out if a given network response needs to have a checkCodeInBody data munging exercise performed.
* Performs a data munging exercise inside of the network response's body if the appropriate flag is set on the request.
* DRYs up data munging