### PR TITLE
Fixes some/most/all issues with regions not loading correctly

### DIFF
--- a/OBAKit/Info.plist
+++ b/OBAKit/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>18.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>20171230.10</string>
+	<string>20180102.17</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/OBAKit/Location/OBARegionStorage.m
+++ b/OBAKit/Location/OBARegionStorage.m
@@ -58,7 +58,13 @@ static NSString * const OBALocalRegionsFileName = @"regions.json";
 - (NSArray<OBARegionV2*>*)readRegionsFromDisk {
     __block NSArray<OBARegionV2*>* regions = nil;
     dispatch_sync(self.serialQueue, ^{
-        regions = [self persistedRegions] ?: [self bundledRegions];
+        NSArray<OBARegionV2*>* persisted = [self persistedRegions];
+        if (persisted.count > 0) {
+            regions = persisted;
+        }
+        else {
+            regions = [self bundledRegions];
+        }
     });
     return regions;
 }

--- a/OBAKit/Services/OBAModelFactory.m
+++ b/OBAKit/Services/OBAModelFactory.m
@@ -171,8 +171,8 @@ static NSString * const kReferences = @"references";
     jsonDictionary = jsonDictionary ?: [self.class staticRegionsJSON];
     
     OBAJsonDigester * digester = [[OBAJsonDigester alloc] init];
-    [digester addRegionV2RulesWithPrefix:@"/data/list/[]"];
-    [digester addSetNext:@selector(addValue:) forPrefix:@"/data/list/[]"];
+    [digester addRegionV2RulesWithPrefix:@"/list/[]"];
+    [digester addSetNext:@selector(addValue:) forPrefix:@"/list/[]"];
     [digester parse:jsonDictionary withRoot:list parameters:[self getDigesterParameters] error:error];
 
     return list;

--- a/OneBusAway Today/Info.plist
+++ b/OneBusAway Today/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>18.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>20171230.10</string>
+	<string>20180102.17</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>

--- a/OneBusAway/Info.plist
+++ b/OneBusAway/Info.plist
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>20171230.10</string>
+	<string>20180102.17</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>

--- a/OneBusAway/OneBusAwayTests/OBAKitTests/models/OBARegionV2_Tests.m
+++ b/OneBusAway/OneBusAwayTests/OBAKitTests/models/OBARegionV2_Tests.m
@@ -7,43 +7,18 @@
 //
 
 #import <XCTest/XCTest.h>
-#import <OBAKit/OBAModelFactory.h>
 #import <OBAKit/OBAReferencesV2.h>
 #import <OBAKit/OBARegionBoundsV2.h>
 #import <OBAKit/OBARegionV2.h>
 #import "OBATestHelpers.h"
 
 @interface OBARegionV2_Tests : XCTestCase
-@property(nonatomic,strong) OBAModelFactory *modelFactory;
-@property(nonatomic,strong) id regionsJSON;
 @end
 
 @implementation OBARegionV2_Tests
 
