### PR TITLE
Adds an option to request 'test' alerts from the server

### DIFF
--- a/OBAKit/Application/OBAApplication.h
+++ b/OBAKit/Application/OBAApplication.h
@@ -34,6 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
  This notification is posted when the region changes and the app cannot generate an API URL from it.
  */
 extern NSString *const OBARegionServerInvalidNotification;
+extern NSString *const OBAShowTestAlertsDefaultsKey;
 
 @interface OBAApplication : NSObject
 @property (nonatomic, strong, readonly) OBAReferencesV2 *references;

--- a/OBAKit/Application/OBAApplication.m
+++ b/OBAKit/Application/OBAApplication.m
@@ -18,8 +18,9 @@
 
 static NSString * const kAppGroup = @"group.org.onebusaway.iphone";
 static NSString *const kOBADefaultRegionApiServerName = @"http://regions.onebusaway.org";
-NSString *const OBARegionServerInvalidNotification = @"OBARegionServerInvalidNotification";
+NSString * const OBARegionServerInvalidNotification = @"OBARegionServerInvalidNotification";
 NSString * const OBAHasMigratedDefaultsToAppGroupDefaultsKey = @"OBAHasMigratedDefaultsToAppGroupDefaultsKey";
+NSString * const OBAShowTestAlertsDefaultsKey = @"OBAShowTestAlertsDefaultsKey";
 
 @interface OBAApplication ()
 @property (nonatomic, strong, readwrite) OBAApplicationConfiguration *configuration;
@@ -122,6 +123,7 @@ NSString * const OBAHasMigratedDefaultsToAppGroupDefaultsKey = @"OBAHasMigratedD
     mutableDefaults[OBADisplayUserHeadingOnMapDefaultsKey] = @(YES);
     mutableDefaults[OBAMapSelectedTypeDefaultsKey] = @(MKMapTypeStandard);
     mutableDefaults[OBAUseStopDrawerDefaultsKey] = @(YES);
+    mutableDefaults[OBAShowTestAlertsDefaultsKey] = @(NO);
 
     defaults = mutableDefaults;
 #endif

--- a/OBAKit/Services/PromisedModelService.swift
+++ b/OBAKit/Services/PromisedModelService.swift
@@ -264,7 +264,11 @@ extension PromisedModelService {
     }
 
     private func buildObacoRequest(region: OBARegionV2) -> OBAURLRequest {
-        let url = obacoJsonDataSource.constructURL(fromPath: "/api/v1/regions/\(region.identifier)/alerts.pb", params: nil)
+        var params: [String: Any]? = nil
+        if OBAApplication.shared().userDefaults.bool(forKey: OBAShowTestAlertsDefaultsKey) {
+            params = ["test": "1"]
+        }
+        let url = obacoJsonDataSource.constructURL(fromPath: "/api/v1/regions/\(region.identifier)/alerts.pb", params: params)
         let obacoRequest = OBAURLRequest.init(url: url, cachePolicy: .useProtocolCachePolicy, timeoutInterval: 10)
         return obacoRequest
     }

--- a/OneBusAway/ui/info/OBASettingsViewController.m
+++ b/OneBusAway/ui/info/OBASettingsViewController.m
@@ -50,6 +50,12 @@
     OBATableSection *drawerSection = [self buildSwitchSectionWithDefaultsKey:OBAUseStopDrawerDefaultsKey switchTitle:NSLocalizedString(@"settings.stop_drawer_switch_title", @"Title for the enable/disable stop drawer switch on the settings controller") footerText:NSLocalizedString(@"settings.stop_drawer_footer_text", @"Footer for the stop drawer switch on the settings controller")];
     [sections addObject:drawerSection];
 
+    // Include debug options:
+    if ([OBAApplication.sharedApplication.userDefaults boolForKey:OBADebugModeUserDefaultsKey]) {
+        OBATableSection *testAlertsSection = [self buildSwitchSectionWithDefaultsKey:OBAShowTestAlertsDefaultsKey switchTitle:@"Show Test Alerts" footerText:@"Set this to 'on' if you are an OBA alerts admin and want to preview your test alerts."];
+        [sections addObject:testAlertsSection];
+    }
+
     self.sections = sections;
     [self.tableView reloadData];
 }


### PR DESCRIPTION
These are alerts that are not formally published yet, thereby giving the user a chance to preview what they'll look like and make sure the alerts look ok.