### PR TITLE
Improve display of popover on iPhones

### DIFF
--- a/OBAKit/UI/OBATheme.h
+++ b/OBAKit/UI/OBATheme.h
@@ -268,4 +268,6 @@
  */
 @property(class,nonatomic,assign,readonly) UIEdgeInsets hoverBarImageInsets;
 
+@property(class,nonatomic,assign,readonly) CGFloat preferredPopoverWidth;
+
 @end

--- a/OBAKit/UI/OBATheme.m
+++ b/OBAKit/UI/OBATheme.m
@@ -313,4 +313,13 @@ static UIFont *_italicFootnoteFont = nil;
     return self.defaultEdgeInsets;
 }
 
++ (CGFloat)preferredPopoverWidth {
+    if (UIScreen.mainScreen.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular) {
+        return 320.f;
+    }
+    else {
+        return CGFLOAT_MAX;
+    }
+}
+
 @end

--- a/OneBusAway/ui/map/OBAMapViewController.m
+++ b/OneBusAway/ui/map/OBAMapViewController.m
@@ -478,7 +478,7 @@ static const double kStopsInRegionRefreshDelayOnDrag = 0.1;
     stopController.embedDelegate = self;
     stopController.inEmbedMode = YES;
 
-    [self oba_presentPopoverViewController:stopController fromView:view popoverSize:CGSizeMake(320, 225) hideNavigationBar:NO];
+    [self oba_presentPopoverViewController:stopController fromView:view popoverSize:CGSizeMake(OBATheme.preferredPopoverWidth, 225) hideNavigationBar:NO];
 }
 
 - (void)mapView:(MKMapView *)mapView annotationView:(MKAnnotationView *)view calloutAccessoryControlTapped:(UIControl *)control {


### PR DESCRIPTION
Use CGFLOAT_MAX as the default popover width when running on a compact horizontal size class (i.e. the iPhone)