### PR TITLE
Adds support for fare payment app deep linking

### DIFF
--- a/OBAKit/Helpers/OBAStrings.h
+++ b/OBAKit/Helpers/OBAStrings.h
@@ -24,6 +24,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property(class,nonatomic,copy,readonly) NSString *close;
 
 /**
+ The text 'Continue'.
+ */
+@property(class,nonatomic,copy,readonly) NSString *continueString;
+
+/**
  The text 'Delete'.
  */
 @property(class,nonatomic,copy,readonly) NSString *delete;

--- a/OBAKit/Helpers/OBAStrings.m
+++ b/OBAKit/Helpers/OBAStrings.m
@@ -75,6 +75,10 @@
     return OBALocalized(@"strings.learn_more", @"Learn More");
 }
 
++ (NSString*)continueString {
+    return OBALocalized(@"strings.continue", @"Continue");
+}
+
 + (nullable NSAttributedString*)attributedStringWithPrependedImage:(UIImage*)image string:(NSString*)string {
     return [self attributedStringWithPrependedImage:image string:string color:nil];
 }

--- a/OBAKit/Info.plist
+++ b/OBAKit/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>18.2.0</string>
 	<key>CFBundleVersion</key>
-	<string>20180803.08</string>
+	<string>20180805.23</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/OBAKit/Models/unmanaged/OBARegionV2.h
+++ b/OBAKit/Models/unmanaged/OBARegionV2.h
@@ -36,6 +36,15 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic,assign) BOOL experimental;
 @property(nonatomic,assign) NSInteger identifier;
 
+// Payments
+@property(nonatomic,assign,readonly) BOOL supportsMobileFarePayment;
+@property(nonatomic,assign,readonly) BOOL paymentAppDoesNotCoverFullRegion;
+@property(nonatomic,copy,nullable) NSString *paymentWarningBody;
+@property(nonatomic,copy,nullable) NSString *paymentWarningTitle;
+@property(nonatomic,copy,nullable) NSString *paymentAppURLScheme;
+@property(nonatomic,copy,nullable) NSString *paymentAppStoreIdentifier;
+@property(nonatomic,copy,nullable,readonly) NSURL *paymentAppDeepLinkURL;
+
 /**
  Signifies that this was created in the RegionBuilderViewController
  */

--- a/OBAKit/Models/unmanaged/OBARegionV2.m
+++ b/OBAKit/Models/unmanaged/OBARegionV2.m
@@ -42,6 +42,11 @@
     [encoder oba_encodeBool:_supportsObaDiscoveryApis forSelector:@selector(supportsObaDiscoveryApis)];
     [encoder oba_encodeBool:_supportsSiriRealtimeApis forSelector:@selector(supportsSiriRealtimeApis)];
     [encoder oba_encodePropertyOnObject:self withSelector:@selector(twitterUrl)];
+
+    [encoder oba_encodePropertyOnObject:self withSelector:@selector(paymentWarningBody)];
+    [encoder oba_encodePropertyOnObject:self withSelector:@selector(paymentWarningTitle)];
+    [encoder oba_encodePropertyOnObject:self withSelector:@selector(paymentAppURLScheme)];
+    [encoder oba_encodePropertyOnObject:self withSelector:@selector(paymentAppStoreIdentifier)];
 }
 
 - (id)initWithCoder:(NSCoder *)decoder {
@@ -65,6 +70,11 @@
         _identifier = [decoder oba_decodeInteger:@selector(identifier)];
         _regionName = [self.class cleanUpRegionName:[decoder oba_decodeObject:@selector(regionName)]];
         _custom = [decoder oba_decodeBool:@selector(custom)];
+
+        _paymentWarningBody = [decoder oba_decodeObject:@selector(paymentWarningBody)];
+        _paymentWarningTitle = [decoder oba_decodeObject:@selector(paymentWarningTitle)];
+        _paymentAppURLScheme = [decoder oba_decodeObject:@selector(paymentAppURLScheme)];
+        _paymentAppStoreIdentifier = [decoder oba_decodeObject:@selector(paymentAppStoreIdentifier)];
     }
 
     return self;
