### PR TITLE
Presents the user with a captive portal browser when appropriate

### DIFF
--- a/OneBusAway/ui/info/OBAAgenciesListViewController.m
+++ b/OneBusAway/ui/info/OBAAgenciesListViewController.m
@@ -54,7 +54,7 @@ typedef NS_ENUM (NSInteger, OBASectionType) {
     }).always(^{
         [SVProgressHUD dismiss];
     }).catch(^(NSError *error) {
-        [AlertPresenter showError:error];
+        [AlertPresenter showError:error presentingController:self];
     });
 }
 

--- a/OneBusAway/ui/map/OBAMapViewController.m
+++ b/OneBusAway/ui/map/OBAMapViewController.m
@@ -306,7 +306,7 @@ static const double kStopsInRegionRefreshDelayOnDrag = 0.1;
 
         self.hideFutureNetworkErrors = YES;
 
-        [AlertPresenter showError:error];
+        [AlertPresenter showError:error presentingController:self];
     }
 }
 

--- a/OneBusAway/ui/stop_details/OBAReportProblemWithRecentTripsViewController.m
+++ b/OneBusAway/ui/stop_details/OBAReportProblemWithRecentTripsViewController.m
@@ -57,7 +57,7 @@
     }).always(^{
         [SVProgressHUD dismiss];
     }).catch(^(NSError *error) {
-        [AlertPresenter showError:error];
+        [AlertPresenter showError:error presentingController:self];
     });
 }
 
@@ -106,7 +106,7 @@
     }).always(^{
         [SVProgressHUD dismiss];
     }).catch(^(NSError *error) {
-        [AlertPresenter showError:error];
+        [AlertPresenter showError:error presentingController:self];
     });
 }
 

--- a/OneBusAway/ui/stop_details/OBAReportProblemWithStopViewController.m
+++ b/OneBusAway/ui/stop_details/OBAReportProblemWithStopViewController.m
@@ -324,7 +324,7 @@ typedef NS_ENUM (NSInteger, OBASectionType) {
         [SVProgressHUD dismiss];
 
         if (error || !responseData) {
-            [AlertPresenter showError:error];
+            [AlertPresenter showError:error presentingController:self];
             return;
         }
 

--- a/OneBusAway/ui/stops/OBAArrivalDepartureOptionsSheet.m
+++ b/OneBusAway/ui/stops/OBAArrivalDepartureOptionsSheet.m
@@ -102,7 +102,7 @@
 
         [AlertPresenter showSuccess:title body:body];
     }).catch(^(NSError *error) {
-        [AlertPresenter showError:error];
+        [AlertPresenter showError:error presentingController:nil];
     }).always(^{
         [SVProgressHUD dismiss];
     });

--- a/OneBusAway/ui/stops/OBAStopViewController.m
+++ b/OneBusAway/ui/stops/OBAStopViewController.m
@@ -208,7 +208,7 @@ static NSUInteger const kDefaultMinutesAfter = 35;
         [self populateTableFromArrivalsAndDeparturesModel:self.arrivalsAndDepartures];
         [self.stopHeaderView populateTableHeaderFromArrivalsAndDeparturesModel:self.arrivalsAndDepartures];
     }).catch(^(NSError *error) {
-        [AlertPresenter showError:error];
+        [AlertPresenter showError:error presentingController:self];
         DDLogError(@"An error occurred while displaying a stop: %@", error);
         return error;
     }).always(^{

--- a/OneBusAway/ui/trip_details/OBAArrivalAndDepartureViewController.m
+++ b/OneBusAway/ui/trip_details/OBAArrivalAndDepartureViewController.m
@@ -318,7 +318,7 @@ static NSTimeInterval const kRefreshTimeInterval = 30;
         self.mapController.tripDetails = tripDetails;
         [self populateTableWithArrivalAndDeparture:self.arrivalAndDeparture tripDetails:self.tripDetails];
     }).catch(^(NSError *error) {
-        [AlertPresenter showError:error];
+        [AlertPresenter showError:error presentingController:self];
     }).always(^{
         [self.reloadLock unlock];
     });


### PR DESCRIPTION
Fixes #1258 - Provide a better experience when users are on a captive portal

This change will display an SFSafariViewController to the user with the URL that is failing to load when the error indicates that the user is on a captive portal wifi network. Typically, this URL should be the address that the user is being redirected to such that they can agree to terms and conditions or watch an ad, or whatever.