### PR TITLE
Moves Stop page filter and '...' buttons into hover bar

### DIFF
--- a/OBAKit/UI/OBATheme.h
+++ b/OBAKit/UI/OBATheme.h
@@ -250,4 +250,10 @@
  The value of +[OBATheme compactPadding] in the form of UIEdgeInsets.
  */
 @property(class,nonatomic,assign,readonly) UIEdgeInsets compactEdgeInsets;
+
+/**
+ Default insets for images placed in UIButtons inside of a hover bar—our version of a FAB.
+ */
+@property(class,nonatomic,assign,readonly) UIEdgeInsets hoverBarImageInsets;
+
 @end

--- a/OBAKit/UI/OBATheme.m
+++ b/OBAKit/UI/OBATheme.m
@@ -293,4 +293,8 @@ static UIFont *_italicFootnoteFont = nil;
     return UIEdgeInsetsMake([self compactPadding], [self compactPadding], [self compactPadding], [self compactPadding]);
 }
 
++ (UIEdgeInsets)hoverBarImageInsets {
+    return self.defaultEdgeInsets;
+}
+
 @end

--- a/OBAKit/UI/OBAUIBuilder.m
+++ b/OBAKit/UI/OBAUIBuilder.m
@@ -58,10 +58,10 @@
 }
 
 + (UIBarButtonItem*)wrappedImageButton:(UIImage*)image accessibilityLabel:(NSString*)label target:(id)target action:(SEL)action {
-    UIButton *button = [[UIButton alloc] initWithFrame:CGRectMake(0, 0, 40, 40)];
-    button.tintColor = UIColor.darkGrayColor;
+    UIButton *button = [[UIButton alloc] initWithFrame:CGRectMake(0, 0, 44, 44)];
+    button.tintColor = OBATheme.OBADarkGreen;
     [button setImage:image forState:UIControlStateNormal];
-    button.imageEdgeInsets = [OBATheme defaultEdgeInsets];
+    button.imageEdgeInsets = [OBATheme hoverBarImageInsets];
     [button addTarget:target action:action forControlEvents:UIControlEventTouchUpInside];
 
     UIBarButtonItem *barButtonItem = [[UIBarButtonItem alloc] initWithCustomView:button];

--- a/OneBusAway/en.lproj/Localizable.strings
+++ b/OneBusAway/en.lproj/Localizable.strings
@@ -852,6 +852,9 @@
 /* Empty data set description when there are no Today View bookmarks. */
 "bookmarks_controller.today_view.no_content_description" = "Add bookmarks to the Today View group to get quick access to bus times. Tap the button below to learn more.";
 
+/* Accessibility label for sorting popover button */
+"bookmarks_controller.sorting_accessibility_label" = "Sort Bookmarks";
+
 /* "Title of the Onboarding Controller. 'Welcome to OneBusAway!' */
 "onboarding_controller.title" = "Welcome to OneBusAway!";
 

--- a/OneBusAway/ui/bookmarks/OBABookmarksViewController.m
+++ b/OneBusAway/ui/bookmarks/OBABookmarksViewController.m
@@ -683,12 +683,8 @@ static NSString * const OBABookmarkSortUserDefaultsKey = @"OBABookmarkSortUserDe
 }
 
 - (void)createSortHoverBar {
-    UIButton *button = [UIButton buttonWithType:UIButtonTypeSystem];
-    button.imageEdgeInsets = UIEdgeInsetsMake(8, 8, 8, 8);
-    button.tintColor = [UIColor blackColor];
-    [button setImage:[UIImage imageNamed:@"sort-amount-desc"] forState:UIControlStateNormal];
-    [button addTarget:self action:@selector(showSortPopover) forControlEvents:UIControlEventTouchUpInside];
-    UIBarButtonItem *sortButton = [[UIBarButtonItem alloc] initWithCustomView:button];
+    NSString *label = NSLocalizedString(@"bookmarks_controller.sorting_accessibility_label", @"Accessibility label for sorting popover button");
+    UIBarButtonItem *sortButton = [OBAUIBuilder wrappedImageButton:[UIImage imageNamed:@"sort-amount-desc"] accessibilityLabel:label target:self action:@selector(showSortPopover)];
 
     self.sortHoverBar = [[ISHHoverBar alloc] init];
     self.sortHoverBar.items = @[sortButton];

--- a/OneBusAway/ui/stops/OBAStopViewController.m
+++ b/OneBusAway/ui/stops/OBAStopViewController.m
@@ -29,6 +29,9 @@
 #import "OBAArrivalDepartureOptionsSheet.h"
 #import "UIViewController+OBAAdditions.h"
 #import "EXTScope.h"
+#import "ISHHoverBar.h"
+
+@import Masonry;
 
 static NSTimeInterval const kRefreshTimeInterval = 30.0;
 static CGFloat const kTableHeaderHeight = 150.f;
@@ -49,6 +52,7 @@ static NSUInteger const kDefaultMinutesAfter = 35;
 @property(nonatomic,strong) OBARouteFilter *routeFilter;
 @property(nonatomic,strong) OBAStopTableHeaderView *stopHeaderView;
 @property(nonatomic,strong) OBAArrivalDepartureOptionsSheet *departureSheetHelper;
+@property(nonatomic,strong) ISHHoverBar *hoverBar;
 @end
 
 @implementation OBAStopViewController
@@ -88,6 +92,8 @@ static NSUInteger const kDefaultMinutesAfter = 35;
     self.refreshControl = [[UIRefreshControl alloc] init];
     [self.refreshControl addTarget:self action:@selector(reloadData:) forControlEvents:UIControlEventValueChanged];
     [self.tableView addSubview:self.refreshControl];
+
+    [self createHoverBar];
 }
 
 - (void)viewWillAppear:(BOOL)animated {
@@ -594,9 +600,6 @@ static NSUInteger const kDefaultMinutesAfter = 35;
     self.stopHeaderView = [[OBAStopTableHeaderView alloc] initWithFrame:CGRectMake(0, 0, CGRectGetWidth(self.tableView.frame), kTableHeaderHeight)];
     self.stopHeaderView.highContrastMode = [OBATheme useHighContrastUI];
 
-    [self.stopHeaderView.menuButton addTarget:self action:@selector(showActionsMenu:) forControlEvents:UIControlEventTouchUpInside];
-    [self.stopHeaderView.filterButton addTarget:self action:@selector(showFilterAndSortUI) forControlEvents:UIControlEventTouchUpInside];
-
     self.tableView.tableHeaderView = self.stopHeaderView;
 }
 
