### PR TITLE
Display 'Skeleton' UI while waiting for initial content load

### DIFF
--- a/OBAKit/OBAKit.h
+++ b/OBAKit/OBAKit.h
@@ -72,6 +72,7 @@ FOUNDATION_EXPORT const unsigned char OBAKitVersionString[];
 #import <OBAKit/OBANavigationTarget.h>
 #import <OBAKit/OBANavigationTargetAnnotation.h>
 #import <OBAKit/OBANavigationTargetAware.h>
+#import <OBAKit/OBAPlaceholderView.h>
 #import <OBAKit/OBAPlacemark.h>
 #import <OBAKit/OBAPlacemarks.h>
 #import <OBAKit/OBAReachability.h>
@@ -120,6 +121,9 @@ FOUNDATION_EXPORT const unsigned char OBAKitVersionString[];
 
 // 3rd Party Components
 #import <OBAKit/UIScrollView+EmptyDataSet.h>
+#import <OBAKit/FBShimmering.h>
+#import <OBAKit/FBShimmeringLayer.h>
+#import <OBAKit/FBShimmeringView.h>
 
 // MVVM
 #import <OBAKit/OBABaseRow.h>

--- a/OBAKit/OBAKit.xcodeproj/project.pbxproj
+++ b/OBAKit/OBAKit.xcodeproj/project.pbxproj
@@ -224,6 +224,17 @@
 		9385BEDC1FB040B300D122D1 /* OBAErrorMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 9385BEDA1FB040B300D122D1 /* OBAErrorMessages.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9385BEDD1FB040B300D122D1 /* OBAErrorMessages.m in Sources */ = {isa = PBXBuildFile; fileRef = 9385BEDB1FB040B300D122D1 /* OBAErrorMessages.m */; };
 		9387F0F91FDDD9F50033A922 /* NetworkResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9387F0F81FDDD9F50033A922 /* NetworkResponse.swift */; };
+		9388C29B1FFDBAEA0068041F /* FBShimmering.h in Headers */ = {isa = PBXBuildFile; fileRef = 9388C2961FFDBAE90068041F /* FBShimmering.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9388C29C1FFDBAEA0068041F /* FBShimmeringLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 9388C2971FFDBAE90068041F /* FBShimmeringLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9388C29D1FFDBAEA0068041F /* FBShimmeringView.h in Headers */ = {isa = PBXBuildFile; fileRef = 9388C2981FFDBAE90068041F /* FBShimmeringView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9388C29E1FFDBAEA0068041F /* FBShimmeringLayer.m in Sources */ = {isa = PBXBuildFile; fileRef = 9388C2991FFDBAE90068041F /* FBShimmeringLayer.m */; };
+		9388C29F1FFDBAEA0068041F /* FBShimmeringView.m in Sources */ = {isa = PBXBuildFile; fileRef = 9388C29A1FFDBAE90068041F /* FBShimmeringView.m */; };
+		9388C2A41FFDF7C90068041F /* OBAPlaceholderView.h in Headers */ = {isa = PBXBuildFile; fileRef = 9388C2A21FFDF7C90068041F /* OBAPlaceholderView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9388C2A51FFDF7C90068041F /* OBAPlaceholderView.m in Sources */ = {isa = PBXBuildFile; fileRef = 9388C2A31FFDF7C90068041F /* OBAPlaceholderView.m */; };
+		9388C2A81FFE1BB90068041F /* OBAPlaceholderRow.h in Headers */ = {isa = PBXBuildFile; fileRef = 9388C2A61FFE1BB90068041F /* OBAPlaceholderRow.h */; };
+		9388C2A91FFE1BB90068041F /* OBAPlaceholderRow.m in Sources */ = {isa = PBXBuildFile; fileRef = 9388C2A71FFE1BB90068041F /* OBAPlaceholderRow.m */; };
+		9388C2AC1FFE1C240068041F /* OBAPlaceholderCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 9388C2AA1FFE1C240068041F /* OBAPlaceholderCell.h */; };
+		9388C2AD1FFE1C240068041F /* OBAPlaceholderCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 9388C2AB1FFE1C240068041F /* OBAPlaceholderCell.m */; };
 		93A6E9E21F5BC18B00AFA61C /* AppInterop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93A6E9E11F5BC18B00AFA61C /* AppInterop.swift */; };
 		93A73BF21F8760F600F213D4 /* OBAClassicDepartureView.h in Headers */ = {isa = PBXBuildFile; fileRef = 93A73BF01F8760F600F213D4 /* OBAClassicDepartureView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		93A73BF31F8760F600F213D4 /* OBAClassicDepartureView.m in Sources */ = {isa = PBXBuildFile; fileRef = 93A73BF11F8760F600F213D4 /* OBAClassicDepartureView.m */; };
@@ -506,6 +517,17 @@
 		9385BEDA1FB040B300D122D1 /* OBAErrorMessages.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OBAErrorMessages.h; sourceTree = "<group>"; };
 		9385BEDB1FB040B300D122D1 /* OBAErrorMessages.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OBAErrorMessages.m; sourceTree = "<group>"; };
 		9387F0F81FDDD9F50033A922 /* NetworkResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkResponse.swift; sourceTree = "<group>"; };
+		9388C2961FFDBAE90068041F /* FBShimmering.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBShimmering.h; sourceTree = "<group>"; };
+		9388C2971FFDBAE90068041F /* FBShimmeringLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBShimmeringLayer.h; sourceTree = "<group>"; };
+		9388C2981FFDBAE90068041F /* FBShimmeringView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBShimmeringView.h; sourceTree = "<group>"; };
+		9388C2991FFDBAE90068041F /* FBShimmeringLayer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBShimmeringLayer.m; sourceTree = "<group>"; };
+		9388C29A1FFDBAE90068041F /* FBShimmeringView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBShimmeringView.m; sourceTree = "<group>"; };
+		9388C2A21FFDF7C90068041F /* OBAPlaceholderView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OBAPlaceholderView.h; sourceTree = "<group>"; };
+		9388C2A31FFDF7C90068041F /* OBAPlaceholderView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OBAPlaceholderView.m; sourceTree = "<group>"; };
+		9388C2A61FFE1BB90068041F /* OBAPlaceholderRow.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OBAPlaceholderRow.h; sourceTree = "<group>"; };
+		9388C2A71FFE1BB90068041F /* OBAPlaceholderRow.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OBAPlaceholderRow.m; sourceTree = "<group>"; };
+		9388C2AA1FFE1C240068041F /* OBAPlaceholderCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OBAPlaceholderCell.h; sourceTree = "<group>"; };
+		9388C2AB1FFE1C240068041F /* OBAPlaceholderCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OBAPlaceholderCell.m; sourceTree = "<group>"; };
 		93A6E9E11F5BC18B00AFA61C /* AppInterop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInterop.swift; sourceTree = "<group>"; };
 		93A73BF01F8760F600F213D4 /* OBAClassicDepartureView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAClassicDepartureView.h; sourceTree = "<group>"; };
 		93A73BF11F8760F600F213D4 /* OBAClassicDepartureView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAClassicDepartureView.m; sourceTree = "<group>"; };
@@ -613,6 +635,10 @@
 				93089DA21F87E6E600694A90 /* OBAViewModelRegistry.m */,
 				93089D9E1F87E6B900694A90 /* OBABaseRow.h */,
 				93089D9D1F87E6B900694A90 /* OBABaseRow.m */,
+				9388C2A61FFE1BB90068041F /* OBAPlaceholderRow.h */,
+				9388C2A71FFE1BB90068041F /* OBAPlaceholderRow.m */,
+				9388C2AA1FFE1C240068041F /* OBAPlaceholderCell.h */,
+				9388C2AB1FFE1C240068041F /* OBAPlaceholderCell.m */,
 			);
 			path = MVVM;
 			sourceTree = "<group>";
