### PR TITLE
Always try to show the user location annotation on the map

### DIFF
--- a/OneBusAway/ui/map/OBAMapViewController.m
+++ b/OneBusAway/ui/map/OBAMapViewController.m
@@ -114,9 +114,7 @@ static const double kStopsInRegionRefreshDelayOnDrag = 0.1;
     self.mostRecentRegion = MKCoordinateRegionMake(CLLocationCoordinate2DMake(0, 0), MKCoordinateSpanMake(0, 0));
 
     self.mapView.rotateEnabled = NO;
-    if ([CLLocationManager authorizationStatus] == kCLAuthorizationStatusAuthorizedWhenInUse) {
-        self.mapView.showsUserLocation = YES;
-    }
+    self.mapView.showsUserLocation = YES;
 
     [self createLocationHoverBar];
 


### PR DESCRIPTION
Fixes #1353 - The user location annotation view should appear on first launch of the app