### PR TITLE
Prioritizes non-bus icons for stops where available

### DIFF
--- a/OBAKit/Models/unmanaged/OBAStopV2.m
+++ b/OBAKit/Models/unmanaged/OBAStopV2.m
@@ -125,10 +125,26 @@
 #pragma mark - Public Helpers
 
 - (OBARouteType)firstAvailableRouteTypeForStop {
-    for (OBARouteV2 *route in self.routes) {
-        if (route.routeType) {
-            return route.routeType.integerValue;
-        }
+    NSSet<NSNumber*> *values = [NSSet setWithArray:[self.routes valueForKey:@"routeType"]];
+
+    if ([values containsObject:@(OBARouteTypeFerry)]) {
+        return OBARouteTypeFerry;
+    }
+
+    if ([values containsObject:@(OBARouteTypeLightRail)]) {
+        return OBARouteTypeLightRail;
+    }
+
+    if ([values containsObject:@(OBARouteTypeTrain)]) {
+        return OBARouteTypeTrain;
+    }
+
+    if ([values containsObject:@(OBARouteTypeMetro)]) {
+        return OBARouteTypeMetro;
+    }
+
+    if ([values containsObject:@(OBARouteTypeBus)]) {
+        return OBARouteTypeBus;
     }
 
     return OBARouteTypeUnknown;


### PR DESCRIPTION
Fixes #1033 - Downtown Seattle light rail stops aren't appropriately marked

This fix makes it a lot easier to figure out where light rail stops are on the map in Seattle. Small change, big win imo.