### PR TITLE
Moves MapRegionManager into OBAApplication

### DIFF
--- a/OBAKit/Application/OBAApplication.h
+++ b/OBAKit/Application/OBAApplication.h
@@ -27,6 +27,7 @@
 @class RegionalAlertsManager;
 @class PromisedModelService;
 @class OBAMapDataLoader;
+@class OBAMapRegionManager;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -44,6 +45,7 @@ extern NSString *const OBARegionServerInvalidNotification;
 @property (nonatomic, strong, readonly) OBARegionHelper *regionHelper;
 @property (nonatomic, strong, readonly) OBAConsoleLogger *consoleLogger;
 @property (nonatomic, strong, readonly) OBAMapDataLoader *mapDataLoader;
+@property (nonatomic, strong, readonly) OBAMapRegionManager *mapRegionManager;
 @property (nonatomic, strong, readonly) NSUserDefaults *userDefaults;
 
 @property (nonatomic, copy, readonly) NSString *googleAnalyticsID;

--- a/OBAKit/Application/OBAApplication.m
+++ b/OBAKit/Application/OBAApplication.m
@@ -13,6 +13,7 @@
 #import <OBAKit/OBAApplicationConfiguration.h>
 #import <OBAKit/OBACommon.h>
 #import <OBAKit/OBAMapDataLoader.h>
+#import <OBAKit/OBAMapRegionManager.h>
 #import <OBAKit/OBAKit-Swift.h>
 
 static NSString * const kAppGroup = @"group.org.onebusaway.iphone";
@@ -31,6 +32,7 @@ NSString * const OBAHasMigratedDefaultsToAppGroupDefaultsKey = @"OBAHasMigratedD
 @property (nonatomic, strong, readwrite) RegionalAlertsManager *regionalAlertsManager;
 @property (nonatomic, strong, readwrite) OBALogging *loggingManager;
 @property (nonatomic, strong, readwrite) OBAMapDataLoader *mapDataLoader;
+@property (nonatomic, strong, readwrite) OBAMapRegionManager *mapRegionManager;
 @property (nonatomic, strong, readwrite) NSUserDefaults *userDefaults;
 @end
 
@@ -86,6 +88,7 @@ NSString * const OBAHasMigratedDefaultsToAppGroupDefaultsKey = @"OBAHasMigratedD
     self.regionHelper = [[OBARegionHelper alloc] initWithLocationManager:self.locationManager modelService:self.modelService];
 
     self.mapDataLoader = [[OBAMapDataLoader alloc] initWithModelService:self.modelService];
