### PR TITLE
Embed a stripped-down stop controller in the map's callouts

### DIFF
--- a/OBAKit/Info.plist
+++ b/OBAKit/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>18.1.1</string>
+	<string>18.2.0</string>
 	<key>CFBundleVersion</key>
-	<string>20180324.12</string>
+	<string>20180623.15</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/OBAKit/UI/Departures/OBADepartureRow.h
+++ b/OBAKit/UI/Departures/OBADepartureRow.h
@@ -23,6 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic,assign) BOOL bookmarkExists;
 @property(nonatomic,assign) BOOL alarmExists;
 @property(nonatomic,assign) BOOL hasArrived;
+@property(nonatomic,assign) BOOL displayContextButton;
 
 + (NSAttributedString*)buildAttributedRoute:(NSString*)route destination:(nullable NSString*)destination;
 @end

--- a/OBAKit/UI/Departures/OBADepartureRow.m
+++ b/OBAKit/UI/Departures/OBADepartureRow.m
@@ -14,6 +14,15 @@
 
 @implementation OBADepartureRow
 
+- (instancetype)initWithAction:(nullable OBARowAction)action {
+    self = [super initWithAction:action];
+
+    if (self) {
+        _displayContextButton = YES;
+    }
+    return self;
+}
+
 + (void)load {
     [OBAViewModelRegistry registerClass:self.class];
 }
@@ -30,7 +39,8 @@
     row->_bookmarkExists = _bookmarkExists;
     row->_alarmExists = _alarmExists;
     row->_hasArrived = _hasArrived;
-
+    row->_displayContextButton = _displayContextButton;
+    
     return row;
 }
 

--- a/OBAKit/UI/OBAClassicDepartureCell.m
+++ b/OBAKit/UI/OBAClassicDepartureCell.m
@@ -66,6 +66,8 @@
     self.accessoryType = [self departureRow].accessoryType;
 
     self.departureView.departureRow = [self departureRow];
+
+    self.departureView.contextMenuButton.hidden = !self.departureRow.displayContextButton;
 }
 
 - (OBADepartureRow*)departureRow {

--- a/OBAKit/UI/PopoverPresenter.swift
+++ b/OBAKit/UI/PopoverPresenter.swift
@@ -16,9 +16,11 @@ import UIKit
         return (nav as UINavigationController)
     }
 
-    @objc public class func popoverMenu(with controller: UIViewController, preferredContentSize: CGSize, presentingView: UIView) -> UINavigationController {
+    @objc public class func popoverMenu(with controller: UIViewController, preferredContentSize: CGSize, presentingView: UIView, hideNavigationBar: Bool) -> UINavigationController {
         let nav = buildNavigationController(for: controller, preferredContentSize: preferredContentSize)
         configurePopover(for: nav, presentedFrom: presentingView)
+
+        nav.isNavigationBarHidden = hideNavigationBar
 
         return (nav as UINavigationController)
     }
@@ -40,11 +42,15 @@ extension PopoverPresenter {
         popoverController.permittedArrowDirections = .any
         popoverController.delegate = navigationController
 
-        if source is UIView {
-            popoverController.sourceView = (source as! UIView)
+        if let source = source as? UIView {
+            popoverController.sourceView = source
+            popoverController.sourceRect = source.bounds
+        }
+        else if let source = source as? UIBarButtonItem {
+            popoverController.barButtonItem = source
         }
         else {
-            popoverController.barButtonItem = (source as! UIBarButtonItem)
+            assert(false)
         }
     }
 }

--- a/OneBusAway Today/Info.plist
+++ b/OneBusAway Today/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>18.1.1</string>
+	<string>18.2.0</string>
 	<key>CFBundleVersion</key>
-	<string>20180324.12</string>
+	<string>20180623.15</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>

--- a/OneBusAway/Info.plist
+++ b/OneBusAway/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>18.1.1</string>
+	<string>18.2.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>20180324.12</string>
+	<string>20180623.15</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>

--- a/OneBusAway/categories/UIViewController+OBAAdditions.h
+++ b/OneBusAway/categories/UIViewController+OBAAdditions.h
@@ -31,6 +31,16 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)oba_presentPopoverViewController:(UIViewController*)viewController fromView:(UIView*)view;
 
 /**
+ Present a popover controller from the specified view on an iPhone or iPad with an explicit popover size.
+
+ @param viewController The view controller that will be presented as a popover.
+ @param view The view from which the popover will be presented.
+ @param popoverSize The preferred content size of the popover.
+ @param hideNavigationBar Show or hide the navigation bar.
+ */
+- (void)oba_presentPopoverViewController:(UIViewController*)viewController fromView:(UIView*)view popoverSize:(CGSize)popoverSize hideNavigationBar:(BOOL)hideNavigationBar;
+
+/**
  True if either the horizontal or vertical size class for this view controller is compact,
  and false otherwise.
  */