@@ -83,6 +93,61 @@
 
     NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"\\s?\\(?beta\\)?" options:NSRegularExpressionCaseInsensitive error:nil];
     return [regex stringByReplacingMatchesInString:regionName options:(NSMatchingOptions)0 range:NSMakeRange(0, regionName.length) withTemplate:@""];
+}
+
+#pragma mark - Payment App
+
+- (void)setPaymentWarningBody:(NSString*)body {
+    if (body == (id)NSNull.null) {
+        _paymentWarningBody = nil;
+    }
+    else {
+        _paymentWarningBody = [body copy];
+    }
+}
+
+- (void)setPaymentWarningTitle:(NSString*)title {
+    if (title == (id)NSNull.null) {
+        _paymentWarningTitle = nil;
+    }
+    else {
+        _paymentWarningTitle = [title copy];
+    }
+}
+
+- (void)setPaymentAppURLScheme:(NSString*)scheme {
+    if (scheme == (id)NSNull.null) {
+        _paymentAppURLScheme = nil;
+    }
+    else {
+        _paymentAppURLScheme = [scheme copy];
+    }
+}
+
+- (void)setPaymentAppStoreIdentifier:(NSString*)appID {
+    if (appID == (id)NSNull.null) {
+        _paymentAppStoreIdentifier = nil;
+    }
+    else {
+        _paymentAppStoreIdentifier = [appID copy];
+    }
+}
+
+- (BOOL)supportsMobileFarePayment {
+    return self.paymentAppURLScheme != nil;
+}
+
+- (BOOL)paymentAppDoesNotCoverFullRegion {
+    return self.paymentWarningTitle != nil && self.paymentWarningBody != nil;
+}
+
+- (NSURL*)paymentAppDeepLinkURL {
+    if (self.supportsMobileFarePayment) {
+        return [NSURL URLWithString:[NSString stringWithFormat:@"%@://open", self.paymentAppURLScheme]];
+    }
+    else {
+        return nil;
+    }
 }
 
 #pragma mark - Other Public Methods
@@ -233,12 +298,28 @@
         return NO;
     }
 
+    if (![self.paymentWarningBody isEqual:object.paymentWarningBody]) {
+        return NO;
+    }
+
+    if (![self.paymentWarningTitle isEqual:object.paymentWarningTitle]) {
+        return NO;
+    }
+
+    if (![self.paymentAppURLScheme isEqual:object.paymentAppURLScheme]) {
+        return NO;
+    }
+
+    if (![self.paymentAppStoreIdentifier isEqual:object.paymentAppStoreIdentifier]) {
+        return NO;
+    }
+
     return YES;
 }
 
 - (NSString*)description
 {
-    return [self oba_description:@[@"baseURL", @"custom", @"regionName", @"siriBaseUrl", @"obaVersionInfo", @"language", @"bounds", @"contactEmail", @"twitterUrl", @"facebookUrl", @"supportsSiriRealtimeApis", @"supportsObaRealtimeApis", @"supportsObaDiscoveryApis", @"active", @"experimental", @"identifier"]];
+    return [self oba_description:@[@"baseURL", @"custom", @"regionName", @"siriBaseUrl", @"obaVersionInfo", @"language", @"bounds", @"contactEmail", @"twitterUrl", @"facebookUrl", @"supportsSiriRealtimeApis", @"supportsObaRealtimeApis", @"supportsObaDiscoveryApis", @"active", @"experimental", @"identifier", @"paymentWarningBody", @"paymentWarningTitle", @"paymentAppURLScheme", @"paymentAppStoreIdentifier"]];
 }
 
 @end

--- a/OBAKit/Services/OBAModelFactory.m
+++ b/OBAKit/Services/OBAModelFactory.m
@@ -438,6 +438,12 @@ static NSString * const kReferences = @"references";
     [self addSetPropertyRule:@"obaBaseUrl" forPrefix:[self extendPrefix:prefix withValue:@"obaBaseUrl"]];
     [self addSetPropertyRule:@"identifier" forPrefix:[self extendPrefix:prefix withValue:@"id"]];
     [self addSetPropertyRule:@"regionName" forPrefix:[self extendPrefix:prefix withValue:@"regionName"]];