@@ -618,5 +621,24 @@ static NSUInteger const kDefaultMinutesAfter = 35;
 
     return [NSDictionary dictionaryWithDictionary:dict];
 }
+
+#pragma mark - Hover Bar
+
+- (void)createHoverBar {
+    NSString *label = NSLocalizedString(@"stop_header_view.menu_button_accessibility_label", @"This is the '...' button in the stop header view.");
+    UIBarButtonItem *menuButton = [OBAUIBuilder wrappedImageButton:[UIImage imageNamed:@"ellipsis_button"] accessibilityLabel:label target:self action:@selector(showActionsMenu:)];
+
+    label = NSLocalizedString(@"stop_header_view.filter_button_accessibility_label", @"This is the Filter button in the stop header view.");
+    UIBarButtonItem *filterButton = [OBAUIBuilder wrappedImageButton:[UIImage imageNamed:@"filter"] accessibilityLabel:label target:self action:@selector(showFilterAndSortUI)];
+
+    self.hoverBar = [[ISHHoverBar alloc] init];
+    self.hoverBar.items = @[menuButton, filterButton];
+    [self.view addSubview:self.hoverBar];
+    [self.hoverBar mas_makeConstraints:^(MASConstraintMaker *make) {
+        make.bottom.equalTo(self.mas_bottomLayoutGuideTop).offset(-OBATheme.defaultMargin);
+        make.trailing.equalTo(self).offset(-OBATheme.defaultMargin);
+    }];
+}
+
 
 @end

--- a/OneBusAway/ui/stops/OBAStopViewController.m
+++ b/OneBusAway/ui/stops/OBAStopViewController.m
@@ -337,12 +337,9 @@ static NSUInteger const kDefaultMinutesAfter = 35;
 
     OBAWalkableRow *walkableRow = [[OBAWalkableRow alloc] init];
 
-    // Only show the user's distance from the stop
+    // Only show the user's distance/time from the stop
     // if they are a negligible distance from it.