--- a/OneBusAway/categories/UIViewController+OBAAdditions.m
+++ b/OneBusAway/categories/UIViewController+OBAAdditions.m
@@ -40,7 +40,11 @@
         sz = CGSizeMake(350, 350); // arbitrary choice. Let's see how it looks.
     }
 
-    UINavigationController *nav = [PopoverPresenter popoverMenuWith:viewController preferredContentSize:sz presentingView:view];
+    [self oba_presentPopoverViewController:viewController fromView:view popoverSize:sz hideNavigationBar:YES];
+}
+
+- (void)oba_presentPopoverViewController:(UIViewController*)viewController fromView:(UIView*)view popoverSize:(CGSize)popoverSize hideNavigationBar:(BOOL)hideNavigationBar {
+    UINavigationController *nav = [PopoverPresenter popoverMenuWith:viewController preferredContentSize:popoverSize presentingView:view hideNavigationBar:hideNavigationBar];
     [self presentViewController:nav animated:YES completion:nil];
 }
 

--- a/OneBusAway/en.lproj/Localizable.strings
+++ b/OneBusAway/en.lproj/Localizable.strings
@@ -915,6 +915,9 @@
 /* Mark All as Read toolbar button title */
 "regional_alerts_controller.mark_all_as_read" = "Mark All as Read";
 
+/* View Stop button in embed mode */
+"stop.view_stop_button_title" = "View Stop";
+
 /* This is the '...' button in the stop header view. */
 "stop_header_view.menu_button_accessibility_label" = "More Options";
 

--- a/OneBusAway/ui/map/OBAMapAnnotationViewBuilder.m
+++ b/OneBusAway/ui/map/OBAMapAnnotationViewBuilder.m
@@ -20,7 +20,7 @@
         view = [[MKAnnotationView alloc] initWithAnnotation:annotation reuseIdentifier:reuseIdentifier];
     }
 
-    view.canShowCallout = YES;
+    view.canShowCallout = NO;
     view.rightCalloutAccessoryView = ({
         UIButton *rightCalloutButton = [UIButton buttonWithType:UIButtonTypeDetailDisclosure];
         [rightCalloutButton setImage:[UIImage imageNamed:@"disclosure_arrow"] forState:UIControlStateNormal];

--- a/OneBusAway/ui/stops/OBAStopViewController.h
+++ b/OneBusAway/ui/stops/OBAStopViewController.h
@@ -10,6 +10,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class OBAStopViewController;
+@protocol OBAEmbeddedStopDelegate<NSObject>
+- (void)embeddedStopController:(OBAStopViewController*)stopController showStop:(NSString*)stopID;
+- (void)embeddedStopController:(OBAStopViewController*)stopController pushViewController:(UIViewController*)viewController animated:(BOOL)animated;
+@end
+
 @interface OBAStopViewController : OBAStaticTableViewController
 INIT_CODER_UNAVAILABLE;
 INIT_NIB_UNAVAILABLE;
@@ -20,6 +26,9 @@ INIT_NIB_UNAVAILABLE;
 @property(nonatomic,copy,readonly) NSString *stopID;
 @property(nonatomic,assign) NSUInteger minutesBefore;
 @property(nonatomic,assign) NSUInteger minutesAfter;
+
+@property(nonatomic,assign) BOOL inEmbedMode;
+@property(nonatomic,weak) id<OBAEmbeddedStopDelegate> embedDelegate;
 
 - (instancetype)initWithStopID:(NSString*)stopID NS_DESIGNATED_INITIALIZER;
 


### PR DESCRIPTION
We've gotten reports of map callouts not being tappable on iOS 12. I spent some time trying to figure out why they weren't working any longer, without luck. It might actually be an iOS bug. But, either way, I've been thinking about presenting more information in the callouts on the map anyway, and the work I did a few months ago to make it easy to present popovers from anywhere means that embedding a stripped-down stop controller on top of the map in a popover is pretty straightforward. I think this is a usability win.