### PR TITLE
Replaces obaco with alerts.onebusaway.org

### DIFF
--- a/OBAKit/Helpers/OBACommon.m
+++ b/OBAKit/Helpers/OBACommon.m
@@ -36,7 +36,7 @@ NSString * const OBAForecastDataDefaultsKey = @"OBAForecastDataDefaultsKey";
 
 NSString * const OBAForecastUpdatedNotification = @"OBAForecastUpdatedNotification";
 
-NSString * const OBADeepLinkServerAddress = @"https://www.onebusaway.co";
+NSString * const OBADeepLinkServerAddress = @"http://alerts.onebusaway.org";
 
 NSString * OBAStringFromBool(BOOL yn) {
     return yn ? @"YES" : @"NO";

--- a/OBAKit/Services/OBAJsonDataSource.h
+++ b/OBAKit/Services/OBAJsonDataSource.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)unparsedDataSourceWithBaseURL:(NSURL*)URL userID:(NSString*)userID;
 
 /**
- OBA.co, obaco, or onebusaway.co is the service that powers deep links in the app,
+ alerts.onebusaway.org, formerly obaco or onebusaway.co, is the service that powers deep links in the app,
  along with other cross-regional services.
  */
 + (instancetype)obacoJSONDataSource;

--- a/OneBusAway/OneBusAwayTests/OBAKitTests/models/OBATripDeepLink_Tests.swift
+++ b/OneBusAway/OneBusAwayTests/OBAKitTests/models/OBATripDeepLink_Tests.swift
@@ -27,7 +27,7 @@ class OBATripDeepLink_Tests: QuickSpec {
                 }
 
                 it("has a properly encoded URL") {
-                    let deepLinkURL = URL.init(string: "https://www.onebusaway.co/regions/0/stops/Hillsborough%20Area%20Regional%20Transit_4551/trips?trip_id=Hillsborough%20Area%20Regional%20Transit_232378&service_date=1486098000000&stop_sequence=8")!
+                    let deepLinkURL = URL.init(string: "http://alerts.onebusaway.org/regions/0/stops/Hillsborough%20Area%20Regional%20Transit_4551/trips?trip_id=Hillsborough%20Area%20Regional%20Transit_232378&service_date=1486098000000&stop_sequence=8")!
                     expect(deepLink.deepLinkURL).to(equal(deepLinkURL))
                 }
             }
@@ -48,7 +48,7 @@ class OBATripDeepLink_Tests: QuickSpec {
                 }
 
                 it("has a properly encoded URL") {
-                    let deepLinkURL = URL.init(string: "https://www.onebusaway.co/regions/1/stops/1_1234567/trips?trip_id=1_232378&service_date=1486098000000&stop_sequence=8")!
+                    let deepLinkURL = URL.init(string: "http://alerts.onebusaway.org/regions/1/stops/1_1234567/trips?trip_id=1_232378&service_date=1486098000000&stop_sequence=8")!
                     expect(deepLink.deepLinkURL).to(equal(deepLinkURL))
                 }
             }

--- a/OneBusAway/OneBusAwayTests/OBAKitTests/models/WeatherForecast_Tests.swift
+++ b/OneBusAway/OneBusAwayTests/OBAKitTests/models/WeatherForecast_Tests.swift
@@ -59,13 +59,6 @@ class WeatherForecast_Tests: QuickSpec {
                     expect(weatherForecast.currentForecast.temperature).to(equal(72.5))
                 }
             }
-
-            describe("IGListKit Integration") {
-                it("conforms to the ListDiffable protocol") {
-                    let conformity = weatherForecast.conforms(to: ListDiffable.self)
-                    expect(conformity).to(beTrue())
-                }
-            }
         }
     }
 }

--- a/OneBusAway/Resources/OneBusAway.entitlements
+++ b/OneBusAway/Resources/OneBusAway.entitlements
@@ -8,6 +8,7 @@
 	<array>
 		<string>applinks:onebusaway.co</string>
 		<string>applinks:www.onebusaway.co</string>
+		<string>applinks:alerts.onebusaway.org</string>
 	</array>
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array>


### PR DESCRIPTION
Fixes #1367 - Add alerts.onebusaway.org to OBA records on developer.apple.com