### PR TITLE
Make searching for routes work properly again

### DIFF
--- a/OBAKit/Info.plist
+++ b/OBAKit/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>18.2.0</string>
 	<key>CFBundleVersion</key>
-	<string>20180703.01</string>
+	<string>20180703.11</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/OBAKit/navigation/OBANavigationTargetAware.h
+++ b/OBAKit/navigation/OBANavigationTargetAware.h
@@ -19,9 +19,6 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol OBANavigationTargetAware<NSObject>
-- (OBANavigationTarget*)navigationTarget;
-
-@optional
 - (void)setNavigationTarget:(OBANavigationTarget*)navigationTarget;
 @end
 

--- a/OneBusAway Today/Info.plist
+++ b/OneBusAway Today/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>18.2.0</string>
 	<key>CFBundleVersion</key>
-	<string>20180703.01</string>
+	<string>20180703.11</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>

--- a/OneBusAway/Info.plist
+++ b/OneBusAway/Info.plist
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>20180703.01</string>
+	<string>20180703.11</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>

--- a/OneBusAway/ui/MapTable/MapTableViewController.swift
+++ b/OneBusAway/ui/MapTable/MapTableViewController.swift
@@ -399,10 +399,8 @@ extension MapTableViewController: MapSearchDelegate, UISearchControllerDelegate,
 
     func mapSearch(_ mapSearch: MapSearchViewController, selectedNavigationTarget target: OBANavigationTarget) {
         OBAAnalytics.reportEvent(withCategory: OBAAnalyticsCategoryUIAction, action: "button_press", label: "Search button clicked", value: nil)
-
-        // abxoxo - todo!
-//        NSString *analyticsLabel = [NSString stringWithFormat:@"Search: %@", NSStringFromOBASearchType(target.searchType)];
-//        [OBAAnalytics reportEventWithCategory:OBAAnalyticsCategoryUIAction action:@"button_press" label:analyticsLabel value:nil];
+        let analyticsLabel = "Search: \(NSStringFromOBASearchType(target.searchType) ?? "Unknown")"
+        OBAAnalytics.reportEvent(withCategory: OBAAnalyticsCategoryUIAction, action: "button_press", label: analyticsLabel, value: nil)
 
         searchController.dismiss(animated: true) { [weak self] in
             // abxoxo - TODO: figure out how to unify -navigateToTarget, this method, and -setNavigationTarget.
@@ -437,5 +435,14 @@ extension MapTableViewController: MapSearchDelegate, UISearchControllerDelegate,
 extension MapTableViewController {
     public func recenterMap() {
         mapController.recenterMap()
+    }
+}
+
+// MARK: - OBANavigationTargetAware
+extension MapTableViewController: OBANavigationTargetAware {
+    func setNavigationTarget(_ navigationTarget: OBANavigationTarget) {
+        // TODO: this controllers should handle setNavigationTarget(),
+        // not the underlying map controller :-\
+        mapController.setNavigationTarget(navigationTarget)
     }
 }

--- a/OneBusAway/ui/bookmarks/OBABookmarksViewController.m
+++ b/OneBusAway/ui/bookmarks/OBABookmarksViewController.m
@@ -142,8 +142,8 @@ static NSString * const OBABookmarkSortUserDefaultsKey = @"OBABookmarkSortUserDe
 
 #pragma mark - OBANavigationTargetAware
 
-- (OBANavigationTarget*)navigationTarget {
-    return [OBANavigationTarget navigationTarget:OBANavigationTargetTypeBookmarks];
+- (void)setNavigationTarget:(OBANavigationTarget *)navigationTarget {
+    // abxoxo - todo!
 }
 
 #pragma mark - Notifications

--- a/OneBusAway/ui/info/OBAInfoViewController.m
+++ b/OneBusAway/ui/info/OBAInfoViewController.m
@@ -310,10 +310,6 @@ static NSString * const kPrivacyURLString = @"http://onebusaway.org/privacy/";
 
 #pragma mark - OBANavigationTargetAware
 
-- (OBANavigationTarget *)navigationTarget {
-    return [OBANavigationTarget navigationTarget:OBANavigationTargetTypeContactUs];
-}
-
 - (void)setNavigationTarget:(OBANavigationTarget *)navigationTarget {
     // abxoxo - ???? - can i just delete this?
 }

--- a/OneBusAway/ui/map/OBAMapViewController.m
+++ b/OneBusAway/ui/map/OBAMapViewController.m
@@ -261,15 +261,6 @@ static const double kStopsInRegionRefreshDelayOnDrag = 0.1;
 
 #pragma mark - OBANavigationTargetAware
 
-- (OBANavigationTarget *)navigationTarget {
-    if (OBASearchTypeRegion == self.mapDataLoader.searchType) {
-        return [OBANavigationTarget navigationTargetForSearchLocationRegion:self.mapView.region];
-    }
-    else {
-        return self.mapDataLoader.searchTarget;
-    }
-}
-
 - (void)setNavigationTarget:(OBANavigationTarget *)target {
     if (OBASearchTypeRegion == target.searchType) {
         [self.mapDataLoader searchPending];

--- a/OneBusAway/ui/recent_stops/OBARecentStopsViewController.m
+++ b/OneBusAway/ui/recent_stops/OBARecentStopsViewController.m
@@ -222,10 +222,6 @@
 
 #pragma mark - OBANavigationTargetAware
 
-- (OBANavigationTarget *)navigationTarget {
-    return [OBANavigationTarget navigationTarget:OBANavigationTargetTypeRecentStops];
-}
-
 - (void)setNavigationTarget:(OBANavigationTarget *)target {
     if ([target isKindOfClass:OBADeepLinkNavigationTarget.class]) {
         OBADeepLinkNavigationTarget *t = (OBADeepLinkNavigationTarget *)target;

--- a/OneBusAway/ui/themes/DrawerApplicationUI.swift
+++ b/OneBusAway/ui/themes/DrawerApplicationUI.swift
@@ -98,13 +98,12 @@ extension DrawerApplicationUI: OBAApplicationUI {
     func navigate(toTargetInternal navigationTarget: OBANavigationTarget) {
         mapNavigationController.popViewController(animated: false)
 
-        var viewController: (UIViewController & OBANavigationTargetAware)?
-        var navController: UINavigationController?
+        let viewController: (UIViewController & OBANavigationTargetAware)
+        let navController: UINavigationController
 
         switch navigationTarget.target {
         case .map, .searchResults:
-            // abxoxo
-//            viewController = mapController
+            viewController = mapController
             navController = mapNavigationController
         case .recentStops:
             viewController = recentsController
@@ -119,15 +118,11 @@ extension DrawerApplicationUI: OBAApplicationUI {
             fallthrough
         default:
             DDLogError("Unhandled target in #file #line: \(navigationTarget.target)")
+            return
         }
 
-        if let navController = navController {
-            tabBarController.selectedViewController = navController
-        }
-
-        if let viewController = viewController {
-            viewController.setNavigationTarget!(navigationTarget)
-        }
+        tabBarController.selectedViewController = navController
+        viewController.setNavigationTarget(navigationTarget)
 
         if navigationTarget.parameters["stop"] != nil, let stopID = navigationTarget.parameters["stopID"] as? String {
             let vc = StopViewController.init(stopID: stopID)


### PR DESCRIPTION
Fixes #1316 - 'Search for Route' not working correctly

* Removes the unused -navigationTarget method from the OBANavigationTargetAware protocol, and makes its -setNavigationTarget: method non-optional.
* Adds support for OBANavigationTargetAware to the map table controller, which is what was preventing the search feature from working properly