+
+    // Payments
+    [self addSetPropertyRule:@"paymentWarningBody" forPrefix:[self extendPrefix:prefix withValue:@"paymentWarningBody"]];
+    [self addSetPropertyRule:@"paymentWarningTitle" forPrefix:[self extendPrefix:prefix withValue:@"paymentWarningTitle"]];
+    [self addSetPropertyRule:@"paymentAppStoreIdentifier" forPrefix:[self extendPrefix:prefix withValue:@"paymentiOSAppStoreIdentifier"]];
+    [self addSetPropertyRule:@"paymentAppURLScheme" forPrefix:[self extendPrefix:prefix withValue:@"paymentiOSAppURLScheme"]];
 }
 
 - (void) addRegionBoundsV2RulesWithPrefix:(NSString*)prefix {

--- a/OBAKit/UI/MVVM/OBAButtonRow.m
+++ b/OBAKit/UI/MVVM/OBAButtonRow.m
@@ -23,6 +23,8 @@
     self = [super initWithStyle:style reuseIdentifier:reuseIdentifier];
 
     if (self) {
+        self.selectionStyle = UITableViewCellSelectionStyleNone;
+
         _borderedButton = [[OBABorderedButton alloc] initWithBorderColor:UIColor.blackColor title:@"Click me"];
         _borderedButton.titleLabel.font = [OBATheme boldFootnoteFont];
         [_borderedButton addTarget:self action:@selector(buttonTapped) forControlEvents:UIControlEventTouchUpInside];

--- a/OBAKit/en.lproj/Localizable.strings
+++ b/OBAKit/en.lproj/Localizable.strings
@@ -40,6 +40,9 @@
 /* Learn More */
 "strings.learn_more" = "Learn More";
 
+/* Continue */
+"strings.continue" = "Continue";
+
 /* No comment provided by engineer. */
 "msg_cellular" = "Cellular";
 

--- a/OneBusAway Today/Info.plist
+++ b/OneBusAway Today/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>18.2.0</string>
 	<key>CFBundleVersion</key>
-	<string>20180803.08</string>
+	<string>20180805.23</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>

--- a/OneBusAway/Info.plist
+++ b/OneBusAway/Info.plist
@@ -54,6 +54,9 @@
 		<string>fb</string>
 		<string>twitter</string>
 		<string>comgooglemaps</string>
+		<string>fb313213768708402HART</string>
+		<string>org.sdmts.riderapp.compassmobile.payments</string>
+		<string>co.bytemark.tgt</string>
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>

--- a/OneBusAway/Info.plist
+++ b/OneBusAway/Info.plist
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>20180803.08</string>
+	<string>20180805.23</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>

--- a/OneBusAway/en.lproj/Localizable.strings
+++ b/OneBusAway/en.lproj/Localizable.strings
@@ -665,6 +665,12 @@
 /* Settings section title on info page */
 "msg_your_location" = "Your Location";
 
+/* Pay My Fare table row */
+"msg_pay_fare" = "Pay My Fare";
+
+/* An alert button that says 'Continue and Do Not Show Again' */
+"info_controller.payment.continue_dont_show_again" = "Continue and Don't Show Again";
+
 /* OBASectionTypeNotes
    OBASectionTypeSubmit */
 "msg_explanatory_send_reports" = "Your reports help OneBusAway find and fix problems with the system.";

--- a/OneBusAway/ui/alerts/OBAAlerts.h
+++ b/OneBusAway/ui/alerts/OBAAlerts.h
@@ -15,6 +15,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface OBAAlerts : NSObject
 + (UIAlertController*)locationServicesDisabledAlert;
 + (UIAlertController*)buildAddBookmarkGroupAlertWithModelDAO:(OBAModelDAO*)modelDAO completion:(void(^)(void))completion;
+
++ (UIAlertAction*)buildCancelButton;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/OneBusAway/ui/alerts/OBAAlerts.m
+++ b/OneBusAway/ui/alerts/OBAAlerts.m
@@ -63,7 +63,7 @@
         textField.text = group.name;
     }];
 
