### PR TITLE
Prevents app from crashing when bad data gets through to the server

### DIFF
--- a/OBAKit/Helpers/OBAErrorMessages.h
+++ b/OBAKit/Helpers/OBAErrorMessages.h
@@ -14,6 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (NSError*)buildErrorForBadData:(nullable id)badData;
 
+@property(nonatomic,copy,class,readonly) NSError *serverError;
 @property(nonatomic,copy,class,readonly) NSError *stopNotFoundError;
 + (NSError*)connectionError:(NSHTTPURLResponse*)response;
 @property(nonatomic,copy,class,readonly) NSError *cannotRegisterAlarm;

--- a/OBAKit/Helpers/OBAErrorMessages.m
+++ b/OBAKit/Helpers/OBAErrorMessages.m
@@ -31,7 +31,10 @@
 }
 
 + (NSError*)errorFromHttpResponse:(NSHTTPURLResponse*)httpResponse {
-    if (httpResponse.statusCode == 404) {
+    if (httpResponse.statusCode >= 500) {
+        return OBAErrorMessages.serverError;
+    }
+    else if (httpResponse.statusCode == 404) {
         return OBAErrorMessages.stopNotFoundError;
     }
     else if (httpResponse.statusCode >= 300 && httpResponse.statusCode <= 399) {
@@ -39,6 +42,10 @@
     }
 
     return nil;
+}
+
++ (NSError*)serverError {
+    return [NSError errorWithDomain:NSURLErrorDomain code:500 userInfo:@{NSLocalizedDescriptionKey: OBALocalized(@"error_messages.server_error", @"code == 500")}];
 }
 
 + (NSError*)stopNotFoundError {

--- a/OBAKit/Services/PromiseWrapper.swift
+++ b/OBAKit/Services/PromiseWrapper.swift
@@ -20,12 +20,18 @@ import PromiseKit
             var jsonObject = try! JSONSerialization.jsonObject(with: (response.object as! Data), options: []) as AnyObject
             var httpResponse = response.URLResponse
 
+            // pre-munge
+            if let error = OBAErrorMessages.error(fromHttpResponse: httpResponse) {
+                throw error
+            }
+
             if checkCode && jsonObject.responds(to: #selector(self.value(forKey:))) {
                 let statusCode = (jsonObject.value(forKey: "code") as! NSNumber).intValue
                 httpResponse = HTTPURLResponse.init(url: httpResponse.url!, statusCode: statusCode, httpVersion: nil, headerFields: httpResponse.allHeaderFields as? [String : String])!
                 jsonObject = jsonObject.value(forKey: "data") as AnyObject
             }
 
+            // post-munge
             if let error = OBAErrorMessages.error(fromHttpResponse: httpResponse) {
                 throw error
             }

--- a/OBAKit/en.lproj/Localizable.strings
+++ b/OBAKit/en.lproj/Localizable.strings
@@ -79,6 +79,10 @@
 /* Standard 'Save' button text. */
 "msg_save" = "Save";
 
+/* code == 500 */
+"error_messages.server_error" = "The server was unable to interpret your request, or it is simply having some problems.";
+
+
 /* code == 404 */
 "mgs_stop_not_found" = "Stop not found";
 


### PR DESCRIPTION
Fixes #1256 - Crashing bug when searching

Basically, we weren't properly handling 500 server errors and were handing back null objects to the client.