+    self.mapRegionManager = [[OBAMapRegionManager alloc] init];
 
     if (!self.configuration.extensionMode) {
         self.regionalAlertsManager = [[RegionalAlertsManager alloc] init];

--- a/OBAKit/Location/OBAMapRegionManager.h
+++ b/OBAKit/Location/OBAMapRegionManager.h
@@ -12,10 +12,16 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class OBAMapRegionManager;
+@protocol OBAMapRegionDelegate<NSObject>
+- (void)mapRegionManager:(OBAMapRegionManager*)manager setRegion:(MKCoordinateRegion)region animated:(BOOL)animated;
+@end
+
 @interface OBAMapRegionManager : NSObject
 @property (nonatomic) BOOL lastRegionChangeWasProgrammatic;
 
-- (instancetype)initWithMapView:(MKMapView*)mapView;
+- (void)addDelegate:(id<OBAMapRegionDelegate>)delegate NS_SWIFT_NAME(add(delegate:));
+- (void)removeDelegate:(id<OBAMapRegionDelegate>)delegate NS_SWIFT_NAME(remove(delegate:));
 
 - (void)setRegion:(MKCoordinateRegion)region;
 - (void)setRegion:(MKCoordinateRegion)region changeWasProgrammatic:(BOOL)changeWasProgrammatic;

--- a/OBAKit/Services/OBAMapDataLoader.h
+++ b/OBAKit/Services/OBAMapDataLoader.h
@@ -26,10 +26,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class OBAMapDataLoader;
 @protocol OBAMapDataLoaderDelegate <NSObject>
+@optional
 - (void)mapDataLoader:(OBAMapDataLoader*)mapDataLoader didUpdateResult:(OBASearchResult*)searchResult;
 - (void)mapDataLoader:(OBAMapDataLoader*)mapDataLoader startedUpdatingWithNavigationTarget:(OBANavigationTarget*)target;
 - (void)mapDataLoaderFinishedUpdating:(OBAMapDataLoader*)mapDataLoader;
 - (void)mapDataLoader:(OBAMapDataLoader*)mapDataLoader didReceiveError:(NSError*)error;
+- (void)mapDataLoader:(OBAMapDataLoader*)mapDataLoader didUpdateMapCenterLocation:(CLLocation*)location;
 @end
 
 @interface OBAMapDataLoader : NSObject
@@ -43,9 +45,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property(weak, nonatomic,readonly) id searchParameter;
 @property(strong,readonly,nullable) OBASearchResult * result;
 
-@property(nonatomic,weak,readonly) CLLocation * searchLocation;
-@property(nonatomic,strong) CLCircularRegion *searchRegion;
-@property(nonatomic,strong) NSError * error;
+@property(nonatomic,copy,readonly) CLLocation * searchLocation;
+@property(nonatomic,copy) CLCircularRegion *searchRegion;
+@property(nonatomic,copy) NSError * error;
 
 - (instancetype)initWithModelService:(PromisedModelService*)modelService;
 

--- a/OBAKit/Services/OBAMapDataLoader.m
+++ b/OBAKit/Services/OBAMapDataLoader.m
@@ -52,25 +52,33 @@
 
 - (void)callDelegatesDidUpdateResult:(OBASearchResult*)searchResult {
     for (id<OBAMapDataLoaderDelegate> delegate in self.delegates) {
-        [delegate mapDataLoader:self didUpdateResult:searchResult];
+        if ([delegate respondsToSelector:@selector(mapDataLoader:didUpdateResult:)]) {
+            [delegate mapDataLoader:self didUpdateResult:searchResult];
+        }
     }
 }
 
 - (void)callDelegatesStartedUpdatingWithNavigationTarget:(OBANavigationTarget*)target {
     for (id<OBAMapDataLoaderDelegate> delegate in self.delegates) {
-        [delegate mapDataLoader:self startedUpdatingWithNavigationTarget:target];
+        if ([delegate respondsToSelector:@selector(mapDataLoader:startedUpdatingWithNavigationTarget:)]) {
+            [delegate mapDataLoader:self startedUpdatingWithNavigationTarget:target];
+        }
     }
 }
 
 - (void)callDelegatesFinishedUpdating {
     for (id<OBAMapDataLoaderDelegate> delegate in self.delegates) {
-        [delegate mapDataLoaderFinishedUpdating:self];
+        if ([delegate respondsToSelector:@selector(mapDataLoaderFinishedUpdating:)]) {
+            [delegate mapDataLoaderFinishedUpdating:self];
+        }
     }
 }
 
 - (void)callDelegatesDidReceiveError:(NSError*)error {
     for (id<OBAMapDataLoaderDelegate> delegate in self.delegates) {
-        [delegate mapDataLoader:self didReceiveError:error];
+        if ([delegate respondsToSelector:@selector(mapDataLoader:didReceiveError:)]) {
+            [delegate mapDataLoader:self didReceiveError:error];
+        }
     }
 }
 

--- a/OneBusAway/ui/map/OBAMapViewController.h
+++ b/OneBusAway/ui/map/OBAMapViewController.h
@@ -28,7 +28,7 @@ INIT_CODER_UNAVAILABLE;
 @property(nonatomic,strong) PromisedModelService *modelService;
 @property(nonatomic,strong) OBALocationManager *locationManager;
 
-- (instancetype)initWithMapDataLoader:(OBAMapDataLoader*)mapDataLoader NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithMapDataLoader:(OBAMapDataLoader*)mapDataLoader mapRegionManager:(OBAMapRegionManager*)mapRegionManager NS_DESIGNATED_INITIALIZER;
 
 - (void)recenterMap;
 @end

--- a/OneBusAway/ui/map/OBAMapViewController.m
+++ b/OneBusAway/ui/map/OBAMapViewController.m
@@ -35,7 +35,7 @@
 static const NSUInteger kShowNClosestStops = 4;
 static const double kStopsInRegionRefreshDelayOnDrag = 0.1;
 
-@interface OBAMapViewController ()<MKMapViewDelegate, UISearchBarDelegate, UISearchControllerDelegate, MapSearchDelegate, OBANavigator>
+@interface OBAMapViewController ()<MKMapViewDelegate, UISearchBarDelegate, UISearchControllerDelegate, MapSearchDelegate, OBANavigator, OBAMapRegionDelegate>
 
 // Map UI
 @property(nonatomic,strong) MKMapView *mapView;
@@ -66,12 +66,16 @@ static const double kStopsInRegionRefreshDelayOnDrag = 0.1;
 
 @implementation OBAMapViewController
 
-- (instancetype)initWithMapDataLoader:(OBAMapDataLoader*)mapDataLoader {
+- (instancetype)initWithMapDataLoader:(OBAMapDataLoader*)mapDataLoader mapRegionManager:(OBAMapRegionManager*)mapRegionManager {
     self = [super initWithNibName:nil bundle:nil];
 
     if (self) {
         _mapDataLoader = mapDataLoader;
         [_mapDataLoader addDelegate:self];
+
+        _mapRegionManager = mapRegionManager;
+        [_mapRegionManager addDelegate:self];
+
         self.title = NSLocalizedString(@"msg_map", @"Map tab title");
         self.tabBarItem.image = [UIImage imageNamed:@"Map"];
         self.tabBarItem.selectedImage = [UIImage imageNamed:@"Map_Selected"];
@@ -108,9 +112,6 @@ static const double kStopsInRegionRefreshDelayOnDrag = 0.1;
 
     self.mostRecentRegion = MKCoordinateRegionMake(CLLocationCoordinate2DMake(0, 0), MKCoordinateSpanMake(0, 0));
 
-    self.mapRegionManager = [[OBAMapRegionManager alloc] initWithMapView:self.mapView];
-    self.mapRegionManager.lastRegionChangeWasProgrammatic = YES;
-    
     self.mapView.rotateEnabled = NO;
     if ([CLLocationManager authorizationStatus] == kCLAuthorizationStatusAuthorizedWhenInUse) {
         self.mapView.showsUserLocation = YES;
@@ -307,6 +308,12 @@ static const double kStopsInRegionRefreshDelayOnDrag = 0.1;
 
 - (void)mapDataLoaderFinishedUpdating:(OBAMapDataLoader*)searchController {
     [self.mapActivityIndicatorView setAnimating:NO];
+}
+
+#pragma mark - OBAMapRegionDelegate
+
+- (void)mapRegionManager:(OBAMapRegionManager*)manager setRegion:(MKCoordinateRegion)region animated:(BOOL)animated {
+    [self.mapView setRegion:region animated:animated];
 }
 
 #pragma mark - OBALocationManager Notifications

--- a/OneBusAway/ui/stops/NearbyStopsViewController.swift
+++ b/OneBusAway/ui/stops/NearbyStopsViewController.swift
@@ -17,7 +17,9 @@ typealias NearbyStopsCanceled = () -> Void
 class NearbyStopsViewController: OBAStaticTableViewController {
     var stop: OBAStopV2?
     var searchResult: OBASearchResult?
+
     var mapDataLoader: OBAMapDataLoader?
+    var mapRegionManager: OBAMapRegionManager?
 
     @objc var presentedModally = false
     @objc var pushesResultsOntoStack = false
@@ -34,11 +36,14 @@ class NearbyStopsViewController: OBAStaticTableViewController {
 
     public var currentCoordinate: CLLocationCoordinate2D?
 
-    @objc init(mapDataLoader: OBAMapDataLoader) {
+    @objc init(mapDataLoader: OBAMapDataLoader, mapRegionManager: OBAMapRegionManager) {
         super.init(nibName: nil, bundle: nil)
 
         self.mapDataLoader = mapDataLoader
         self.mapDataLoader?.add(self)
+
+        self.mapRegionManager = mapRegionManager
+        self.mapRegionManager?.add(delegate: self)
     }
 
     @objc init(withStop stop: OBAStopV2) {
@@ -76,10 +81,6 @@ class NearbyStopsViewController: OBAStaticTableViewController {
 
 // MARK: - Map Data Loader
 extension NearbyStopsViewController: OBAMapDataLoaderDelegate {
-    func mapDataLoaderFinishedUpdating(_ mapDataLoader: OBAMapDataLoader) {
-        //
-    }
-
     func mapDataLoader(_ mapDataLoader: OBAMapDataLoader, didReceiveError error: Error) {
         //
     }
@@ -89,7 +90,14 @@ extension NearbyStopsViewController: OBAMapDataLoaderDelegate {
         self.loadData()
     }
 
-    func mapDataLoader(_ mapDataLoader: OBAMapDataLoader, startedUpdatingWith target: OBANavigationTarget) {
+    func mapDataLoader(_ mapDataLoader: OBAMapDataLoader, didUpdate mapCenterLocation: CLLocation) {
+
+    }
+}
+
+// MARK: - Map Region Manager
+extension NearbyStopsViewController: OBAMapRegionDelegate {
+    func mapRegionManager(_ manager: OBAMapRegionManager, setRegion region: MKCoordinateRegion, animated: Bool) {
         //
     }
 }

--- a/OneBusAway/ui/themes/OBAClassicApplicationUI.m
+++ b/OneBusAway/ui/themes/OBAClassicApplicationUI.m
@@ -54,10 +54,10 @@ static NSString *kOBASelectedTabIndexDefaultsKey = @"OBASelectedTabIndexDefaults
         UIViewController *firstTab = nil;
 
         if (showDrawer) {
-            _mapViewController = [[OBAMapViewController alloc] initWithMapDataLoader:application.mapDataLoader];
+            _mapViewController = [[OBAMapViewController alloc] initWithMapDataLoader:application.mapDataLoader mapRegionManager:application.mapRegionManager];
             _mapNavigationController = [[UINavigationController alloc] initWithRootViewController:_mapViewController];
 
-            _nearbyStopsController = [[NearbyStopsViewController alloc] initWithMapDataLoader:application.mapDataLoader];
+            _nearbyStopsController = [[NearbyStopsViewController alloc] initWithMapDataLoader:application.mapDataLoader mapRegionManager:application.mapRegionManager];
             _nearbyStopsNavigation = [[UINavigationController alloc] initWithRootViewController:_nearbyStopsController];
 
             _pulleyController = [[PulleyViewController alloc] initWithContentViewController:_mapNavigationController drawerViewController:_nearbyStopsNavigation];
@@ -68,7 +68,7 @@ static NSString *kOBASelectedTabIndexDefaultsKey = @"OBASelectedTabIndexDefaults
             firstTab = _pulleyController;
         }
         else {
-            _mapViewController = [[OBAMapViewController alloc] initWithMapDataLoader:application.mapDataLoader];
+            _mapViewController = [[OBAMapViewController alloc] initWithMapDataLoader:application.mapDataLoader mapRegionManager:application.mapRegionManager];
             _mapNavigationController = [[UINavigationController alloc] initWithRootViewController:_mapViewController];
 
             firstTab = _mapNavigationController;


### PR DESCRIPTION
This way, we can inject it into both the Map View Controller and the Nearby Stops Controller, which will allow us to drive the sorting of the Nearby Stops controller by where the map is centered.