-    [alertController addAction:[UIAlertAction actionWithTitle:OBAStrings.cancel style:UIAlertActionStyleCancel handler:nil]];
+    [alertController addAction:self.buildCancelButton];
 
     UIAlertAction *saveButton = [UIAlertAction actionWithTitle:OBAStrings.save style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
         OBABookmarkGroup *newGroup = [[OBABookmarkGroup alloc] initWithName:alertController.textFields.firstObject.text];
@@ -74,6 +74,12 @@
     alertController.saveButton = saveButton;
 
     return alertController;
+}
+
+#pragma mark - Action Buttons
+
++ (UIAlertAction*)buildCancelButton {
+    return [UIAlertAction actionWithTitle:OBAStrings.cancel style:UIAlertActionStyleCancel handler:nil];
 }
 
 @end

--- a/OneBusAway/ui/bookmark_groups/OBABookmarkGroupsViewController.m
+++ b/OneBusAway/ui/bookmark_groups/OBABookmarkGroupsViewController.m
@@ -10,6 +10,7 @@
 @import OBAKit;
 @import Masonry;
 #import "OBALabelFooterView.h"
+#import "OBAAlerts.h"
 
 @implementation OBABookmarkGroupsViewController {
     UIAlertAction *_saveButton;
@@ -95,7 +96,7 @@
                                          handler:(group) ? editGroup : addGroup];
 
     _saveButton.enabled = (group.name.length > 0);
-    [alertController addAction:[UIAlertAction actionWithTitle:OBAStrings.cancel style:UIAlertActionStyleCancel handler:nil]];
+    [alertController addAction:OBAAlerts.buildCancelButton];
     [alertController addAction:_saveButton];
 
     [self presentViewController:alertController animated:YES completion:nil];