@@ -928,6 +954,7 @@
 		934196A61DB0B0AF004BBBB7 /* UI */ = {
 			isa = PBXGroup;
 			children = (
+				9388C2951FFDBAE90068041F /* Shimmer */,
 				93E5929D1F8CABD70079A2D8 /* Containers */,
 				93089DAA1F87E8F200694A90 /* OBAClassicDepartureCell.h */,
 				93089DAB1F87E8F200694A90 /* OBAClassicDepartureCell.m */,
@@ -992,6 +1019,20 @@
 				9377DD521EE4682E00134AE8 /* BorderedButton.swift */,
 			);
 			path = Controls;
+			sourceTree = "<group>";
+		};
+		9388C2951FFDBAE90068041F /* Shimmer */ = {
+			isa = PBXGroup;
+			children = (
+				9388C2961FFDBAE90068041F /* FBShimmering.h */,
+				9388C2971FFDBAE90068041F /* FBShimmeringLayer.h */,
+				9388C2991FFDBAE90068041F /* FBShimmeringLayer.m */,
+				9388C2981FFDBAE90068041F /* FBShimmeringView.h */,
+				9388C29A1FFDBAE90068041F /* FBShimmeringView.m */,
+				9388C2A21FFDF7C90068041F /* OBAPlaceholderView.h */,
+				9388C2A31FFDF7C90068041F /* OBAPlaceholderView.m */,
+			);
+			path = Shimmer;
 			sourceTree = "<group>";
 		};
 		93E5929D1F8CABD70079A2D8 /* Containers */ = {
@@ -1099,8 +1140,10 @@
 				934196B61DB0B0AF004BBBB7 /* OBAModelServiceRequest.h in Headers */,
 				9341967A1DB0B099004BBBB7 /* OBASituationConsequenceV2.h in Headers */,
 				9341962C1DB0B099004BBBB7 /* OBAVehicleMapAnnotation.h in Headers */,
+				9388C2A41FFDF7C90068041F /* OBAPlaceholderView.h in Headers */,
 				9341966D1DB0B099004BBBB7 /* OBAReportProblemWithStopV2.h in Headers */,
 				934196051DB0B099004BBBB7 /* OBADateHelpers.h in Headers */,
+				9388C2A81FFE1BB90068041F /* OBAPlaceholderRow.h in Headers */,
 				934196AE1DB0B0AF004BBBB7 /* OBADataSourceConfig.h in Headers */,
 				9341961A1DB0B099004BBBB7 /* OBAUser.h in Headers */,
 				934196B81DB0B0AF004BBBB7 /* OBATheme.h in Headers */,
@@ -1123,6 +1166,7 @@
 				93FFA5FA1F88305300EA8008 /* OBAArrivalAndDepartureSectionBuilder.h in Headers */,
 				934196201DB0B099004BBBB7 /* OBARegionChangeRequest.h in Headers */,
 				9327DEF31E02306900502F06 /* OBACanvasView.h in Headers */,
+				9388C2AC1FFE1C240068041F /* OBAPlaceholderCell.h in Headers */,
 				934196321DB0B099004BBBB7 /* OBAModelPersistenceLayer.h in Headers */,
 				93089DA01F87E6B900694A90 /* OBABaseRow.h in Headers */,
 				934196781DB0B099004BBBB7 /* OBAServiceAlertsModel.h in Headers */,
@@ -1143,12 +1187,14 @@
 				934196651DB0B099004BBBB7 /* OBAPlacemarks.h in Headers */,
 				934196761DB0B099004BBBB7 /* OBASearchResult.h in Headers */,
 				934C50951E2A1FB500DFDCA0 /* NSCoder+OBAAdditions.h in Headers */,
+				9388C29C1FFDBAEA0068041F /* FBShimmeringLayer.h in Headers */,
 				93089DA31F87E6E600694A90 /* OBAViewModelRegistry.h in Headers */,
 				9341960E1DB0B099004BBBB7 /* OBAMapHelpers.h in Headers */,
 				9341964F1DB0B099004BBBB7 /* OBAArrivalsAndDeparturesForStopV2.h in Headers */,
 				930AFE9E1DD183720092AE82 /* OBAWalkingDirections.h in Headers */,
 				931C60D71EC3975A0086EC37 /* OBAApplicationConfiguration.h in Headers */,
 				93E592B01F8D3C600079A2D8 /* OBABookmarkedRouteRow.h in Headers */,
+				9388C29D1FFDBAEA0068041F /* FBShimmeringView.h in Headers */,
 				934196091DB0B099004BBBB7 /* OBAImageHelpers.h in Headers */,
 				934196281DB0B099004BBBB7 /* OBATripContinuationMapAnnotation.h in Headers */,
 				93E592A11F8CABD70079A2D8 /* OBAVibrantBlurContainerView.h in Headers */,
@@ -1167,6 +1213,7 @@
 				934196D31DB0C02F004BBBB7 /* NSDate+DateTools.h in Headers */,
 				934196CF1DB0B369004BBBB7 /* OBAKit.h in Headers */,
 				93A73BF21F8760F600F213D4 /* OBAClassicDepartureView.h in Headers */,
+				9388C29B1FFDBAEA0068041F /* FBShimmering.h in Headers */,
 				93A73BF61F87613A00F213D4 /* OBADepartureTimeLabel.h in Headers */,
 				93B282C41DC664C7005013D7 /* OBATripDeepLink.h in Headers */,
 				935C39191F772CE300737DC4 /* NSString+OBAAdditions.h in Headers */,
@@ -1326,6 +1373,7 @@
 				934196561DB0B099004BBBB7 /* OBACoordinateBounds.m in Sources */,
 				93E592A51F8CACBF0079A2D8 /* OBAStaticTableViewController.m in Sources */,
 				931C60D81EC3975A0086EC37 /* OBAApplicationConfiguration.m in Sources */,
+				9388C2A91FFE1BB90068041F /* OBAPlaceholderRow.m in Sources */,
 				934196151DB0B099004BBBB7 /* OBAStopIconFactory.m in Sources */,
 				93A73BF71F87613A00F213D4 /* OBADepartureTimeLabel.m in Sources */,
 				93089DA41F87E6E600694A90 /* OBAViewModelRegistry.m in Sources */,
@@ -1355,6 +1403,7 @@
 				93FF1AB21EC39270006C883D /* OBALogging.m in Sources */,
 				93E592971F8CA6870079A2D8 /* OBATableViewCell.m in Sources */,
 				9327DEF41E02306900502F06 /* OBACanvasView.m in Sources */,
+				9388C2AD1FFE1C240068041F /* OBAPlaceholderCell.m in Sources */,
 				93089DAD1F87E8F200694A90 /* OBAClassicDepartureCell.m in Sources */,
 				9341963A1DB0B099004BBBB7 /* OBASelectorJsonDigesterRule.m in Sources */,
 				933A47161FDCCB81009EB332 /* PromiseWrapper.swift in Sources */,
@@ -1385,6 +1434,7 @@
 				93F3F8A21E7BCA8C0025FC78 /* FileHelpers.swift in Sources */,
 				934196231DB0B099004BBBB7 /* OBARegionHelper.m in Sources */,
 				93F3F8911E7A88EA0025FC78 /* RegionalAlertsManager.swift in Sources */,
+				9388C29F1FFDBAEA0068041F /* FBShimmeringView.m in Sources */,
 				9341964A1DB0B099004BBBB7 /* OBAAgencyWithCoverageV2.m in Sources */,
 				934C509A1E2B656900DFDCA0 /* NSDictionary+OBAAdditions.m in Sources */,
 				934196081DB0B099004BBBB7 /* OBAEmailHelper.m in Sources */,
@@ -1393,6 +1443,7 @@
 				934196B11DB0B0AF004BBBB7 /* OBAJsonDataSource.m in Sources */,
 				934196481DB0B099004BBBB7 /* OBAAgencyV2.m in Sources */,
 				9358CDAF1DEA1AB000132CDE /* OBADepartureCellHelpers.m in Sources */,
+				9388C2A51FFDF7C90068041F /* OBAPlaceholderView.m in Sources */,
 				93A73BF31F8760F600F213D4 /* OBAClassicDepartureView.m in Sources */,
 				934196341DB0B099004BBBB7 /* OBACallMethodJsonDigesterRule.m in Sources */,
 				9341962F1DB0B099004BBBB7 /* OBAModelDAO.m in Sources */,
@@ -1410,6 +1461,7 @@
 				9341966E1DB0B099004BBBB7 /* OBAReportProblemWithStopV2.m in Sources */,
 				934196B51DB0B0AF004BBBB7 /* OBAModelService.m in Sources */,
 				93FFA5FB1F88305300EA8008 /* OBAArrivalAndDepartureSectionBuilder.m in Sources */,
+				9388C29E1FFDBAEA0068041F /* FBShimmeringLayer.m in Sources */,
 				934196641DB0B099004BBBB7 /* OBAPlacemark.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/OBAKit/UI/MVVM/OBAPlaceholderCell.h
+++ b/OBAKit/UI/MVVM/OBAPlaceholderCell.h
@@ -1,0 +1,14 @@
+//
+//  OBAPlaceholderCell.h
+//  OBAKit
+//
+//  Created by Aaron Brethorst on 1/4/18.
+//  Copyright © 2018 OneBusAway. All rights reserved.
+//
+
+@import UIKit;
+#import <OBAKit/OBATableCell.h>
+
+@interface OBAPlaceholderCell : UITableViewCell<OBATableCell>
+
+@end

--- a/OBAKit/UI/MVVM/OBAPlaceholderCell.m
+++ b/OBAKit/UI/MVVM/OBAPlaceholderCell.m
@@ -1,0 +1,44 @@
+//
+//  OBAPlaceholderCell.m
+//  OBAKit
+//
+//  Created by Aaron Brethorst on 1/4/18.
+//  Copyright © 2018 OneBusAway. All rights reserved.
+//
+
+#import <OBAKit/OBAPlaceholderCell.h>
+#import <OBAKit/OBAPlaceholderView.h>
+#import <OBAKit/FBShimmeringView.h>
+@import Masonry;
+
+@interface OBAPlaceholderCell ()
+@property(nonatomic,strong) FBShimmeringView *shimmeringView;
+@property(nonatomic,strong) OBAPlaceholderView *placeholderView;
+@end
+
+@implementation OBAPlaceholderCell
+@synthesize tableRow = _tableRow;
+
+- (instancetype)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier {
+    self = [super initWithStyle:style reuseIdentifier:reuseIdentifier];
+
+    if (self) {
+        _shimmeringView = [[FBShimmeringView alloc] initWithFrame:CGRectZero];
+        [self.contentView addSubview:_shimmeringView];
+        [_shimmeringView mas_makeConstraints:^(MASConstraintMaker *make) {
+            make.edges.equalTo(self.contentView);
+        }];
+
+        _placeholderView = [[OBAPlaceholderView alloc] initWithFrame:CGRectZero];
+        _shimmeringView.contentView = _placeholderView;
+        [_placeholderView mas_makeConstraints:^(MASConstraintMaker *make) {
+            make.edges.equalTo(_shimmeringView);
+        }];
+
+        _shimmeringView.shimmering = YES;
+    }
+
+    return self;
+}
+
+@end

--- a/OBAKit/UI/MVVM/OBAPlaceholderRow.h
+++ b/OBAKit/UI/MVVM/OBAPlaceholderRow.h
@@ -1,0 +1,14 @@
+//
+//  OBAPlaceholderRow.h
+//  OBAKit
+//
+//  Created by Aaron Brethorst on 1/4/18.
+//  Copyright © 2018 OneBusAway. All rights reserved.
+//
+
+@import UIKit;
+#import <OBAKit/OBABaseRow.h>
+
+@interface OBAPlaceholderRow : OBABaseRow
+
+@end

--- a/OBAKit/UI/MVVM/OBAPlaceholderRow.m
+++ b/OBAKit/UI/MVVM/OBAPlaceholderRow.m
@@ -1,0 +1,27 @@
+//
+//  OBAPlaceholderRow.m
+//  OBAKit
+//
+//  Created by Aaron Brethorst on 1/4/18.
+//  Copyright © 2018 OneBusAway. All rights reserved.
+//
+
+#import <OBAKit/OBAPlaceholderRow.h>
+#import <OBAKit/OBAViewModelRegistry.h>
+#import <OBAKit/OBAPlaceholderCell.h>
+
+@implementation OBAPlaceholderRow
+
++ (void)load {
+    [OBAViewModelRegistry registerClass:self.class];
+}
+
++ (void)registerViewsWithTableView:(UITableView *)tableView {
+    [tableView registerClass:[OBAPlaceholderCell class] forCellReuseIdentifier:[self cellReuseIdentifier]];
+}
+
+- (NSString*)cellReuseIdentifier {
+    return NSStringFromClass(self.class);
+}
+
+@end

--- a/OBAKit/UI/MVVM/OBAStaticTableViewController.h
+++ b/OBAKit/UI/MVVM/OBAStaticTableViewController.h
@@ -84,6 +84,16 @@ typedef NS_ENUM(NSUInteger, OBARootViewStyle) {
 - (nullable NSIndexPath*)indexPathForModel:(id)model;
 
 - (BOOL)replaceRowAtIndexPath:(NSIndexPath*)indexPath withRow:(OBABaseRow*)row;
+
+/**
+ Displays a few rows of shimmering placeholder cells while content loads.
+ */
+- (void)displayLoadingUI;
+
+/**
+ Dismisses shimmering placeholder cells.
+ */
+- (void)hideLoadingUI;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/OBAKit/UI/MVVM/OBAStaticTableViewController.m
+++ b/OBAKit/UI/MVVM/OBAStaticTableViewController.m
@@ -12,6 +12,7 @@
 #import <OBAKit/OBAMacros.h>
 #import <OBAKit/OBATableCell.h>
 #import <OBAKit/OBATheme.h>
+#import <OBAKit/OBAPlaceholderRow.h>
 
 @interface OBAStaticTableViewController ()<UITableViewDataSource, UITableViewDelegate, DZNEmptyDataSetSource, DZNEmptyDataSetDelegate>
 @property(nonatomic,strong,readwrite) UITableView *tableView;
@@ -62,6 +63,9 @@
 
     self.tableView.emptyDataSetSource = self;
     self.tableView.emptyDataSetDelegate = self;
+
+    // Shimmering 'Loading' Cells
+    [self displayLoadingUI];
 }
 
 - (void)viewWillAppear:(BOOL)animated {
@@ -323,6 +327,24 @@
 - (NSArray<UITableViewRowAction *> *)tableView:(UITableView *)tableView editActionsForRowAtIndexPath:(NSIndexPath *)indexPath {
     OBABaseRow *row = [self rowAtIndexPath:indexPath];
     return row.rowActions;
+}
+
+#pragma mark - Placeholder UI
+
+- (void)displayLoadingUI {
+    OBAPlaceholderRow *row1 = [[OBAPlaceholderRow alloc] init];
+    OBAPlaceholderRow *row2 = [[OBAPlaceholderRow alloc] init];
+
+    NSArray *placeholderRows = @[row1, row2];
+    OBATableSection *placeholderSection = [[OBATableSection alloc] initWithTitle:nil rows:placeholderRows];
+    self.sections = @[placeholderSection];
+
+    [self.tableView reloadData];
+}
+
+- (void)hideLoadingUI {
+    self.sections = @[];
+    [self.tableView reloadData];
 }
 
 #pragma mark - DZNEmptyDataSet

--- a/OBAKit/UI/Shimmer/FBShimmering.h
+++ b/OBAKit/UI/Shimmer/FBShimmering.h
@@ -1,0 +1,71 @@
+/**
+ Copyright (c) 2014-present, Facebook, Inc.
+ All rights reserved.
+ 
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree. An additional grant
+ of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <CoreGraphics/CoreGraphics.h>
+#import <Foundation/Foundation.h>
+
+typedef NS_ENUM(NSInteger, FBShimmerDirection) {
+  //! Shimmer animation goes from left to right
+  FBShimmerDirectionRight,
+  //! Shimmer animation goes from right to left
+  FBShimmerDirectionLeft,
+  //! Shimmer animation goes from below to above
+  FBShimmerDirectionUp,
+  //! Shimmer animation goes from above to below
+  FBShimmerDirectionDown,
+};
+
+static const CGFloat FBShimmerDefaultBeginTime = CGFLOAT_MAX;
+
+@protocol FBShimmering <NSObject>
+
+//! @abstract Set this to YES to start shimming and NO to stop. Defaults to NO.
+@property (assign, nonatomic, readwrite, getter = isShimmering) BOOL shimmering;
+
+//! @abstract The time interval between shimmerings in seconds. Defaults to 0.4.
+@property (assign, nonatomic, readwrite) CFTimeInterval shimmeringPauseDuration;
+
+//! @abstract The opacity of the content while it is shimmering. Defaults to 0.5.
+@property (assign, nonatomic, readwrite) CGFloat shimmeringAnimationOpacity;
+
+//! @abstract The opacity of the content before it is shimmering. Defaults to 1.0.
+@property (assign, nonatomic, readwrite) CGFloat shimmeringOpacity;
+
+//! @abstract The speed of shimmering, in points per second. Defaults to 230.
+@property (assign, nonatomic, readwrite) CGFloat shimmeringSpeed;
+
+//! @abstract The highlight length of shimmering. Range of [0,1], defaults to 1.0.
+@property (assign, nonatomic, readwrite) CGFloat shimmeringHighlightLength;
+
+//! @abstract Same as "shimmeringHighlightLength", just for downward compatibility. @deprecated
+@property (assign, nonatomic, readwrite, getter = shimmeringHighlightLength, setter = setShimmeringHighlightLength:) CGFloat shimmeringHighlightWidth DEPRECATED_MSG_ATTRIBUTE("Use shimmeringHighlightLength");
+
+//! @abstract The direction of shimmering animation. Defaults to FBShimmerDirectionRight.
+@property (assign, nonatomic, readwrite) FBShimmerDirection shimmeringDirection;
+
+//! @abstract The duration of the fade used when shimmer begins. Defaults to 0.1.
+@property (assign, nonatomic, readwrite) CFTimeInterval shimmeringBeginFadeDuration;
+
+//! @abstract The duration of the fade used when shimmer ends. Defaults to 0.3.
+@property (assign, nonatomic, readwrite) CFTimeInterval shimmeringEndFadeDuration;
+
+/**
+ @abstract The absolute CoreAnimation media time when the shimmer will fade in.
+ @discussion Only valid after setting {@ref shimmering} to NO.
+ */
+@property (assign, nonatomic, readonly) CFTimeInterval shimmeringFadeTime;
+
+/**
+ @abstract The absolute CoreAnimation media time when the shimmer will begin.
+ @discussion Only valid after setting {@ref shimmering} to YES.
+ */
+@property (assign, nonatomic) CFTimeInterval shimmeringBeginTime;
+
+@end
+

--- a/OBAKit/UI/Shimmer/FBShimmeringLayer.h
+++ b/OBAKit/UI/Shimmer/FBShimmeringLayer.h
@@ -1,0 +1,22 @@
+/**
+ Copyright (c) 2014-present, Facebook, Inc.
+ All rights reserved.
+ 
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree. An additional grant
+ of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <QuartzCore/CALayer.h>
+
+#import <OBAKit/FBShimmering.h>
+
+/**
+  @abstract Lightweight, generic shimmering layer.
+ */
+@interface FBShimmeringLayer : CALayer <FBShimmering>
+
+//! @abstract The content layer to be shimmered.
+@property (strong, nonatomic) CALayer *contentLayer;
+
+@end

--- a/OBAKit/UI/Shimmer/FBShimmeringLayer.m
+++ b/OBAKit/UI/Shimmer/FBShimmeringLayer.m
@@ -1,0 +1,479 @@
+/**
+ Copyright (c) 2014-present, Facebook, Inc.
+ All rights reserved.
+ 
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree. An additional grant
+ of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <OBAKit/FBShimmeringLayer.h>
+
+#import <QuartzCore/CAAnimation.h>
+#import <QuartzCore/CAGradientLayer.h>
+#import <QuartzCore/CATransaction.h>
+
+#import <UIKit/UIGeometry.h>
+#import <UIKit/UIColor.h>
+
+#if !__has_feature(objc_arc)
+#error This file must be compiled with ARC. Convert your project to ARC or specify the -fobjc-arc flag.
+#endif
+
+#if TARGET_IPHONE_SIMULATOR
+UIKIT_EXTERN float UIAnimationDragCoefficient(void); // UIKit private drag coeffient, use judiciously
+#endif
+
+static CGFloat FBShimmeringLayerDragCoefficient(void)
+{
+#if TARGET_IPHONE_SIMULATOR
+  return UIAnimationDragCoefficient();
+#else
+  return 1.0;
+#endif
+}
+
+static void FBShimmeringLayerAnimationApplyDragCoefficient(CAAnimation *animation)
+{
+  CGFloat k = FBShimmeringLayerDragCoefficient();
+  
+  if (k != 0 && k != 1) {
+    animation.speed = 1 / k;
+  }
+}
+
+// animations keys
+static NSString *const kFBShimmerSlideAnimationKey = @"slide";
+static NSString *const kFBFadeAnimationKey = @"fade";
+static NSString *const kFBEndFadeAnimationKey = @"fade-end";
+
+static CABasicAnimation *fade_animation(CALayer *layer, CGFloat opacity, CFTimeInterval duration)
+{
+  CABasicAnimation *animation = [CABasicAnimation animationWithKeyPath:@"opacity"];
+  animation.fromValue = @([(layer.presentationLayer ?: layer) opacity]);
+  animation.toValue = @(opacity);
+  animation.fillMode = kCAFillModeBoth;
+  animation.removedOnCompletion = NO;
+  animation.duration = duration;
+  FBShimmeringLayerAnimationApplyDragCoefficient(animation);
+  return animation;
+}
+
+static CABasicAnimation *shimmer_slide_animation(CFTimeInterval duration, FBShimmerDirection direction)
+{
+  CABasicAnimation *animation = [CABasicAnimation animationWithKeyPath:@"position"];
+  animation.toValue = [NSValue valueWithCGPoint:CGPointZero];
+  animation.duration = duration;
+  animation.repeatCount = HUGE_VALF;
+  FBShimmeringLayerAnimationApplyDragCoefficient(animation);
+  if (direction == FBShimmerDirectionLeft ||
+      direction == FBShimmerDirectionUp) {
+    animation.speed = -fabsf(animation.speed);
+  }
+  return animation;
+}
+
+// take a shimmer slide animation and turns into repeating
+static CAAnimation *shimmer_slide_repeat(CAAnimation *a, CFTimeInterval duration, FBShimmerDirection direction)
+{
+  CAAnimation *anim = [a copy];
+  anim.repeatCount = HUGE_VALF;
+  anim.duration = duration;
+  anim.speed = (direction == FBShimmerDirectionRight || direction == FBShimmerDirectionDown) ? fabsf(anim.speed) : -fabsf(anim.speed);
+  return anim;
+}
+
+// take a shimmer slide animation and turns into finish
+static CAAnimation *shimmer_slide_finish(CAAnimation *a)
+{
+  CAAnimation *anim = [a copy];
+  anim.repeatCount = 0;
+  return anim;
+}
+
+@interface FBShimmeringMaskLayer : CAGradientLayer
+@property (readonly, nonatomic) CALayer *fadeLayer;
+@end
+
+@implementation FBShimmeringMaskLayer
+
+- (instancetype)init
+{
+  self = [super init];
+  if (nil != self) {
+    _fadeLayer = [[CALayer alloc] init];
+    _fadeLayer.backgroundColor = [UIColor whiteColor].CGColor;
+    [self addSublayer:_fadeLayer];
+  }
+  return self;
+}
+
+- (void)layoutSublayers
+{
+  [super layoutSublayers];
+  CGRect r = self.bounds;
+  _fadeLayer.bounds = r;
+  _fadeLayer.position = CGPointMake(CGRectGetMidX(r), CGRectGetMidY(r));
+}
+
+@end
+
+@interface FBShimmeringLayer ()
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 100000
+// iOS 10 SDK has CALayerDelegate and CAAnimationDelegate as proper protocols.
+<CALayerDelegate, CAAnimationDelegate>
+#endif
+
+@property (strong, nonatomic) FBShimmeringMaskLayer *maskLayer;
+@end
+
+@implementation FBShimmeringLayer
+{
+  CALayer *_contentLayer;
+  FBShimmeringMaskLayer *_maskLayer;
+}
+
+#pragma mark - Lifecycle
+
+@synthesize shimmering = _shimmering;
+@synthesize shimmeringPauseDuration = _shimmeringPauseDuration;
+@synthesize shimmeringAnimationOpacity = _shimmeringAnimationOpacity;
+@synthesize shimmeringOpacity = _shimmeringOpacity;
+@synthesize shimmeringSpeed = _shimmeringSpeed;
+@synthesize shimmeringHighlightLength = _shimmeringHighlightLength;
+@synthesize shimmeringDirection = _shimmeringDirection;
+@synthesize shimmeringFadeTime = _shimmeringFadeTime;
+@synthesize shimmeringBeginFadeDuration = _shimmeringBeginFadeDuration;
+@synthesize shimmeringEndFadeDuration = _shimmeringEndFadeDuration;
+@synthesize shimmeringBeginTime = _shimmeringBeginTime;
+@dynamic shimmeringHighlightWidth;
+
+- (instancetype)init
+{
+  self = [super init];
+  if (nil != self) {
+    // default configuration
+    _shimmeringPauseDuration = 0.4;
+    _shimmeringSpeed = 230.0;
+    _shimmeringHighlightLength = 1.0;
+    _shimmeringAnimationOpacity = 0.5;
+    _shimmeringOpacity = 1.0;
+    _shimmeringDirection = FBShimmerDirectionRight;
+    _shimmeringBeginFadeDuration = 0.1;
+    _shimmeringEndFadeDuration = 0.3;
+    _shimmeringBeginTime = FBShimmerDefaultBeginTime;
+  }
+  return self;
+}
+
+#pragma mark - Properties
+
+- (void)setContentLayer:(CALayer *)contentLayer
+{
+  // reset mask
+  self.maskLayer = nil;
+
+  // note content layer and add for display
+  _contentLayer = contentLayer;
+  self.sublayers = contentLayer ? @[contentLayer] : nil;
+
+  // update shimmering animation
+  [self _updateShimmering];
+}
+
+- (void)setShimmering:(BOOL)shimmering
+{
+  if (shimmering != _shimmering) {
+    _shimmering = shimmering;
+    [self _updateShimmering];
+  }
+}
+
+- (void)setShimmeringSpeed:(CGFloat)speed
+{
+  if (speed != _shimmeringSpeed) {
+    _shimmeringSpeed = speed;
+    [self _updateShimmering];
+  }
+}
+
+- (void)setShimmeringHighlightLength:(CGFloat)length
+{
+  if (length != _shimmeringHighlightLength) {
+    _shimmeringHighlightLength = length;
+    [self _updateShimmering];
+  }
+}
+
+- (void)setShimmeringDirection:(FBShimmerDirection)direction
+{
+  if (direction != _shimmeringDirection) {
+    _shimmeringDirection = direction;
+    [self _updateShimmering];
+  }
+}
+
+- (void)setShimmeringPauseDuration:(CFTimeInterval)duration
+{
+  if (duration != _shimmeringPauseDuration) {
+    _shimmeringPauseDuration = duration;
+    [self _updateShimmering];
+  }
+}
+
+- (void)setShimmeringAnimationOpacity:(CGFloat)shimmeringAnimationOpacity
+{
+  if (shimmeringAnimationOpacity != _shimmeringAnimationOpacity) {
+    _shimmeringAnimationOpacity = shimmeringAnimationOpacity;
+    [self _updateMaskColors];
+  }
+}
+
+- (void)setShimmeringOpacity:(CGFloat)shimmeringOpacity
+{
+  if (shimmeringOpacity != _shimmeringOpacity) {
+    _shimmeringOpacity = shimmeringOpacity;
+    [self _updateMaskColors];
+  }
+}
+
+- (void)setShimmeringBeginTime:(CFTimeInterval)beginTime
+{
+  if (beginTime != _shimmeringBeginTime) {
+    _shimmeringBeginTime = beginTime;
+    [self _updateShimmering];
+  }
+}
+
+- (void)layoutSublayers
+{
+  [super layoutSublayers];
+  CGRect r = self.bounds;
+  _contentLayer.anchorPoint = CGPointMake(0.5, 0.5);
+  _contentLayer.bounds = r;
+  _contentLayer.position = CGPointMake(CGRectGetMidX(r), CGRectGetMidY(r));
+  
+  if (nil != _maskLayer) {
+    [self _updateMaskLayout];
+  }
+}
+
+- (void)setBounds:(CGRect)bounds
+{
+  CGRect oldBounds = self.bounds;
+  [super setBounds:bounds];
+ 
+  if (!CGRectEqualToRect(oldBounds, bounds)) {
+    [self _updateShimmering];
+  }
+}
+
+#pragma mark - Internal
+
+- (void)_clearMask
+{
+  if (nil == _maskLayer) {
+    return;
+  }
+
+  BOOL disableActions = [CATransaction disableActions];
+  [CATransaction setDisableActions:YES];
+
+  self.maskLayer = nil;
+  _contentLayer.mask = nil;
+  
+  [CATransaction setDisableActions:disableActions];
+}
+
+- (void)_createMaskIfNeeded
+{
+  if (_shimmering && !_maskLayer) {
+    _maskLayer = [FBShimmeringMaskLayer layer];
+    _maskLayer.delegate = self;
+    _contentLayer.mask = _maskLayer;
+    [self _updateMaskColors];
+    [self _updateMaskLayout];
+  }
+}
+
+- (void)_updateMaskColors
+{
+  if (nil == _maskLayer) {
+    return;
+  }
+
+  // We create a gradient to be used as a mask.
+  // In a mask, the colors do not matter, it's the alpha that decides the degree of masking.
+  UIColor *maskedColor = [UIColor colorWithWhite:1.0 alpha:_shimmeringOpacity];
+  UIColor *unmaskedColor = [UIColor colorWithWhite:1.0 alpha:_shimmeringAnimationOpacity];
+
+  // Create a gradient from masked to unmasked to masked.
+  _maskLayer.colors = @[(__bridge id)maskedColor.CGColor, (__bridge id)unmaskedColor.CGColor, (__bridge id)maskedColor.CGColor];
+}
+
+- (void)_updateMaskLayout
+{
+  // Everything outside the mask layer is hidden, so we need to create a mask long enough for the shimmered layer to be always covered by the mask.
+  CGFloat length = 0.0f;
+  if (_shimmeringDirection == FBShimmerDirectionDown ||
+      _shimmeringDirection == FBShimmerDirectionUp) {
+    length = CGRectGetHeight(_contentLayer.bounds);
+  } else {
+    length = CGRectGetWidth(_contentLayer.bounds);
+  }
+  if (0 == length) {
+    return;
+  }
+
+  // extra distance for the gradient to travel during the pause.
+  CGFloat extraDistance = length + _shimmeringSpeed * _shimmeringPauseDuration;
+
+  // compute how far the shimmering goes
+  CGFloat fullShimmerLength = length * 3.0f + extraDistance;
+  CGFloat travelDistance = length * 2.0f + extraDistance;
+  
+  // position the gradient for the desired width
+  CGFloat highlightOutsideLength = (1.0 - _shimmeringHighlightLength) / 2.0;
+  _maskLayer.locations = @[@(highlightOutsideLength),
+                           @(0.5),
+                           @(1.0 - highlightOutsideLength)];
+
+  CGFloat startPoint = (length + extraDistance) / fullShimmerLength;
+  CGFloat endPoint = travelDistance / fullShimmerLength;
+  
+  // position for the start of the animation
+  _maskLayer.anchorPoint = CGPointZero;
+  if (_shimmeringDirection == FBShimmerDirectionDown ||
+      _shimmeringDirection == FBShimmerDirectionUp) {
+    _maskLayer.startPoint = CGPointMake(0.0, startPoint);
+    _maskLayer.endPoint = CGPointMake(0.0, endPoint);
+    _maskLayer.position = CGPointMake(0.0, -travelDistance);
+    _maskLayer.bounds = CGRectMake(0.0, 0.0, CGRectGetWidth(_contentLayer.bounds), fullShimmerLength);
+  } else {
+    _maskLayer.startPoint = CGPointMake(startPoint, 0.0);
+    _maskLayer.endPoint = CGPointMake(endPoint, 0.0);
+    _maskLayer.position = CGPointMake(-travelDistance, 0.0);
+    _maskLayer.bounds = CGRectMake(0.0, 0.0, fullShimmerLength, CGRectGetHeight(_contentLayer.bounds));
+  }
+}
+
+- (void)_updateShimmering
+{
+  // create mask if needed
+  [self _createMaskIfNeeded];
+
+  // if not shimmering and no mask, noop
+  if (!_shimmering && !_maskLayer) {
+    return;
+  }
+
+  // ensure layout
+  [self layoutIfNeeded];
+
+  BOOL disableActions = [CATransaction disableActions];
+  if (!_shimmering) {
+    if (disableActions) {
+      // simply remove mask
+      [self _clearMask];
+    } else {
+      // end slide
+      CFTimeInterval slideEndTime = 0;
+
+      CAAnimation *slideAnimation = [_maskLayer animationForKey:kFBShimmerSlideAnimationKey];
+      if (slideAnimation != nil) {
+
+        // determine total time sliding
+        CFTimeInterval now = CACurrentMediaTime();
+        CFTimeInterval slideTotalDuration = now - slideAnimation.beginTime;
+
+        // determine time offset into current slide
+        CFTimeInterval slideTimeOffset = fmod(slideTotalDuration, slideAnimation.duration);
+
+        // transition to non-repeating slide
+        CAAnimation *finishAnimation = shimmer_slide_finish(slideAnimation);
+
+        // adjust begin time to now - offset
+        finishAnimation.beginTime = now - slideTimeOffset;
+
+        // note slide end time and begin
+        slideEndTime = finishAnimation.beginTime + slideAnimation.duration;
+        [_maskLayer addAnimation:finishAnimation forKey:kFBShimmerSlideAnimationKey];
+      }
+
+      // fade in text at slideEndTime
+      CABasicAnimation *fadeInAnimation = fade_animation(_maskLayer.fadeLayer, 1.0, _shimmeringEndFadeDuration);
+      fadeInAnimation.delegate = self;
+      [fadeInAnimation setValue:@YES forKey:kFBEndFadeAnimationKey];
+      fadeInAnimation.beginTime = slideEndTime;
+      [_maskLayer.fadeLayer addAnimation:fadeInAnimation forKey:kFBFadeAnimationKey];
+
+      // expose end time for synchronization
+      _shimmeringFadeTime = slideEndTime;
+    }
+  } else {
+    // fade out text, optionally animated
+    CABasicAnimation *fadeOutAnimation = nil;
+    if (_shimmeringBeginFadeDuration > 0.0 && !disableActions) {
+      fadeOutAnimation = fade_animation(_maskLayer.fadeLayer, 0.0, _shimmeringBeginFadeDuration);
+      [_maskLayer.fadeLayer addAnimation:fadeOutAnimation forKey:kFBFadeAnimationKey];
+    } else {
+      BOOL innerDisableActions = [CATransaction disableActions];
+      [CATransaction setDisableActions:YES];
+
+      _maskLayer.fadeLayer.opacity = 0.0;
+      [_maskLayer.fadeLayer removeAllAnimations];
+      
+      [CATransaction setDisableActions:innerDisableActions];
+    }
+
+    // begin slide animation
+    CAAnimation *slideAnimation = [_maskLayer animationForKey:kFBShimmerSlideAnimationKey];
+    
+    // compute shimmer duration
+    CGFloat length = 0.0f;
+    if (_shimmeringDirection == FBShimmerDirectionDown ||
+        _shimmeringDirection == FBShimmerDirectionUp) {
+      length = CGRectGetHeight(_contentLayer.bounds);
+    } else {
+      length = CGRectGetWidth(_contentLayer.bounds);
+    }
+    CFTimeInterval animationDuration = (length / _shimmeringSpeed) + _shimmeringPauseDuration;
+    
+    if (slideAnimation != nil) {
+      // ensure existing slide animation repeats
+      [_maskLayer addAnimation:shimmer_slide_repeat(slideAnimation, animationDuration, _shimmeringDirection) forKey:kFBShimmerSlideAnimationKey];
+    } else {
+      // add slide animation
+      slideAnimation = shimmer_slide_animation(animationDuration, _shimmeringDirection);
+      slideAnimation.fillMode = kCAFillModeForwards;
+      slideAnimation.removedOnCompletion = NO;
+      if (_shimmeringBeginTime == FBShimmerDefaultBeginTime) {
+        _shimmeringBeginTime = CACurrentMediaTime() + fadeOutAnimation.duration;
+      }
+      slideAnimation.beginTime = _shimmeringBeginTime;
+      
+      [_maskLayer addAnimation:slideAnimation forKey:kFBShimmerSlideAnimationKey];
+    }
+  }
+}
+
+#pragma mark - CALayerDelegate
+
+- (id<CAAction>)actionForLayer:(CALayer *)layer forKey:(NSString *)event
+{
+  // no associated actions
+  return (id)kCFNull;
+}
+
+#pragma mark - CAAnimationDelegate
+
+- (void)animationDidStop:(CAAnimation *)anim finished:(BOOL)flag
+{
+  if (flag && [[anim valueForKey:kFBEndFadeAnimationKey] boolValue]) {
+    [_maskLayer.fadeLayer removeAnimationForKey:kFBFadeAnimationKey];
+
+    [self _clearMask];
+  }
+}
+
+@end

--- a/OBAKit/UI/Shimmer/FBShimmeringView.h
+++ b/OBAKit/UI/Shimmer/FBShimmeringView.h
@@ -1,0 +1,22 @@
+/**
+ Copyright (c) 2014-present, Facebook, Inc.
+ All rights reserved.
+ 
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree. An additional grant
+ of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <UIKit/UIView.h>
+
+#import <OBAKit/FBShimmering.h>
+
+/**
+  @abstract Lightweight, generic shimmering view.
+ */
+@interface FBShimmeringView : UIView <FBShimmering>
+
+//! @abstract The content view to be shimmered.
+@property (strong, nonatomic) UIView *contentView;
+
+@end

--- a/OBAKit/UI/Shimmer/FBShimmeringView.m
+++ b/OBAKit/UI/Shimmer/FBShimmeringView.m
@@ -1,0 +1,72 @@
+/**
+ Copyright (c) 2014-present, Facebook, Inc.
+ All rights reserved.
+ 
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree. An additional grant
+ of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <OBAKit/FBShimmeringView.h>
+#import <OBAKit/FBShimmeringLayer.h>
+
+#if !__has_feature(objc_arc)
+#error This file must be compiled with ARC. Convert your project to ARC or specify the -fobjc-arc flag.
+#endif
+
+@implementation FBShimmeringView
+
++ (Class)layerClass
+{
+  return [FBShimmeringLayer class];
+}
+
+#define __layer ((FBShimmeringLayer *)self.layer)
+
+#define LAYER_ACCESSOR(accessor, ctype) \
+- (ctype)accessor { \
+  return [__layer accessor]; \
+}
+
+#define LAYER_MUTATOR(mutator, ctype) \
+- (void)mutator (ctype)value { \
+  [__layer mutator value]; \
+}
+
+#define LAYER_RW_PROPERTY(accessor, mutator, ctype) \
+  LAYER_ACCESSOR (accessor, ctype) \
+  LAYER_MUTATOR (mutator, ctype)
+
+LAYER_RW_PROPERTY(isShimmering, setShimmering:, BOOL)
+LAYER_RW_PROPERTY(shimmeringPauseDuration, setShimmeringPauseDuration:, CFTimeInterval)
+LAYER_RW_PROPERTY(shimmeringAnimationOpacity, setShimmeringAnimationOpacity:, CGFloat)
+LAYER_RW_PROPERTY(shimmeringOpacity, setShimmeringOpacity:, CGFloat)
+LAYER_RW_PROPERTY(shimmeringSpeed, setShimmeringSpeed:, CGFloat)
+LAYER_RW_PROPERTY(shimmeringHighlightLength, setShimmeringHighlightLength:, CGFloat)
+LAYER_RW_PROPERTY(shimmeringDirection, setShimmeringDirection:, FBShimmerDirection)
+LAYER_ACCESSOR(shimmeringFadeTime, CFTimeInterval)
+LAYER_RW_PROPERTY(shimmeringBeginFadeDuration, setShimmeringBeginFadeDuration:, CFTimeInterval)
+LAYER_RW_PROPERTY(shimmeringEndFadeDuration, setShimmeringEndFadeDuration:, CFTimeInterval)
+LAYER_RW_PROPERTY(shimmeringBeginTime, setShimmeringBeginTime:, CFTimeInterval)
+
+- (void)setContentView:(UIView *)contentView
+{
+  if (contentView != _contentView) {
+    _contentView = contentView;
+    [self addSubview:contentView];
+    __layer.contentLayer = contentView.layer;
+  }
+}
+
+- (void)layoutSubviews
+{
+  // Autolayout requires these to be set on the UIView, not the CALayer.
+  // Do this *before* the layer has a chance to set the properties, as the
+  // setters would be ignored (even for autolayout) if set to the same value.
+  _contentView.bounds = self.bounds;
+  _contentView.center = self.center;
+
+  [super layoutSubviews];
+}
+
+@end

--- a/OBAKit/UI/Shimmer/OBAPlaceholderView.h
+++ b/OBAKit/UI/Shimmer/OBAPlaceholderView.h
@@ -1,0 +1,13 @@
+//
+//  OBAPlaceholderView.h
+//  OBAKit
+//
+//  Created by Aaron Brethorst on 1/3/18.
+//  Copyright © 2018 OneBusAway. All rights reserved.
+//
+
+@import UIKit;
+
+@interface OBAPlaceholderView : UIView
+
+@end

--- a/OBAKit/UI/Shimmer/OBAPlaceholderView.m
+++ b/OBAKit/UI/Shimmer/OBAPlaceholderView.m
@@ -1,0 +1,80 @@
+//
+//  OBAPlaceholderView.m
+//  OBAKit
+//
+//  Created by Aaron Brethorst on 1/3/18.
+//  Copyright © 2018 OneBusAway. All rights reserved.
+//
+
+#import <OBAKit/OBAPlaceholderView.h>
+
+static CGFloat const kLineThickness = 10.f;
+static CGFloat const kMargin = 20.f;
+static CGFloat const kTopMargin = 8.f;
+
+@interface OBAPlaceholderView ()
+@property(nonatomic,strong) UIView *topLine;
+@property(nonatomic,strong) UIView *middleLine;
+@property(nonatomic,strong) UIView *bottomLine;
+@end
+
+@implementation OBAPlaceholderView
+
+- (instancetype)initWithFrame:(CGRect)frame {
+    self = [super initWithFrame:frame];
+
+    if (self) {
+        UIColor *color = [UIColor colorWithWhite:0.9f alpha:1.f];
+
+        _topLine = [[UIView alloc] initWithFrame:CGRectZero];
+        _topLine.backgroundColor = color;
+
+        _middleLine = [[UIView alloc] initWithFrame:CGRectZero];
+        _middleLine.backgroundColor = color;
+
+        _bottomLine = [[UIView alloc] initWithFrame:CGRectZero];
+        _bottomLine.backgroundColor = color;
+
+        [self addSubview:_topLine];
+        [self addSubview:_middleLine];
+        [self addSubview:_bottomLine];
+    }
+    return self;
+}
+
+- (CGSize)intrinsicContentSize {
+    CGSize sz = [super intrinsicContentSize];
+
+    sz.width = self.frame.size.width;
+
+    [self layoutLines];
+
+    sz.height = CGRectGetMaxY(self.bottomLine.frame) + kTopMargin;
+
+    return sz;
+}
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    [self layoutLines];
+}
+
+- (void)layoutLines {
+    CGFloat width = CGRectGetWidth(self.frame);
+
+    CGFloat topLineWidth = width * 0.60f;
+    CGRect topLineFrame = CGRectMake(kMargin, kTopMargin, topLineWidth, kLineThickness);
+    self.topLine.frame = topLineFrame;
+
+    CGFloat midLineOrigin = kTopMargin + (2 * kLineThickness);
+    CGFloat midLineWidth = width * 0.8f;
+    CGRect midLineFrame = CGRectMake(kMargin, midLineOrigin, midLineWidth, kLineThickness);
+    self.middleLine.frame = midLineFrame;
+
+    CGFloat bottomLineOrigin = midLineOrigin + (2 * kLineThickness);
+    CGFloat bottomLineWidth = width * 0.5f;
+    CGRect bottomLineFrame = CGRectMake(kMargin, bottomLineOrigin, bottomLineWidth, kLineThickness);
+    self.bottomLine.frame = bottomLineFrame;
+}
+
+@end

--- a/OneBusAway/credits.html
+++ b/OneBusAway/credits.html
@@ -425,6 +425,41 @@
 
         THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     </pre></code>
+    
+    <h2 id='shimmer'>Shimmer</h2>
+    <pre><code>
+      BSD License
+
+      For Shimmer software
+
+      Copyright (c) 2014, Facebook, Inc. All rights reserved.
+
+      Redistribution and use in source and binary forms, with or without modification,
+      are permitted provided that the following conditions are met:
+
+       * Redistributions of source code must retain the above copyright notice, this
+         list of conditions and the following disclaimer.
+
+       * Redistributions in binary form must reproduce the above copyright notice,
+         this list of conditions and the following disclaimer in the documentation
+         and/or other materials provided with the distribution.
+
+       * Neither the name Facebook nor the names of its contributors may be used to
+         endorse or promote products derived from this software without specific
+         prior written permission.
+
+      THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+      ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+      WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+      DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+      ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+      (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+      LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+      ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+      (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+      SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+    </code></pre>
+    
     <h2>Icons</h2>
     <p>The following icons are licensed under the terms of Creative Commons Attribution license (CC-BY 3.0):</p>
     <ul>


### PR DESCRIPTION
Just like Facebook or Slack show shimmering 'skeleton' rows while you're awaiting initial content load, OBA now does the same thing! Using FB's FBShimmering project, I've added a new placeholder row and cell. Two placeholder rows are added to the static table controller as the static table's data source at table load, which means that the new feature works across the app without any further changes.

![simulator screen shot - iphone se - 2018-01-04 at 08 45 00](https://user-images.githubusercontent.com/2254/34574225-9c15ea58-f12b-11e7-858b-dbdad29cd9bf.png)
