### PR TITLE
Removes extraneous text from arrival and departure controller title

### DIFF
--- a/OBAKit/Models/unmanaged/OBATripStatusV2.m
+++ b/OBAKit/Models/unmanaged/OBATripStatusV2.m
@@ -49,7 +49,7 @@
     NSInteger mins = sd / 60;
     NSInteger secs = sd % 60;
 
-    return [NSString stringWithFormat:@"%@: %ldm %lds%@", OBALocalized(@"msg_schedule_deviation", @"cell.textLabel.text"), (long)mins, (long)secs, label];
+    return [NSString stringWithFormat:@"%ldm %lds%@", (long)mins, (long)secs, label];
 }
 
 - (NSString*)description {

--- a/OBAKit/en.lproj/Localizable.strings
+++ b/OBAKit/en.lproj/Localizable.strings
@@ -79,9 +79,6 @@
 /* Standard 'Save' button text. */
 "msg_save" = "Save";
 
-/* cell.textLabel.text */
-"msg_schedule_deviation" = "Schedule deviation";
-
 /* code == 404 */
 "mgs_stop_not_found" = "Stop not found";
 

--- a/OBAKit/es.lproj/Localizable.strings
+++ b/OBAKit/es.lproj/Localizable.strings
@@ -73,9 +73,6 @@
 /* Standard 'Save' button text. */
 "msg_save" = "Guardar";
 
-/* cell.textLabel.text */
-"msg_schedule_deviation" = "Desviación";
-
 /* code == 404 */
 "mgs_stop_not_found" = "La Parada no fue encontrada";
 

--- a/OneBusAway/en.lproj/Localizable.strings
+++ b/OneBusAway/en.lproj/Localizable.strings
@@ -687,9 +687,6 @@
 /* No comment provided by engineer. */
 "text_only_routes_colon_param" = "Routes: %@";
 
-/* cell.textLabel.text */
-"msg_schedule_deviation" = "Schedule deviation";
-
 /* title */
 "msg_mayus_vehicle" = "Vehicle";
 

--- a/OneBusAway/es.lproj/Localizable.strings
+++ b/OneBusAway/es.lproj/Localizable.strings
@@ -684,9 +684,6 @@
 /* No comment provided by engineer. */
 "text_only_routes_colon_param" = "Rutas: %@";
 
-/* cell.textLabel.text */
-"msg_schedule_deviation" = "Desviación";
-
 /* title */
 "msg_mayus_vehicle" = "Vehículo";
 

--- a/OneBusAway/zh-Hant.lproj/Localizable.strings
+++ b/OneBusAway/zh-Hant.lproj/Localizable.strings
@@ -661,9 +661,6 @@
 /* No comment provided by engineer. */
 "text_only_routes_colon_param" = "路線: %@";
 
-/* cell.textLabel.text */
-"msg_schedule_deviation" = "預計行程差";
-
 /* title */
 "msg_mayus_vehicle" = "車次";
 


### PR DESCRIPTION
Fixes #1257 - Remove text "schedule deviation" from nav bar title

This text adds little value and makes it harder to see what really matters in the title bar