--- a/OneBusAway/ui/fare_payments/OBAFarePayments.h
+++ b/OneBusAway/ui/fare_payments/OBAFarePayments.h
@@ -1,0 +1,28 @@
+//
+//  OBAFarePayments.h
+//  OneBusAway
+//
+//  Created by Aaron Brethorst on 8/5/18.
+//  Copyright © 2018 OneBusAway. All rights reserved.
+//
+
+@import Foundation;
+@import UIKit;
+@import OBAKit;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class OBAFarePayments;
+@protocol OBAFarePaymentsDelegate<NSObject>
+- (void)farePayments:(OBAFarePayments*)farePayments presentViewController:(UIViewController*)viewController animated:(BOOL)animated completion:(void(^ _Nullable)(void))completion;
+- (void)farePayments:(OBAFarePayments*)farePayments presentError:(NSError*)error;
+@end
+
+@interface OBAFarePayments : NSObject
+@property(nonatomic,weak) id<OBAFarePaymentsDelegate> delegate;
+- (instancetype)initWithApplication:(OBAApplication*)application delegate:(id<OBAFarePaymentsDelegate>)delegate;
+
+- (void)beginFarePaymentWorkflow;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/OneBusAway/ui/fare_payments/OBAFarePayments.m
+++ b/OneBusAway/ui/fare_payments/OBAFarePayments.m
@@ -1,0 +1,103 @@
+//
+//  OBAFarePayments.m
+//  OneBusAway
+//
+//  Created by Aaron Brethorst on 8/5/18.
+//  Copyright © 2018 OneBusAway. All rights reserved.
+//
+
+#import "OBAFarePayments.h"
+#import "OBAAlerts.h"
+@import StoreKit;
+
+@interface OBAFarePayments () <SKStoreProductViewControllerDelegate>
+@property(nonatomic,strong) OBAApplication *application;
+@property(nonatomic,strong,readonly) OBARegionV2 *currentRegion;
+@end
+
+@implementation OBAFarePayments
+
+- (instancetype)initWithApplication:(OBAApplication*)application delegate:(id<OBAFarePaymentsDelegate>)delegate {
+    self = [super init];
+
+    if (self) {
+        _application = application;
+        _delegate = delegate;
+    }
+    return self;
+}
+
+#pragma mark - Private Helpers
+
+- (OBARegionV2*)currentRegion {
+    return self.application.modelDao.currentRegion;
+}
+
+#pragma mark - Fare Payment
+
+- (void)beginFarePaymentWorkflow {
+    OBARegionV2 *region = self.currentRegion;
+
+    if (region.paymentAppDoesNotCoverFullRegion && [self showPaymentWarningForRegion:region]) {
+        [self displayPaymentAppWarningForRegion:region];
+    }
+    else {
+        [self launchAppOrShowAppStoreForRegion:region];
+    }
+}
+
+- (void)launchAppOrShowAppStoreForRegion:(OBARegionV2*)region {
+    if ([UIApplication.sharedApplication canOpenURL:region.paymentAppDeepLinkURL]) {
+        [UIApplication.sharedApplication openURL:region.paymentAppDeepLinkURL options:@{} completionHandler:nil];
+    }
+    else {
+        [self displayAppStorePageForAppWithIdentifier:region.paymentAppStoreIdentifier];
+    }
+}
+
+- (void)displayAppStorePageForAppWithIdentifier:(NSString*)identifier {
+    SKStoreProductViewController *storeViewController = [[SKStoreProductViewController alloc] init];
+    storeViewController.delegate = self;
+
+    id<OBAFarePaymentsDelegate> delegate = self.delegate;
+
+    NSDictionary *params = @{SKStoreProductParameterITunesItemIdentifier: identifier};
+    [storeViewController loadProductWithParameters:params completionBlock:nil];
+    [delegate farePayments:self presentViewController:storeViewController animated:YES completion:nil];
+}
+
+- (void)productViewControllerDidFinish:(SKStoreProductViewController *)viewController {
+    [viewController dismissViewControllerAnimated:YES completion:nil];
+}
+
+- (void)displayPaymentAppWarningForRegion:(OBARegionV2*)region {
+    NSString *title = region.paymentWarningTitle;
+    NSString *body = region.paymentWarningBody;
+
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:title message:body preferredStyle:UIAlertControllerStyleAlert];
+    [alert addAction:OBAAlerts.buildCancelButton];
+
+    UIAlertAction *dontShowAgain = [UIAlertAction actionWithTitle:NSLocalizedString(@"info_controller.payment.continue_dont_show_again", @"An alert button that says 'Continue and Do Not Show Again'") style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+        [self.application.userDefaults setBool:YES forKey:[self suppressPaymentWarningUserDefaultsKeyForRegion:region]];
+        [self launchAppOrShowAppStoreForRegion:region];
+    }];
+    [alert addAction:dontShowAgain];
+
+    UIAlertAction *continueButton = [UIAlertAction actionWithTitle:OBAStrings.continueString style:UIAlertActionStyleDefault handler:^(UIAlertAction * action) {
+        [self launchAppOrShowAppStoreForRegion:region];
+    }];
+    [alert addAction:continueButton];
+
+    [self.delegate farePayments:self presentViewController:alert animated:YES completion:nil];
+}
+
+- (NSString*)suppressPaymentWarningUserDefaultsKeyForRegion:(OBARegionV2*)region {
+    return [NSString stringWithFormat:@"SuppressPaymentWarning_Region_%@", @(region.identifier)];
+}
+
+- (BOOL)showPaymentWarningForRegion:(OBARegionV2*)region {
+    NSString *key = [self suppressPaymentWarningUserDefaultsKeyForRegion:region];
+    return ![self.application.userDefaults boolForKey:key];
+}
+
+@end

--- a/org.onebusaway.iphone.xcodeproj/project.pbxproj
+++ b/org.onebusaway.iphone.xcodeproj/project.pbxproj
@@ -181,6 +181,7 @@
 		9385EC401DCF1D910020CCB2 /* ServiceAlertDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9385EC3F1DCF1D910020CCB2 /* ServiceAlertDetailsViewController.swift */; };
 		93876DFB1E68AD3900B4343F /* OBAMapAnnotationViewBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 93876DFA1E68AD3900B4343F /* OBAMapAnnotationViewBuilder.m */; };
 		939A1A8021163F60001D5654 /* EditBookmarkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 939A1A7F21163F60001D5654 /* EditBookmarkViewController.swift */; };