-    if (minutesToArrivalAtStop == 0) {
-        walkableRow.text = distanceString;
-    }
-    else {
+    if (minutesToArrivalAtStop > 0) {
         walkableRow.text = [NSString stringWithFormat:NSLocalizedString(@"text_walk_to_stop_info_params",), distanceString, @(minutesToArrivalAtStop), [OBADateHelpers formatShortTimeNoDate:expectedArrivalDate]];
     }
 

--- a/OneBusAway/ui/stops/views/OBAStopTableHeaderView.h
+++ b/OneBusAway/ui/stops/views/OBAStopTableHeaderView.h
@@ -15,8 +15,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface OBAStopTableHeaderView : UIView
 @property(nonatomic,assign) BOOL highContrastMode;
-@property(nonatomic,strong,readonly) UIButton *menuButton;
-@property(nonatomic,strong,readonly) UIButton *filterButton;
 - (void)populateTableHeaderFromArrivalsAndDeparturesModel:(OBAArrivalsAndDeparturesForStopV2*)result;
 @end
 

--- a/OneBusAway/ui/stops/views/OBAStopTableHeaderView.m
+++ b/OneBusAway/ui/stops/views/OBAStopTableHeaderView.m
@@ -19,8 +19,6 @@
 @property(nonatomic,strong) UIImageView *headerImageView;
 @property(nonatomic,strong) UILabel *stopInformationLabel;
 @property(nonatomic,strong) OBAStopV2 *stop;
-@property(nonatomic,strong,readwrite) UIButton *menuButton;
-@property(nonatomic,strong,readwrite) UIButton *filterButton;
 @end
 
 @implementation OBAStopTableHeaderView
@@ -50,39 +48,12 @@
             label;
         });
 
-        _menuButton = [UIButton buttonWithType:UIButtonTypeSystem];
-        [_menuButton setContentHuggingPriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
-        [_menuButton setImage:[UIImage imageNamed:@"ellipsis_button"] forState:UIControlStateNormal];
-        _menuButton.tintColor = [UIColor whiteColor];
-        _menuButton.accessibilityLabel = NSLocalizedString(@"stop_header_view.menu_button_accessibility_label", @"This is the '...' button in the stop header view.");
-
-        _filterButton = [UIButton buttonWithType:UIButtonTypeSystem];
-        _filterButton.imageView.contentMode = UIViewContentModeScaleAspectFit;
-        [_filterButton setContentHuggingPriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
-        _filterButton.imageEdgeInsets = UIEdgeInsetsMake(8, 8, 8, 8);
-        [_filterButton setImage:[UIImage imageNamed:@"filter"] forState:UIControlStateNormal];
-        _filterButton.tintColor = [UIColor whiteColor];
-        _filterButton.accessibilityLabel = NSLocalizedString(@"stop_header_view.filter_button_accessibility_label", @"This is the Filter button in the stop header view.");
-
-        UIStackView *buttonStack = [[UIStackView alloc] initWithArrangedSubviews:@[[UIView new], _filterButton, _menuButton]];
-        buttonStack.axis = UILayoutConstraintAxisHorizontal;
-        buttonStack.spacing = [OBATheme defaultPadding];
-        buttonStack.distribution = UIStackViewDistributionFill;
-
-        UIStackView *stack = [[UIStackView alloc] initWithArrangedSubviews:@[_stopInformationLabel, buttonStack]];
+        UIStackView *stack = [[UIStackView alloc] initWithArrangedSubviews:@[_stopInformationLabel]];
         stack.axis = UILayoutConstraintAxisVertical;
 
         [self addSubview:stack];
         [stack mas_makeConstraints:^(MASConstraintMaker *make) {
             make.edges.equalTo(self);
-        }];
-
-        [_filterButton mas_makeConstraints:^(MASConstraintMaker *make) {
-            make.size.equalTo([NSValue valueWithCGSize:CGSizeMake(48.f, 40.f)]);
-        }];
-
-        [_menuButton mas_makeConstraints:^(MASConstraintMaker *make) {
-            make.size.equalTo([NSValue valueWithCGSize:CGSizeMake(56.f, 40.f)]);
         }];
 
         [stack mas_makeConstraints:^(MASConstraintMaker *make) {


### PR DESCRIPTION
Fixes #1278 - Move the Stop page's filter and '...' buttons into an ISHHoverBar

Every other part of the app is adopting these FAB-like buttons. The Stop page should do the same thing. Also, use a helper method I wrote recently to DRY up similar button creations throughout the app.