### PR TITLE
Fixes #1264 - Stop search broken in Beta 18.1.0

### DIFF
--- a/OBAKit/Helpers/OBACommon.h
+++ b/OBAKit/Helpers/OBACommon.h
@@ -18,18 +18,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef NS_ENUM(NSInteger, OBASearchType) {
-    OBASearchTypeNone=0,
-    OBASearchTypePending,
-    OBASearchTypeRegion,
-    OBASearchTypeRoute,
-    OBASearchTypeStops,
-    OBASearchTypeAddress,
-    OBASearchTypePlacemark,
-    OBASearchTypeStopId,
-    OBASearchTypeRegionalAlert,
-};
-
 typedef NS_ENUM(NSInteger, OBANavigationTargetType) {
     OBANavigationTargetTypeUndefined=0,
     OBANavigationTargetTypeMap,
@@ -45,8 +33,6 @@ typedef NS_ENUM(NSUInteger, OBAErrorCode) {
     OBAErrorCodeMissingMethodParameters,
     OBAErrorCodeBadData,
 };
-
-NSString * _Nullable NSStringFromOBASearchType(OBASearchType searchType);
 
 extern NSString * const OBAErrorDomain;
 

--- a/OBAKit/Helpers/OBACommon.h
+++ b/OBAKit/Helpers/OBACommon.h
@@ -18,15 +18,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef NS_ENUM(NSInteger, OBANavigationTargetType) {
-    OBANavigationTargetTypeUndefined=0,
-    OBANavigationTargetTypeMap,
-    OBANavigationTargetTypeSearchResults,
-    OBANavigationTargetTypeRecentStops,
-    OBANavigationTargetTypeBookmarks,
-    OBANavigationTargetTypeContactUs,
-};
-
 typedef NS_ENUM(NSUInteger, OBAErrorCode) {
     OBAErrorCodeLocationAuthorizationFailed = 1002,
     OBAErrorCodePushNotificationAuthorizationDenied,

--- a/OBAKit/Helpers/OBACommon.m
+++ b/OBAKit/Helpers/OBACommon.m
@@ -35,35 +35,6 @@ NSString * const OBADebugModeUserDefaultsKey = @"OBADebugModeUserDefaultsKey";
 
 NSString * const OBADeepLinkServerAddress = @"https://www.onebusaway.co";
 
-NSString * NSStringFromOBASearchType(OBASearchType searchType) {
-    switch (searchType) {
-        case OBASearchTypePending: {
-            return OBALocalized(@"search_type.pending", @"OBASearchTypePending. Rendered as 'Pending' in English.");
-        }
-        case OBASearchTypeRegion: {
-            return OBALocalized(@"search_type.region", @"OBASearchTypeRegion. Rendered as 'Region' in English.");
-        }
-        case OBASearchTypeRoute: {
-            return OBALocalized(@"search_type.route", @"OBASearchTypeRoute. Rendered as 'Route' in English.");
-        }
-        case OBASearchTypeStops: {
-            return OBALocalized(@"search_type.stops", @"OBASearchTypeStops. Rendered as 'Stops' in English.");
-        }
-        case OBASearchTypeAddress: {
-            return OBALocalized(@"search_type.address", @"OBASearchTypeAddress. Rendered as 'Address' in English.");
-        }
-        case OBASearchTypePlacemark: {
-            return OBALocalized(@"search_type.placemark", @"OBASearchTypePlacemark. Rendered as 'Placemark' in English.");
-        }
-        case OBASearchTypeStopId: {
-            return OBALocalized(@"search_type.stop_id", @"OBASearchTypeStopId. Rendered as 'Stop ID' in English.");
-        }
-        default: {
-            return nil;
-        }
-    }
-}
-
 NSString * OBAStringFromBool(BOOL yn) {
     return yn ? @"YES" : @"NO";
 }

--- a/OBAKit/Models/navigation/OBAAlarmNavigationTarget.h
+++ b/OBAKit/Models/navigation/OBAAlarmNavigationTarget.h
@@ -1,0 +1,21 @@
+//
+//  OBAAlarmNavigationTarget.h
+//  OBAKit
+//
+//  Created by Aaron Brethorst on 2/21/18.
+//  Copyright © 2018 OneBusAway. All rights reserved.
+//
+
+#import <OBAKit/OBAKit.h>
+
+@class OBAAlarm;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface OBAAlarmNavigationTarget : OBANavigationTarget
+@property(nonatomic,copy,nullable) OBAAlarm *alarm;
+
++ (instancetype)navigationTargetWithAlarm:(OBAAlarm*)alarm;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/OBAKit/Models/navigation/OBAAlarmNavigationTarget.m
+++ b/OBAKit/Models/navigation/OBAAlarmNavigationTarget.m
@@ -1,0 +1,44 @@
+//
+//  OBAAlarmNavigationTarget.m
+//  OBAKit
+//
+//  Created by Aaron Brethorst on 2/21/18.
+//  Copyright © 2018 OneBusAway. All rights reserved.
+//
+
+#import <OBAKit/OBAAlarmNavigationTarget.h>
+#import <OBAKit/OBAAlarm.h>
+
+@implementation OBAAlarmNavigationTarget
+
++ (instancetype)navigationTargetWithAlarm:(OBAAlarm*)alarm {
+    OBAAlarmNavigationTarget *target = [OBAAlarmNavigationTarget navigationTarget:OBANavigationTargetTypeRecentStops];
+    target.alarm = alarm;
+    return target;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder {
+    self = [super initWithCoder:aDecoder];
+
+    if (self) {
+        _alarm = [aDecoder decodeObjectForKey:NSStringFromSelector(@selector(alarm))];
+    }
+
+    return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder {
+    [super encodeWithCoder:aCoder];
+
+    [aCoder encodeObject:_alarm forKey:NSStringFromSelector(@selector(alarm))];
+}
+
+- (id)copyWithZone:(NSZone *)zone {
+    OBAAlarmNavigationTarget *target = [super copyWithZone:zone];
+    target->_alarm = [_alarm copyWithZone:zone];
+
+    return target;
+}
+
+
+@end

--- a/OBAKit/Models/navigation/OBADeepLinkNavigationTarget.h
+++ b/OBAKit/Models/navigation/OBADeepLinkNavigationTarget.h
@@ -1,0 +1,21 @@
+//
+//  OBADeepLinkNavigationTarget.h
+//  OBAKit
+//
+//  Created by Aaron Brethorst on 2/21/18.
+//  Copyright © 2018 OneBusAway. All rights reserved.
+//
+
+#import <OBAKit/OBAKit.h>
+
+@class OBATripDeepLink;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface OBADeepLinkNavigationTarget : OBANavigationTarget
+@property(nonatomic,copy,nullable) OBATripDeepLink *tripDeepLink;
+
++ (instancetype)targetWithTripDeepLink:(OBATripDeepLink*)tripDeepLink;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/OBAKit/Models/navigation/OBADeepLinkNavigationTarget.m
+++ b/OBAKit/Models/navigation/OBADeepLinkNavigationTarget.m
@@ -1,0 +1,44 @@
+//
+//  OBADeepLinkNavigationTarget.m
+//  OBAKit
+//
+//  Created by Aaron Brethorst on 2/21/18.
+//  Copyright © 2018 OneBusAway. All rights reserved.
+//
+
+#import <OBAKit/OBADeepLinkNavigationTarget.h>
+#import <OBAKit/OBATripDeepLink.h>
+
+@implementation OBADeepLinkNavigationTarget
+
++ (instancetype)targetWithTripDeepLink:(OBATripDeepLink*)tripDeepLink {
+    OBADeepLinkNavigationTarget *target = [self navigationTarget:OBANavigationTargetTypeRecentStops];
+    target.tripDeepLink = tripDeepLink;
+
+    return target;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder {
+    self = [super initWithCoder:aDecoder];
+
+    if (self) {
+        _tripDeepLink = [aDecoder decodeObjectForKey:NSStringFromSelector(@selector(tripDeepLink))];
+    }
+
+    return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder {
+    [super encodeWithCoder:aCoder];
+
+    [aCoder encodeObject:_tripDeepLink forKey:NSStringFromSelector(@selector(tripDeepLink))];
+}
+
+- (id)copyWithZone:(NSZone *)zone {
+    OBADeepLinkNavigationTarget *target = [super copyWithZone:zone];
+    target->_tripDeepLink = [_tripDeepLink copyWithZone:zone];
+
+    return target;
+}
+
+@end

--- a/OBAKit/Models/navigation/OBANavigationTarget.h
+++ b/OBAKit/Models/navigation/OBANavigationTarget.h
@@ -46,14 +46,15 @@ extern NSString * const OBAUserSearchQueryKey;
 @end
 
 @interface OBANavigationTarget (Builders)
-+ (OBANavigationTarget*)navigationTargetForSearchNone;
-+ (OBANavigationTarget*)navigationTargetForSearchLocationRegion:(MKCoordinateRegion)region;
-+ (OBANavigationTarget*)navigationTargetForSearchRoute:(NSString*)routeQuery;
-+ (OBANavigationTarget*)navigationTargetForRoute:(OBARouteV2*)route;
-+ (OBANavigationTarget*)navigationTargetForSearchAddress:(NSString*)addressQuery;
-+ (OBANavigationTarget*)navigationTargetForSearchPlacemark:(OBAPlacemark*)placemark;
-+ (OBANavigationTarget*)navigationTargetForStopID:(NSString*)stopID;
-+ (OBANavigationTarget*)navigationTargetForRegionalAlert:(OBARegionalAlert*)regionalAlert;
++ (instancetype)navigationTargetForSearchNone;
++ (instancetype)navigationTargetForSearchLocationRegion:(MKCoordinateRegion)region;
++ (instancetype)navigationTargetForSearchRoute:(NSString*)routeQuery;
++ (instancetype)navigationTargetForRoute:(OBARouteV2*)route;
++ (instancetype)navigationTargetForSearchAddress:(NSString*)addressQuery;
++ (instancetype)navigationTargetForSearchPlacemark:(OBAPlacemark*)placemark;
++ (instancetype)navigationTargetForStopID:(NSString*)stopID;
++ (instancetype)navigationTargetForStopIDSearch:(NSString*)stopID;
++ (instancetype)navigationTargetForRegionalAlert:(OBARegionalAlert*)regionalAlert;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/OBAKit/Models/navigation/OBANavigationTarget.h
+++ b/OBAKit/Models/navigation/OBANavigationTarget.h
@@ -31,10 +31,10 @@ extern NSString * const OBANavigationTargetSearchKey;
 extern NSString * const kOBASearchControllerSearchLocationParameter;
 extern NSString * const OBAUserSearchQueryKey;
 
-@interface OBANavigationTarget : NSObject <NSCoding>
+@interface OBANavigationTarget : NSObject <NSCoding, NSCopying>
 @property(nonatomic,assign,readonly) OBANavigationTargetType target;
 @property(nonatomic,strong,readonly) NSDictionary * parameters;
-@property(nonatomic,strong) id object;
+//@property(nonatomic,strong) id object;
 @property(nonatomic,assign,readonly) OBASearchType searchType;
 @property(nonatomic,strong,readonly,nullable) id searchArgument;
 @property(nonatomic,copy,readonly,nullable) NSString *userFacingSearchQuery;

--- a/OBAKit/Models/navigation/OBANavigationTarget.h
+++ b/OBAKit/Models/navigation/OBANavigationTarget.h
@@ -18,6 +18,7 @@
 @import MapKit;
 
 #import <OBAKit/OBACommon.h>
+#import <OBAKit/OBASearchType.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -34,7 +35,6 @@ extern NSString * const OBAUserSearchQueryKey;
 @interface OBANavigationTarget : NSObject <NSCoding, NSCopying>
 @property(nonatomic,assign,readonly) OBANavigationTargetType target;
 @property(nonatomic,strong,readonly) NSDictionary * parameters;
-//@property(nonatomic,strong) id object;
 @property(nonatomic,assign,readonly) OBASearchType searchType;
 @property(nonatomic,strong,readonly,nullable) id searchArgument;
 @property(nonatomic,copy,readonly,nullable) NSString *userFacingSearchQuery;

--- a/OBAKit/Models/navigation/OBANavigationTarget.m
+++ b/OBAKit/Models/navigation/OBANavigationTarget.m
@@ -107,20 +107,20 @@ NSString * const OBAUserSearchQueryKey = @"OBAUserSearchQueryKey";
 
 @implementation OBANavigationTarget (Builders)
 
-+ (OBANavigationTarget*)navigationTargetForSearchNone {
++ (instancetype)navigationTargetForSearchNone {
     return [self navigationTargetForSearchType:OBASearchTypeNone];
 }
 
-+ (OBANavigationTarget*)navigationTargetForSearchLocationRegion:(MKCoordinateRegion)region {
++ (instancetype)navigationTargetForSearchLocationRegion:(MKCoordinateRegion)region {
     NSData * data = [NSData dataWithBytes:&region length:sizeof(MKCoordinateRegion)];
     return [self navigationTargetForSearchType:OBASearchTypeRegion argument:data];
 }
 
-+ (OBANavigationTarget*)navigationTargetForSearchRoute:(NSString*)routeQuery {
++ (instancetype)navigationTargetForSearchRoute:(NSString*)routeQuery {
     return [self navigationTargetForSearchType:OBASearchTypeRoute argument:routeQuery];
 }
 
-+ (OBANavigationTarget*)navigationTargetForRoute:(OBARouteV2*)route {
++ (instancetype)navigationTargetForRoute:(OBARouteV2*)route {
     NSString *str = OBALocalized(@"navigation_target.search_query.route_format", @"e.g. Search for Route: <Route Number>");
     NSString *searchQuery = [NSString stringWithFormat:str, route.safeShortName];
 
@@ -129,34 +129,38 @@ NSString * const OBAUserSearchQueryKey = @"OBAUserSearchQueryKey";
                                extraParameters:@{OBAUserSearchQueryKey: searchQuery}];
 }
 
-+ (OBANavigationTarget*)navigationTargetForSearchAddress:(NSString*)addressQuery {
++ (instancetype)navigationTargetForSearchAddress:(NSString*)addressQuery {
     return [self navigationTargetForSearchType:OBASearchTypeAddress argument:addressQuery];
 }
 
-+ (OBANavigationTarget*)navigationTargetForSearchPlacemark:(OBAPlacemark*)placemark {
++ (instancetype)navigationTargetForSearchPlacemark:(OBAPlacemark*)placemark {
     return [self navigationTargetForSearchType:OBASearchTypePlacemark argument:placemark];
 }
 
-+ (OBANavigationTarget*)navigationTargetForStopID:(NSString*)stopID {
++ (instancetype)navigationTargetForStopID:(NSString*)stopID {
     return [self navigationTargetForSearchType:OBASearchTypeStopId argument:stopID];
 }
 
-+ (OBANavigationTarget*)navigationTargetForRegionalAlert:(OBARegionalAlert*)regionalAlert {
++ (instancetype)navigationTargetForStopIDSearch:(NSString*)stopID {
+    return [self navigationTargetForSearchType:OBASearchTypeStopIdSearch argument:stopID];
+}
+
++ (instancetype)navigationTargetForRegionalAlert:(OBARegionalAlert*)regionalAlert {
     OBANavigationTarget *target = [self navigationTargetForSearchType:OBASearchTypeRegionalAlert argument:regionalAlert];
     target.target = OBANavigationTargetTypeContactUs;
 
     return target;
 }
 
-+ (OBANavigationTarget*)navigationTargetForSearchType:(OBASearchType)searchType {
++ (instancetype)navigationTargetForSearchType:(OBASearchType)searchType {
     return [self navigationTargetForSearchType:searchType argument:nil];
 }
 
-+ (OBANavigationTarget*)navigationTargetForSearchType:(OBASearchType)searchType argument:(nullable id)argument {
++ (instancetype)navigationTargetForSearchType:(OBASearchType)searchType argument:(nullable id)argument {
     return [self navigationTargetForSearchType:searchType argument:argument extraParameters:nil];
 }
 
-+ (OBANavigationTarget*)navigationTargetForSearchType:(OBASearchType)searchType argument:(nullable id)argument extraParameters:(nullable NSDictionary*)dictionary {
++ (instancetype)navigationTargetForSearchType:(OBASearchType)searchType argument:(nullable id)argument extraParameters:(nullable NSDictionary*)dictionary {
     dictionary = dictionary ?: @{};
 
     NSMutableDictionary * params = [NSMutableDictionary dictionaryWithDictionary:dictionary];
@@ -166,7 +170,7 @@ NSString * const OBAUserSearchQueryKey = @"OBAUserSearchQueryKey";
         params[OBANavigationTargetSearchKey] = argument;
     }
 
-    OBANavigationTarget *target = [OBANavigationTarget navigationTarget:OBANavigationTargetTypeSearchResults parameters:params];
+    OBANavigationTarget *target = [self navigationTarget:OBANavigationTargetTypeSearchResults parameters:params];
 
     return target;
 }

--- a/OBAKit/Models/navigation/OBANavigationTarget.m
+++ b/OBAKit/Models/navigation/OBANavigationTarget.m
@@ -55,7 +55,6 @@ NSString * const OBAUserSearchQueryKey = @"OBAUserSearchQueryKey";
     if (self = [super init]) {
         _target = [coder oba_decodeInteger:@selector(target)];
         _parameters = [NSMutableDictionary dictionaryWithDictionary:[coder oba_decodeObject:@selector(parameters)]];
-        _object = [coder oba_decodeObject:@selector(object)];
     }
     return self;
 }
@@ -63,9 +62,16 @@ NSString * const OBAUserSearchQueryKey = @"OBAUserSearchQueryKey";
 - (void)encodeWithCoder:(NSCoder *)coder {
     [coder oba_encodeInteger:_target forSelector:@selector(target)];
     [coder oba_encodeObject:_parameters forSelector:@selector(parameters)];
-    if ([_object conformsToProtocol:@protocol(NSCoding)]) {
-        [coder oba_encodeObject:_object forSelector:@selector(object)];
-    }
+}
+
+#pragma mark - NSCopying
+
+- (id)copyWithZone:(NSZone *)zone {
+    OBANavigationTarget *target = [[self.class allocWithZone:zone] init];
+    target->_target = _target;
+    target->_parameters = [_parameters copyWithZone:zone];
+
+    return target;
 }
 
 #pragma mark - Public

--- a/OBAKit/Models/navigation/OBASearchType.h
+++ b/OBAKit/Models/navigation/OBASearchType.h
@@ -1,0 +1,24 @@
+//
+//  OBASearchType.h
+//  OBAKit
+//
+//  Created by Aaron Brethorst on 2/21/18.
+//  Copyright © 2018 OneBusAway. All rights reserved.
+//
+
+@import Foundation;
+
+typedef NS_ENUM(NSUInteger, OBASearchType) {
+    OBASearchTypeNone=0,
+    OBASearchTypePending,
+    OBASearchTypeRegion,
+    OBASearchTypeRoute,
+    OBASearchTypeStops,
+    OBASearchTypeAddress,
+    OBASearchTypePlacemark,
+    OBASearchTypeStopId,
+    OBASearchTypeRegionalAlert,
+};
+
+NSString * _Nullable NSStringFromOBASearchType(OBASearchType searchType);
+

--- a/OBAKit/Models/navigation/OBASearchType.h
+++ b/OBAKit/Models/navigation/OBASearchType.h
@@ -8,6 +8,15 @@
 
 @import Foundation;
 
+typedef NS_ENUM(NSInteger, OBANavigationTargetType) {
+    OBANavigationTargetTypeUndefined=0,
+    OBANavigationTargetTypeMap,
+    OBANavigationTargetTypeSearchResults,
+    OBANavigationTargetTypeRecentStops,
+    OBANavigationTargetTypeBookmarks,
+    OBANavigationTargetTypeContactUs,
+};
+
 typedef NS_ENUM(NSUInteger, OBASearchType) {
     OBASearchTypeNone=0,
     OBASearchTypePending,
@@ -18,6 +27,7 @@ typedef NS_ENUM(NSUInteger, OBASearchType) {
     OBASearchTypePlacemark,
     OBASearchTypeStopId,
     OBASearchTypeRegionalAlert,
+    OBASearchTypeStopIdSearch,
 };
 
 NSString * _Nullable NSStringFromOBASearchType(OBASearchType searchType);

--- a/OBAKit/Models/navigation/OBASearchType.m
+++ b/OBAKit/Models/navigation/OBASearchType.m
@@ -1,0 +1,39 @@
+//
+//  OBASearchType.m
+//  OBAKit
+//
+//  Created by Aaron Brethorst on 2/21/18.
+//  Copyright © 2018 OneBusAway. All rights reserved.
+//
+
+#import <OBAKit/OBASearchType.h>
+#import <OBAKit/OBAMacros.h>
+
+NSString * NSStringFromOBASearchType(OBASearchType searchType) {
+    switch (searchType) {
+        case OBASearchTypePending: {
+            return OBALocalized(@"search_type.pending", @"OBASearchTypePending. Rendered as 'Pending' in English.");
+        }
+        case OBASearchTypeRegion: {
+            return OBALocalized(@"search_type.region", @"OBASearchTypeRegion. Rendered as 'Region' in English.");
+        }
+        case OBASearchTypeRoute: {
+            return OBALocalized(@"search_type.route", @"OBASearchTypeRoute. Rendered as 'Route' in English.");
+        }
+        case OBASearchTypeStops: {
+            return OBALocalized(@"search_type.stops", @"OBASearchTypeStops. Rendered as 'Stops' in English.");
+        }
+        case OBASearchTypeAddress: {
+            return OBALocalized(@"search_type.address", @"OBASearchTypeAddress. Rendered as 'Address' in English.");
+        }
+        case OBASearchTypePlacemark: {
+            return OBALocalized(@"search_type.placemark", @"OBASearchTypePlacemark. Rendered as 'Placemark' in English.");
+        }
+        case OBASearchTypeStopId: {
+            return OBALocalized(@"search_type.stop_id", @"OBASearchTypeStopId. Rendered as 'Stop ID' in English.");
+        }
+        default: {
+            return nil;
+        }
+    }
+}

--- a/OBAKit/Models/navigation/OBASearchType.m
+++ b/OBAKit/Models/navigation/OBASearchType.m
@@ -29,6 +29,7 @@ NSString * NSStringFromOBASearchType(OBASearchType searchType) {
         case OBASearchTypePlacemark: {
             return OBALocalized(@"search_type.placemark", @"OBASearchTypePlacemark. Rendered as 'Placemark' in English.");
         }
+        case OBASearchTypeStopIdSearch:
         case OBASearchTypeStopId: {
             return OBALocalized(@"search_type.stop_id", @"OBASearchTypeStopId. Rendered as 'Stop ID' in English.");
         }

--- a/OBAKit/Models/navigation/OBAStopSearchNavigationTarget.h
+++ b/OBAKit/Models/navigation/OBAStopSearchNavigationTarget.h
@@ -1,0 +1,18 @@
+//
+//  OBAStopSearchNavigationTarget.h
+//  OBAKit
+//
+//  Created by Aaron Brethorst on 2/22/18.
+//  Copyright © 2018 OneBusAway. All rights reserved.
+//
+
+#import <OBAKit/OBANavigationTarget.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface OBAStopSearchNavigationTarget : OBANavigationTarget
+@property(nonatomic,copy) NSString *stopSearchQuery;
++ (instancetype)targetWithStopSearchQuery:(NSString*)searchQuery;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/OBAKit/Models/navigation/OBAStopSearchNavigationTarget.m
+++ b/OBAKit/Models/navigation/OBAStopSearchNavigationTarget.m
@@ -1,0 +1,43 @@
+//
+//  OBAStopSearchNavigationTarget.m
+//  OBAKit
+//
+//  Created by Aaron Brethorst on 2/22/18.
+//  Copyright © 2018 OneBusAway. All rights reserved.
+//
+
+#import <OBAKit/OBAStopSearchNavigationTarget.h>
+
+@implementation OBAStopSearchNavigationTarget
+
++ (instancetype)targetWithStopSearchQuery:(NSString*)searchQuery {
+    OBAStopSearchNavigationTarget *target = [self navigationTargetForStopIDSearch:searchQuery];
+    target.stopSearchQuery = searchQuery;
+
+    return target;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder {
+    self = [super initWithCoder:aDecoder];
+
+    if (self) {
+        _stopSearchQuery = [aDecoder decodeObjectForKey:NSStringFromSelector(@selector(stopSearchQuery))];
+    }
+
+    return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder {
+    [super encodeWithCoder:aCoder];
+
+    [aCoder encodeObject:_stopSearchQuery forKey:NSStringFromSelector(@selector(stopSearchQuery))];
+}
+
+- (id)copyWithZone:(NSZone *)zone {
+    OBAStopSearchNavigationTarget *target = [super copyWithZone:zone];
+    target->_stopSearchQuery = [_stopSearchQuery copyWithZone:zone];
+
+    return target;
+}
+
+@end

--- a/OBAKit/Models/unmanaged/OBAPlacemark.h
+++ b/OBAKit/Models/unmanaged/OBAPlacemark.h
@@ -18,7 +18,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface OBAPlacemark : NSObject <NSCoding,MKAnnotation>
+@interface OBAPlacemark : NSObject <NSCopying,NSCoding,MKAnnotation>
 @property(nonatomic,copy) NSString * name;
 @property(nonatomic,copy) NSString * address;
 @property(nonatomic,copy) NSString * icon;

--- a/OBAKit/Models/unmanaged/OBAPlacemark.m
+++ b/OBAKit/Models/unmanaged/OBAPlacemark.m
@@ -23,13 +23,25 @@
     self = [super init];
 
     if (self) {
-        _address = address;
+        _address = [address copy];
         _coordinate = coordinate;
     }
     return self;
 }
 
-#pragma mark NSCoder Methods
+#pragma mark - NSCopying
+
+- (id)copyWithZone:(NSZone *)zone {
+    OBAPlacemark *placemark = [[self.class allocWithZone:zone] init];
+    placemark->_address = [_address copyWithZone:zone];
+    placemark->_coordinate = _coordinate;
+    placemark->_icon = [_icon copyWithZone:zone];
+    placemark->_name = [_name copyWithZone:zone];
+
+    return placemark;
+}
+
+#pragma mark - NSCoder Methods
 
 - (id)initWithCoder:(NSCoder*)coder {
     self = [super init];
@@ -53,7 +65,7 @@
     [coder oba_encodeObject:data forSelector:@selector(coordinate)];
 }
 
-- (CLLocation*) location {
+- (CLLocation*)location {
     return [[CLLocation alloc] initWithLatitude:_coordinate.latitude longitude:_coordinate.longitude];
 }
 

--- a/OBAKit/Models/unmanaged/OBASearchResult.h
+++ b/OBAKit/Models/unmanaged/OBASearchResult.h
@@ -18,7 +18,7 @@
 @import Foundation;
 @import MapKit;
 
-#import <OBAKit/OBACommon.h>
+#import <OBAKit/OBASearchType.h>
 #import <OBAKit/OBAListWithRangeAndReferencesV2.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/OBAKit/OBAKit.h
+++ b/OBAKit/OBAKit.h
@@ -112,6 +112,7 @@ FOUNDATION_EXPORT const unsigned char OBAKitVersionString[];
 #import <OBAKit/OBAWalkingDirections.h>
 
 // Navigation
+#import <OBAKit/OBASearchType.h>
 #import <OBAKit/OBAAlarmNavigationTarget.h>
 #import <OBAKit/OBADeepLinkNavigationTarget.h>
 #import <OBAKit/OBANavigationTarget.h>

--- a/OBAKit/OBAKit.h
+++ b/OBAKit/OBAKit.h
@@ -118,6 +118,7 @@ FOUNDATION_EXPORT const unsigned char OBAKitVersionString[];
 #import <OBAKit/OBANavigationTarget.h>
 #import <OBAKit/OBANavigationTargetAnnotation.h>
 #import <OBAKit/OBANavigationTargetAware.h>
+#import <OBAKit/OBAStopSearchNavigationTarget.h>
 
 // Categories
 #import <OBAKit/NSArray+OBAAdditions.h>

--- a/OBAKit/OBAKit.h
+++ b/OBAKit/OBAKit.h
@@ -64,9 +64,6 @@ FOUNDATION_EXPORT const unsigned char OBAKitVersionString[];
 #import <OBAKit/OBAModelPersistenceLayer.h>
 #import <OBAKit/OBAModelService.h>
 #import <OBAKit/OBAModelServiceRequest.h>
-#import <OBAKit/OBANavigationTarget.h>
-#import <OBAKit/OBANavigationTargetAnnotation.h>
-#import <OBAKit/OBANavigationTargetAware.h>
 #import <OBAKit/OBAPlaceholderView.h>
 #import <OBAKit/OBAPlacemark.h>
 #import <OBAKit/OBAPlacemarks.h>
@@ -113,6 +110,13 @@ FOUNDATION_EXPORT const unsigned char OBAKitVersionString[];
 #import <OBAKit/OBAVibrantBlurContainerView.h>
 #import <OBAKit/OBAVehicleStatusV2.h>
 #import <OBAKit/OBAWalkingDirections.h>
+
+// Navigation
+#import <OBAKit/OBAAlarmNavigationTarget.h>
+#import <OBAKit/OBADeepLinkNavigationTarget.h>
+#import <OBAKit/OBANavigationTarget.h>
+#import <OBAKit/OBANavigationTargetAnnotation.h>
+#import <OBAKit/OBANavigationTargetAware.h>
 
 // Categories
 #import <OBAKit/NSArray+OBAAdditions.h>

--- a/OBAKit/OBAKit.xcodeproj/project.pbxproj
+++ b/OBAKit/OBAKit.xcodeproj/project.pbxproj
@@ -292,6 +292,8 @@
 		93EA5A3C203DF21800CE6CAC /* OBADeepLinkNavigationTarget.m in Sources */ = {isa = PBXBuildFile; fileRef = 93EA5A3A203DF21800CE6CAC /* OBADeepLinkNavigationTarget.m */; };
 		93EA5A3F203DF41B00CE6CAC /* OBAAlarmNavigationTarget.h in Headers */ = {isa = PBXBuildFile; fileRef = 93EA5A3D203DF41B00CE6CAC /* OBAAlarmNavigationTarget.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		93EA5A40203DF41B00CE6CAC /* OBAAlarmNavigationTarget.m in Sources */ = {isa = PBXBuildFile; fileRef = 93EA5A3E203DF41B00CE6CAC /* OBAAlarmNavigationTarget.m */; };
+		93EA5A48203DFDAA00CE6CAC /* OBASearchType.h in Headers */ = {isa = PBXBuildFile; fileRef = 93EA5A46203DFDAA00CE6CAC /* OBASearchType.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		93EA5A4B203DFEC300CE6CAC /* OBASearchType.m in Sources */ = {isa = PBXBuildFile; fileRef = 93EA5A4A203DFEC300CE6CAC /* OBASearchType.m */; };
 		93F3F8911E7A88EA0025FC78 /* RegionalAlertsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93F3F8901E7A88EA0025FC78 /* RegionalAlertsManager.swift */; };
 		93F3F89C1E7B02400025FC78 /* OBARegionalAlert.h in Headers */ = {isa = PBXBuildFile; fileRef = 93F3F89A1E7B02400025FC78 /* OBARegionalAlert.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		93F3F89D1E7B02400025FC78 /* OBARegionalAlert.m in Sources */ = {isa = PBXBuildFile; fileRef = 93F3F89B1E7B02400025FC78 /* OBARegionalAlert.m */; };
@@ -606,6 +608,8 @@
 		93EA5A3A203DF21800CE6CAC /* OBADeepLinkNavigationTarget.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OBADeepLinkNavigationTarget.m; sourceTree = "<group>"; };
 		93EA5A3D203DF41B00CE6CAC /* OBAAlarmNavigationTarget.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OBAAlarmNavigationTarget.h; sourceTree = "<group>"; };
 		93EA5A3E203DF41B00CE6CAC /* OBAAlarmNavigationTarget.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OBAAlarmNavigationTarget.m; sourceTree = "<group>"; };
+		93EA5A46203DFDAA00CE6CAC /* OBASearchType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OBASearchType.h; sourceTree = "<group>"; };
+		93EA5A4A203DFEC300CE6CAC /* OBASearchType.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OBASearchType.m; sourceTree = "<group>"; };
 		93F3F8901E7A88EA0025FC78 /* RegionalAlertsManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegionalAlertsManager.swift; sourceTree = "<group>"; };
 		93F3F89A1E7B02400025FC78 /* OBARegionalAlert.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBARegionalAlert.h; sourceTree = "<group>"; };
 		93F3F89B1E7B02400025FC78 /* OBARegionalAlert.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBARegionalAlert.m; sourceTree = "<group>"; };
@@ -1130,6 +1134,8 @@
 				93EA5A3A203DF21800CE6CAC /* OBADeepLinkNavigationTarget.m */,
 				93EA5A3D203DF41B00CE6CAC /* OBAAlarmNavigationTarget.h */,
 				93EA5A3E203DF41B00CE6CAC /* OBAAlarmNavigationTarget.m */,
+				93EA5A46203DFDAA00CE6CAC /* OBASearchType.h */,
+				93EA5A4A203DFEC300CE6CAC /* OBASearchType.m */,
 			);
 			path = navigation;
 			sourceTree = "<group>";
@@ -1229,6 +1235,7 @@
 				93F3F89C1E7B02400025FC78 /* OBARegionalAlert.h in Headers */,
 				934196631DB0B099004BBBB7 /* OBAPlacemark.h in Headers */,
 				934196511DB0B099004BBBB7 /* OBABookmarkGroup.h in Headers */,
+				93EA5A48203DFDAA00CE6CAC /* OBASearchType.h in Headers */,
 				9341962A1DB0B099004BBBB7 /* OBATripStopTimeMapAnnotation.h in Headers */,
 				93E592B11F8D3C600079A2D8 /* OBABookmarkedRouteCell.h in Headers */,
 				93E5929B1F8CAA9C0079A2D8 /* OBATableSection.h in Headers */,
@@ -1516,6 +1523,7 @@
 				9341963C1DB0B099004BBBB7 /* OBASetCoordinatePropertyJsonDigesterRule.m in Sources */,
 				934196931DB0B099004BBBB7 /* OBAVehicleStatusV2.m in Sources */,
 				93F3F8A21E7BCA8C0025FC78 /* FileHelpers.swift in Sources */,
+				93EA5A4B203DFEC300CE6CAC /* OBASearchType.m in Sources */,
 				934196231DB0B099004BBBB7 /* OBARegionHelper.m in Sources */,
 				93F3F8911E7A88EA0025FC78 /* RegionalAlertsManager.swift in Sources */,
 				9388C29F1FFDBAEA0068041F /* FBShimmeringView.m in Sources */,

--- a/OBAKit/OBAKit.xcodeproj/project.pbxproj
+++ b/OBAKit/OBAKit.xcodeproj/project.pbxproj
@@ -294,6 +294,8 @@
 		93EA5A40203DF41B00CE6CAC /* OBAAlarmNavigationTarget.m in Sources */ = {isa = PBXBuildFile; fileRef = 93EA5A3E203DF41B00CE6CAC /* OBAAlarmNavigationTarget.m */; };
 		93EA5A48203DFDAA00CE6CAC /* OBASearchType.h in Headers */ = {isa = PBXBuildFile; fileRef = 93EA5A46203DFDAA00CE6CAC /* OBASearchType.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		93EA5A4B203DFEC300CE6CAC /* OBASearchType.m in Sources */ = {isa = PBXBuildFile; fileRef = 93EA5A4A203DFEC300CE6CAC /* OBASearchType.m */; };
+		93EA5A57203F368700CE6CAC /* OBAStopSearchNavigationTarget.h in Headers */ = {isa = PBXBuildFile; fileRef = 93EA5A55203F368700CE6CAC /* OBAStopSearchNavigationTarget.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		93EA5A58203F368700CE6CAC /* OBAStopSearchNavigationTarget.m in Sources */ = {isa = PBXBuildFile; fileRef = 93EA5A56203F368700CE6CAC /* OBAStopSearchNavigationTarget.m */; };
 		93F3F8911E7A88EA0025FC78 /* RegionalAlertsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93F3F8901E7A88EA0025FC78 /* RegionalAlertsManager.swift */; };
 		93F3F89C1E7B02400025FC78 /* OBARegionalAlert.h in Headers */ = {isa = PBXBuildFile; fileRef = 93F3F89A1E7B02400025FC78 /* OBARegionalAlert.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		93F3F89D1E7B02400025FC78 /* OBARegionalAlert.m in Sources */ = {isa = PBXBuildFile; fileRef = 93F3F89B1E7B02400025FC78 /* OBARegionalAlert.m */; };
@@ -610,6 +612,8 @@
 		93EA5A3E203DF41B00CE6CAC /* OBAAlarmNavigationTarget.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OBAAlarmNavigationTarget.m; sourceTree = "<group>"; };
 		93EA5A46203DFDAA00CE6CAC /* OBASearchType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OBASearchType.h; sourceTree = "<group>"; };
 		93EA5A4A203DFEC300CE6CAC /* OBASearchType.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OBASearchType.m; sourceTree = "<group>"; };
+		93EA5A55203F368700CE6CAC /* OBAStopSearchNavigationTarget.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OBAStopSearchNavigationTarget.h; sourceTree = "<group>"; };
+		93EA5A56203F368700CE6CAC /* OBAStopSearchNavigationTarget.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OBAStopSearchNavigationTarget.m; sourceTree = "<group>"; };
 		93F3F8901E7A88EA0025FC78 /* RegionalAlertsManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegionalAlertsManager.swift; sourceTree = "<group>"; };
 		93F3F89A1E7B02400025FC78 /* OBARegionalAlert.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBARegionalAlert.h; sourceTree = "<group>"; };
 		93F3F89B1E7B02400025FC78 /* OBARegionalAlert.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBARegionalAlert.m; sourceTree = "<group>"; };
@@ -1128,14 +1132,16 @@
 		93EA5A38203DF1DC00CE6CAC /* navigation */ = {
 			isa = PBXGroup;
 			children = (
+				93EA5A46203DFDAA00CE6CAC /* OBASearchType.h */,
+				93EA5A4A203DFEC300CE6CAC /* OBASearchType.m */,
 				934195C51DB0B099004BBBB7 /* OBANavigationTarget.h */,
 				934195C61DB0B099004BBBB7 /* OBANavigationTarget.m */,
 				93EA5A39203DF21800CE6CAC /* OBADeepLinkNavigationTarget.h */,
 				93EA5A3A203DF21800CE6CAC /* OBADeepLinkNavigationTarget.m */,
 				93EA5A3D203DF41B00CE6CAC /* OBAAlarmNavigationTarget.h */,
 				93EA5A3E203DF41B00CE6CAC /* OBAAlarmNavigationTarget.m */,
-				93EA5A46203DFDAA00CE6CAC /* OBASearchType.h */,
-				93EA5A4A203DFEC300CE6CAC /* OBASearchType.m */,
+				93EA5A55203F368700CE6CAC /* OBAStopSearchNavigationTarget.h */,
+				93EA5A56203F368700CE6CAC /* OBAStopSearchNavigationTarget.m */,
 			);
 			path = navigation;
 			sourceTree = "<group>";
@@ -1187,6 +1193,7 @@
 				936EB1B91E91A83700F4F3A7 /* OBARegionStorage.h in Headers */,
 				932CE84D20263F0C003091D3 /* OBABookmarkedRouteErrorCell.h in Headers */,
 				9341965E1DB0B099004BBBB7 /* OBAHasServiceAlerts.h in Headers */,
+				93EA5A57203F368700CE6CAC /* OBAStopSearchNavigationTarget.h in Headers */,
 				934195FA1DB0B099004BBBB7 /* NSObject+OBADescription.h in Headers */,
 				9358CDB21DEA242B00132CDE /* OBAUpcomingDeparture.h in Headers */,
 				934C50A91E2B6D2700DFDCA0 /* OBAAlarm.h in Headers */,
@@ -1542,6 +1549,7 @@
 				934196341DB0B099004BBBB7 /* OBACallMethodJsonDigesterRule.m in Sources */,
 				9341962F1DB0B099004BBBB7 /* OBAModelDAO.m in Sources */,
 				934196061DB0B099004BBBB7 /* OBADateHelpers.m in Sources */,
+				93EA5A58203F368700CE6CAC /* OBAStopSearchNavigationTarget.m in Sources */,
 				934196771DB0B099004BBBB7 /* OBASearchResult.m in Sources */,
 				934196381DB0B099004BBBB7 /* OBAJsonDigester.m in Sources */,
 				930AFE9F1DD183720092AE82 /* OBAWalkingDirections.m in Sources */,

--- a/OBAKit/OBAKit.xcodeproj/project.pbxproj
+++ b/OBAKit/OBAKit.xcodeproj/project.pbxproj
@@ -288,6 +288,10 @@
 		93E592B11F8D3C600079A2D8 /* OBABookmarkedRouteCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 93E592AD1F8D3C600079A2D8 /* OBABookmarkedRouteCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		93E592B21F8D3C600079A2D8 /* OBABookmarkedRouteCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 93E592AE1F8D3C600079A2D8 /* OBABookmarkedRouteCell.m */; };
 		93E592B31F8D3C600079A2D8 /* OBABookmarkedRouteRow.m in Sources */ = {isa = PBXBuildFile; fileRef = 93E592AF1F8D3C600079A2D8 /* OBABookmarkedRouteRow.m */; };
+		93EA5A3B203DF21800CE6CAC /* OBADeepLinkNavigationTarget.h in Headers */ = {isa = PBXBuildFile; fileRef = 93EA5A39203DF21800CE6CAC /* OBADeepLinkNavigationTarget.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		93EA5A3C203DF21800CE6CAC /* OBADeepLinkNavigationTarget.m in Sources */ = {isa = PBXBuildFile; fileRef = 93EA5A3A203DF21800CE6CAC /* OBADeepLinkNavigationTarget.m */; };
+		93EA5A3F203DF41B00CE6CAC /* OBAAlarmNavigationTarget.h in Headers */ = {isa = PBXBuildFile; fileRef = 93EA5A3D203DF41B00CE6CAC /* OBAAlarmNavigationTarget.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		93EA5A40203DF41B00CE6CAC /* OBAAlarmNavigationTarget.m in Sources */ = {isa = PBXBuildFile; fileRef = 93EA5A3E203DF41B00CE6CAC /* OBAAlarmNavigationTarget.m */; };
 		93F3F8911E7A88EA0025FC78 /* RegionalAlertsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93F3F8901E7A88EA0025FC78 /* RegionalAlertsManager.swift */; };
 		93F3F89C1E7B02400025FC78 /* OBARegionalAlert.h in Headers */ = {isa = PBXBuildFile; fileRef = 93F3F89A1E7B02400025FC78 /* OBARegionalAlert.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		93F3F89D1E7B02400025FC78 /* OBARegionalAlert.m in Sources */ = {isa = PBXBuildFile; fileRef = 93F3F89B1E7B02400025FC78 /* OBARegionalAlert.m */; };
@@ -598,6 +602,10 @@
 		93E592AE1F8D3C600079A2D8 /* OBABookmarkedRouteCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBABookmarkedRouteCell.m; sourceTree = "<group>"; };
 		93E592AF1F8D3C600079A2D8 /* OBABookmarkedRouteRow.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBABookmarkedRouteRow.m; sourceTree = "<group>"; };
 		93E592BB1F8D778C0079A2D8 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		93EA5A39203DF21800CE6CAC /* OBADeepLinkNavigationTarget.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OBADeepLinkNavigationTarget.h; sourceTree = "<group>"; };
+		93EA5A3A203DF21800CE6CAC /* OBADeepLinkNavigationTarget.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OBADeepLinkNavigationTarget.m; sourceTree = "<group>"; };
+		93EA5A3D203DF41B00CE6CAC /* OBAAlarmNavigationTarget.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OBAAlarmNavigationTarget.h; sourceTree = "<group>"; };
+		93EA5A3E203DF41B00CE6CAC /* OBAAlarmNavigationTarget.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OBAAlarmNavigationTarget.m; sourceTree = "<group>"; };
 		93F3F8901E7A88EA0025FC78 /* RegionalAlertsManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegionalAlertsManager.swift; sourceTree = "<group>"; };
 		93F3F89A1E7B02400025FC78 /* OBARegionalAlert.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBARegionalAlert.h; sourceTree = "<group>"; };
 		93F3F89B1E7B02400025FC78 /* OBARegionalAlert.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBARegionalAlert.m; sourceTree = "<group>"; };
@@ -822,6 +830,7 @@
 		934195841DB0B099004BBBB7 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				93EA5A38203DF1DC00CE6CAC /* navigation */,
 				93F3F8991E7B022D0025FC78 /* mantle */,
 				934195851DB0B099004BBBB7 /* annotations */,
 				9341958E1DB0B099004BBBB7 /* dao */,
@@ -914,8 +923,6 @@
 				934195C21DB0B099004BBBB7 /* OBAHasServiceAlerts.h */,
 				934195C31DB0B099004BBBB7 /* OBAListWithRangeAndReferencesV2.h */,
 				934195C41DB0B099004BBBB7 /* OBAListWithRangeAndReferencesV2.m */,
-				934195C51DB0B099004BBBB7 /* OBANavigationTarget.h */,
-				934195C61DB0B099004BBBB7 /* OBANavigationTarget.m */,
 				934195C71DB0B099004BBBB7 /* OBAPlacemark.h */,
 				934195C81DB0B099004BBBB7 /* OBAPlacemark.m */,
 				934195C91DB0B099004BBBB7 /* OBAPlacemarks.h */,
@@ -1114,6 +1121,19 @@
 			path = Bookmarks;
 			sourceTree = "<group>";
 		};
+		93EA5A38203DF1DC00CE6CAC /* navigation */ = {
+			isa = PBXGroup;
+			children = (
+				934195C51DB0B099004BBBB7 /* OBANavigationTarget.h */,
+				934195C61DB0B099004BBBB7 /* OBANavigationTarget.m */,
+				93EA5A39203DF21800CE6CAC /* OBADeepLinkNavigationTarget.h */,
+				93EA5A3A203DF21800CE6CAC /* OBADeepLinkNavigationTarget.m */,
+				93EA5A3D203DF41B00CE6CAC /* OBAAlarmNavigationTarget.h */,
+				93EA5A3E203DF41B00CE6CAC /* OBAAlarmNavigationTarget.m */,
+			);
+			path = navigation;
+			sourceTree = "<group>";
+		};
 		93F3F88F1E7A88D10025FC78 /* regional_alerts */ = {
 			isa = PBXGroup;
 			children = (
@@ -1241,6 +1261,7 @@
 				9388C2D32001567F0068041F /* OBAStackedMarqueeLabels.h in Headers */,
 				934C50951E2A1FB500DFDCA0 /* NSCoder+OBAAdditions.h in Headers */,
 				9388C29C1FFDBAEA0068041F /* FBShimmeringLayer.h in Headers */,
+				93EA5A3B203DF21800CE6CAC /* OBADeepLinkNavigationTarget.h in Headers */,
 				93089DA31F87E6E600694A90 /* OBAViewModelRegistry.h in Headers */,
 				9341960E1DB0B099004BBBB7 /* OBAMapHelpers.h in Headers */,
 				9341964F1DB0B099004BBBB7 /* OBAArrivalsAndDeparturesForStopV2.h in Headers */,
@@ -1258,6 +1279,7 @@
 				934196901DB0B099004BBBB7 /* OBATripV2.h in Headers */,
 				934196711DB0B099004BBBB7 /* OBARouteType.h in Headers */,
 				9385BEDC1FB040B300D122D1 /* OBAErrorMessages.h in Headers */,
+				93EA5A3F203DF41B00CE6CAC /* OBAAlarmNavigationTarget.h in Headers */,
 				934196121DB0B099004BBBB7 /* OBARouteFilter.h in Headers */,
 				934195FC1DB0B099004BBBB7 /* UILabel+OBAAdditions.h in Headers */,
 				930653F41E71D704005AF0C9 /* OBADeepLinkRouter.h in Headers */,
@@ -1400,6 +1422,7 @@
 				9358CDB31DEA242B00132CDE /* OBAUpcomingDeparture.m in Sources */,
 				934196011DB0B099004BBBB7 /* OBACommon.m in Sources */,
 				934196811DB0B099004BBBB7 /* OBAStopPreferencesV2.m in Sources */,
+				93EA5A40203DF41B00CE6CAC /* OBAAlarmNavigationTarget.m in Sources */,
 				934196831DB0B099004BBBB7 /* OBAStopsForRouteV2.m in Sources */,
 				930AFE901DD0717A0092AE82 /* Array+Functional.swift in Sources */,
 				9341967D1DB0B099004BBBB7 /* OBASituationV2.m in Sources */,
@@ -1503,6 +1526,7 @@
 				9341967F1DB0B099004BBBB7 /* OBAStopAccessEventV2.m in Sources */,
 				93E592941F8CA6260079A2D8 /* OBATableRow.m in Sources */,
 				934196B11DB0B0AF004BBBB7 /* OBAJsonDataSource.m in Sources */,
+				93EA5A3C203DF21800CE6CAC /* OBADeepLinkNavigationTarget.m in Sources */,
 				934196481DB0B099004BBBB7 /* OBAAgencyV2.m in Sources */,
 				9358CDAF1DEA1AB000132CDE /* OBADepartureCellHelpers.m in Sources */,
 				9388C2A51FFDF7C90068041F /* OBAPlaceholderView.m in Sources */,

--- a/OBAKit/Services/OBAMapDataLoader.m
+++ b/OBAKit/Services/OBAMapDataLoader.m
@@ -232,7 +232,7 @@
             break;
         }
 
-        case OBASearchTypeStopId: {
+        case OBASearchTypeStopIdSearch: {
             promise = [self requestStopIDWithStopCode:searchTypeParameter];
             break;
         }

--- a/OneBusAway/OBAApplicationDelegate.m
+++ b/OneBusAway/OBAApplicationDelegate.m
@@ -262,8 +262,7 @@ static NSString * const OBALastRegionRefreshDateUserDefaultsKey = @"OBALastRegio
         // OK, it works, so write it into the model DAO.
         [self.application.modelDao addSharedTrip:tripDeepLink];
 
-        OBANavigationTarget *target = [OBANavigationTarget navigationTarget:OBANavigationTargetTypeRecentStops];
-        target.object = tripDeepLink;
+        OBADeepLinkNavigationTarget *target = [OBADeepLinkNavigationTarget targetWithTripDeepLink:tripDeepLink];
         [appDelegate navigateToTarget:target];
     }).catch(^(NSError *error) {
         NSString *body = [NSString stringWithFormat:NSLocalizedString(@"text_error_cant_show_shared_trip_param", @"Error message displayed to the user when something goes wrong with a just-tapped shared trip."), error.localizedDescription];
@@ -377,10 +376,8 @@ static NSString * const OBALastRegionRefreshDateUserDefaultsKey = @"OBALastRegio
 
     [self.application.modelService requestArrivalAndDepartureWithConvertible:alarm].then(^(OBAArrivalAndDepartureV2 *arrivalAndDeparture) {
         alarm.title = arrivalAndDeparture.bestAvailableNameWithHeadsign;
-
-        OBANavigationTarget *target = [OBANavigationTarget navigationTarget:OBANavigationTargetTypeRecentStops];
-        target.object = alarm;
-        [self navigateToTarget:target];
+        OBAAlarmNavigationTarget *alarmTarget = [OBAAlarmNavigationTarget navigationTargetWithAlarm:alarm];
+        [self navigateToTarget:alarmTarget];
     }).catch(^(NSError *error) {
         NSString *body = [NSString stringWithFormat:NSLocalizedString(@"notifications.error_messages.formatted_cant_display", @"Error message displayed to the user when something goes wrong with a just-tapped notification."), error.localizedDescription];
         [AlertPresenter showWarning:OBAStrings.error body:body];

--- a/OneBusAway/ui/map/OBAMapAnnotationViewBuilder.m
+++ b/OneBusAway/ui/map/OBAMapAnnotationViewBuilder.m
@@ -109,9 +109,15 @@
 + (void)updateAnnotationsOnMapView:(MKMapView*)mapView fromSearchResult:(OBASearchResult*)result bookmarkAnnotations:(NSArray*)bookmarks {
     NSMutableArray *allCurrentAnnotations = [[NSMutableArray alloc] init];
 
-    [allCurrentAnnotations addObjectsFromArray:bookmarks];
+    NSSet *bookmarkStopIDs = nil;
 
-    NSSet *bookmarkStopIDs = [NSSet setWithArray:[bookmarks valueForKey:@"stopId"]];
+    if (result.searchType != OBASearchTypeStopIdSearch && result.searchType != OBASearchTypeRoute) {
+        [allCurrentAnnotations addObjectsFromArray:bookmarks];
+        bookmarkStopIDs = [NSSet setWithArray:[bookmarks valueForKey:@"stopId"]];
+    }
+    else {
+        bookmarkStopIDs = [NSSet set];
+    }
 
     // prospectiveAnnotation *should* be an OBAStopV2, but there are some indications that this
     // is not always the case. To that end, we'll just go belt and suspenders on it and see if

--- a/OneBusAway/ui/map/OBAMapViewController.m
+++ b/OneBusAway/ui/map/OBAMapViewController.m
@@ -788,7 +788,8 @@ static const double kStopsInRegionRefreshDelayOnDrag = 0.1;
         case OBASearchTypeRoute:
         case OBASearchTypeStops:
         case OBASearchTypeAddress:
-        case OBASearchTypeStopId: {
+        case OBASearchTypeStopId:
+        case OBASearchTypeStopIdSearch: {
             NSString *query = navigationTarget.userFacingSearchQuery;
 
             if (!query) {
@@ -848,6 +849,7 @@ static const double kStopsInRegionRefreshDelayOnDrag = 0.1;
     }
 
     switch (result.searchType) {
+        case OBASearchTypeStopIdSearch:
         case OBASearchTypeStopId:
             return [OBAMapHelpers computeRegionForNClosestStops:result.values center:[self currentLocation] numberOfStops:kShowNClosestStops];
 
@@ -912,7 +914,7 @@ static const double kStopsInRegionRefreshDelayOnDrag = 0.1;
         alertTitle = NSLocalizedString(@"msg_no_places_found", @"showNoResultsAlertWithTitle");
         alertMessage = NSLocalizedString(@"msg_explanatory_no_places_found", @"prompt");
     }
-    else if (OBASearchTypeStopId == result.searchType) {
+    else if (OBASearchTypeStopId == result.searchType || OBASearchTypeStopIdSearch == result.searchType) {
         alertTitle = NSLocalizedString(@"msg_minus_no_stops_found", @"showNoResultsAlertWithTitle");
         alertMessage = NSLocalizedString(@"msg_explanatory_minus_no_stops_found", @"prompt");
     }

--- a/OneBusAway/ui/recent_stops/OBARecentStopsViewController.m
+++ b/OneBusAway/ui/recent_stops/OBARecentStopsViewController.m
@@ -227,8 +227,9 @@
 }
 
 - (void)setNavigationTarget:(OBANavigationTarget *)target {
-    if ([target.object conformsToProtocol:@protocol(OBAArrivalAndDepartureConvertible)]) {
-        OBAArrivalAndDepartureViewController *controller = [[OBAArrivalAndDepartureViewController alloc] initWithArrivalAndDepartureConvertible:target.object];
+    if ([target isKindOfClass:OBADeepLinkNavigationTarget.class]) {
+        OBADeepLinkNavigationTarget *t = (OBADeepLinkNavigationTarget *)target;
+        OBAArrivalAndDepartureViewController *controller = [[OBAArrivalAndDepartureViewController alloc] initWithArrivalAndDepartureConvertible:t.tripDeepLink];
         [self.navigationController pushViewController:controller animated:YES];
     }
     else if (target.parameters[OBAStopIDNavigationTargetParameter]) {
@@ -236,7 +237,7 @@
         [self showStopViewControllerWithStopID:stopID];
     }
     else {
-        DDLogError(@"Unhandled object type (%@) from OBANavigationTarget: %@", target.object, target);
+        DDLogError(@"Unhandled OBANavigationTarget: %@", target);
     }
 }
 

--- a/OneBusAway/ui/search/MapSearchViewController.swift
+++ b/OneBusAway/ui/search/MapSearchViewController.swift
@@ -120,7 +120,7 @@ class MapSearchViewController: OBAStaticTableViewController, UISearchResultsUpda
         // Stop Number Row
         let stopNumberText = MapSearchViewController.quickLookupRowText(title: NSLocalizedString("map_search.search_for_stop_number", comment: "Stop Number: <STOP NUMBER>"), searchText: searchText)
         let stopNumberRow = OBATableRow.init(attributedTitle: stopNumberText) { _ in
-            let target = OBANavigationTarget(forStopID: searchText)
+            let target = OBAStopSearchNavigationTarget(stopSearchQuery: searchText)
             self.delegate?.mapSearch(self, selectedNavigationTarget: target)
         }
         stopNumberRow.accessoryType = .disclosureIndicator


### PR DESCRIPTION
Fixes #1264 - Stop search broken in Beta 18.1.0

Adds a new navigation target type specifically for user initiated stop searches. Also split out other navigation target types into separate classes.