+		939A1A8E21178A81001D5654 /* OBAFarePayments.m in Sources */ = {isa = PBXBuildFile; fileRef = 939A1A8D21178A81001D5654 /* OBAFarePayments.m */; };
 		93A1C68A20B3F63F00E176DE /* ForecastSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93A1C68920B3F63F00E176DE /* ForecastSectionController.swift */; };
 		93A637DB20A2CCE30005248C /* HorizontalSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93A637D820A2CCE20005248C /* HorizontalSectionController.swift */; };
 		93A637DC20A2CCE30005248C /* DisplaySectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93A637D920A2CCE20005248C /* DisplaySectionController.swift */; };
@@ -547,6 +548,8 @@
 		93876DF91E68AD3900B4343F /* OBAMapAnnotationViewBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAMapAnnotationViewBuilder.h; sourceTree = "<group>"; };
 		93876DFA1E68AD3900B4343F /* OBAMapAnnotationViewBuilder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAMapAnnotationViewBuilder.m; sourceTree = "<group>"; };
 		939A1A7F21163F60001D5654 /* EditBookmarkViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditBookmarkViewController.swift; sourceTree = "<group>"; };
+		939A1A8C21178A81001D5654 /* OBAFarePayments.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OBAFarePayments.h; sourceTree = "<group>"; };
+		939A1A8D21178A81001D5654 /* OBAFarePayments.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OBAFarePayments.m; sourceTree = "<group>"; };
 		939CEB241C0E406500E1D2B7 /* rvtd.gpx */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = rvtd.gpx; sourceTree = "<group>"; };
 		93A1C68920B3F63F00E176DE /* ForecastSectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForecastSectionController.swift; sourceTree = "<group>"; };
 		93A637D820A2CCE20005248C /* HorizontalSectionController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HorizontalSectionController.swift; sourceTree = "<group>"; };
@@ -835,6 +838,7 @@
 		934196E81DB0C13F004BBBB7 /* ui */ = {
 			isa = PBXGroup;
 			children = (
+				939A1A8A21178A67001D5654 /* fare_payments */,
 				9341B81F20B65DDF006450FC /* listkit */,
 				93A1C68620B3F0D200E176DE /* MapTable */,
 				930CE4D81E9BFB440073F04D /* debugging */,
@@ -1478,6 +1482,15 @@
 			path = Shapes;
 			sourceTree = "<group>";
 		};
+		939A1A8A21178A67001D5654 /* fare_payments */ = {
+			isa = PBXGroup;
+			children = (
+				939A1A8C21178A81001D5654 /* OBAFarePayments.h */,
+				939A1A8D21178A81001D5654 /* OBAFarePayments.m */,
+			);
+			path = fare_payments;
+			sourceTree = "<group>";
+		};
 		93A1C68620B3F0D200E176DE /* MapTable */ = {
 			isa = PBXGroup;
 			children = (
@@ -1889,6 +1902,7 @@
 				934197871DB0C140004BBBB7 /* OBACreditsViewController.m in Sources */,
 				934197921DB0C140004BBBB7 /* OBADiversionViewController.m in Sources */,
 				9341B82220B65DF9006450FC /* SelfSizingCollectionCell.swift in Sources */,
+				939A1A8E21178A81001D5654 /* OBAFarePayments.m in Sources */,
 				93A1C68A20B3F63F00E176DE /* ForecastSectionController.swift in Sources */,
 				93DCEF7220E5AF2F0004E087 /* LabelSectionController.swift in Sources */,
 				934198211DB0C1BA004BBBB7 /* OBATextFieldTableViewCell.m in Sources */,


### PR DESCRIPTION
Fixes #1336 - Add link to regional fare payment app

* Makes sure that the experience is commensurate to Android's
* Adds new 'Pay Fare' option to the info tab
* Wires up the app to support 'deep linking' (after a fashion) into payment apps for Puget Sound, Tampa, and San Diego