-- (void)setUp {
-    [super setUp];
-
-    OBAReferencesV2 *references = [[OBAReferencesV2 alloc] init];
-    self.modelFactory = [[OBAModelFactory alloc] initWithReferences:references];
-    self.regionsJSON = [OBATestHelpers jsonObjectFromFile:@"regions-v3.json"];
-}
-
-- (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
-    [super tearDown];
-}
-
-- (NSArray<OBARegionV2*>*)getRegions {
-    NSArray *regions = [[self.modelFactory getRegionsV2FromJson:self.regionsJSON error:nil] values];
-    return regions;
-}
-
-- (OBARegionV2*)getTampaRegion {
-    return [self getRegions][0];
-}
-
-- (void)testRegionsCount {
-    NSArray<OBARegionV2*>* regions = [self getRegions];
+- (void)validateRegionsCount {
+    NSArray<OBARegionV2*>* regions = [OBATestHelpers regionsList];
     XCTAssertEqual(regions.count, 12);
 }
 
@@ -81,7 +56,7 @@
 #pragma mark - Other Methods
 
 - (void)testCenterCoordinate {
-    OBARegionV2 *tampa = [self getTampaRegion];
+    OBARegionV2 *tampa = [OBATestHelpers tampaRegion];
     MKMapRect tampaServiceRect = MKMapRectMake(72439895.221134216, 112245249.35188442, 516632.36992569268, 476938.48868602514);
     MKMapPoint centerPoint = MKMapPointMake(MKMapRectGetMidX(tampaServiceRect), MKMapRectGetMidY(tampaServiceRect));
     CLLocationCoordinate2D knownGoodCoordinate = MKCoordinateForMapPoint(centerPoint);
@@ -119,15 +94,11 @@
 #pragma mark - Tampa
 
 - (void)testTampa {
-    NSArray<OBARegionV2*>* regions = [self getRegions];
-    OBARegionV2 *tampa = regions[0];
-
-    [self testTampaWithRegion:tampa];
+    [self testTampaWithRegion:[OBATestHelpers tampaRegion]];
 }
 
 - (void)testUnarchivedTampa {
-    NSArray<OBARegionV2*>* regions = [self getRegions];
-    OBARegionV2 *firstTampa = regions[0];
+    OBARegionV2 *firstTampa = [OBATestHelpers tampaRegion];
     NSData *data = [NSKeyedArchiver archivedDataWithRootObject:firstTampa];
 
     OBARegionV2 *tampa = [NSKeyedUnarchiver unarchiveObjectWithData:data];
@@ -178,14 +149,14 @@
 #pragma mark - Boston
 
 - (void)testBoston {
-    NSArray<OBARegionV2*>* regions = [self getRegions];
+    NSArray<OBARegionV2*>* regions = [OBATestHelpers regionsList];
     NSPredicate *predicate = [NSPredicate predicateWithFormat:@"regionName == %@", @"Boston"];
     OBARegionV2 *boston = [[regions filteredArrayUsingPredicate:predicate] firstObject];
     [self testBostonWithRegion:boston];
 }
 
 - (void)testUnarchivingBoston {
-    NSArray<OBARegionV2*>* regions = [self getRegions];
+    NSArray<OBARegionV2*>* regions = [OBATestHelpers regionsList];
     NSPredicate *predicate = [NSPredicate predicateWithFormat:@"regionName == %@", @"Boston"];
     OBARegionV2 *boston = [[regions filteredArrayUsingPredicate:predicate] firstObject];
 

--- a/OneBusAway/OneBusAwayTests/helpers/OBATestHelpers.h
+++ b/OneBusAway/OneBusAwayTests/helpers/OBATestHelpers.h
@@ -94,6 +94,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property(class,nonatomic,readonly,copy) OBARegionV2 *pugetSoundRegion;
 @property(class,nonatomic,readonly,copy) OBARegionV2 *tampaRegion;
+@property(class,nonatomic,readonly,copy) NSArray<OBARegionV2*> *regionsList;
 
 // Time and Time Zones
 

--- a/OneBusAway/OneBusAwayTests/helpers/OBATestHelpers.m
+++ b/OneBusAway/OneBusAwayTests/helpers/OBATestHelpers.m
@@ -51,15 +51,18 @@
 }
 
 + (OBARegionV2*)pugetSoundRegion {
-    OBAModelFactory *modelFactory = [[OBAModelFactory alloc] initWithReferences:[[OBAReferencesV2 alloc] init]];
-    NSArray *regions = [[modelFactory getRegionsV2FromJson:[OBATestHelpers jsonObjectFromFile:@"regions-v3.json"] error:nil] values];
-    return regions[1];
+    return self.regionsList[1];
 }
 
 + (OBARegionV2*)tampaRegion {
+    return self.regionsList[0];
+}
+
++ (NSArray<OBARegionV2*>*)regionsList {
     OBAModelFactory *modelFactory = [[OBAModelFactory alloc] initWithReferences:[[OBAReferencesV2 alloc] init]];
-    NSArray *regions = [[modelFactory getRegionsV2FromJson:[OBATestHelpers jsonObjectFromFile:@"regions-v3.json"] error:nil] values];
-    return regions[0];
+    id jsonData = [OBATestHelpers jsonObjectFromFile:@"regions-v3.json"][@"data"];
+    OBAListWithRangeAndReferencesV2 *list = [modelFactory getRegionsV2FromJson:jsonData error:nil];
+    return list.values;
 }
 
 #pragma mark - Time and Time Zones


### PR DESCRIPTION
Fixes #1247 - After building project no region list

The clever change I made in the PromiseWrapper to 'unroll' downloaded JSON data's internal structure had the side effect of breaking region loading. This fixes that issue. Also, in the off-chance bad data that hsa no regions ever gets persisted to disk again, this will also make sure that the bundled region data is consulted instead.