### PR TITLE
Route Today View widget deep links using the onebusaway:// url scheme

### DIFF
--- a/OBAKit/Helpers/OBACommon.h
+++ b/OBAKit/Helpers/OBACommon.h
@@ -46,6 +46,7 @@ extern NSString * const OBAForecastDataDefaultsKey;
 extern NSString * const OBAForecastUpdatedNotification;
 
 // Server Addresses
+extern NSString * const OBAInAppDeepLinkSchemeAddress;
 extern NSString * const OBADeepLinkServerAddress;
 extern NSString * const OBARegionsServerAddress;
 

--- a/OBAKit/Helpers/OBACommon.m
+++ b/OBAKit/Helpers/OBACommon.m
@@ -36,6 +36,7 @@ NSString * const OBAForecastDataDefaultsKey = @"OBAForecastDataDefaultsKey";
 
 NSString * const OBAForecastUpdatedNotification = @"OBAForecastUpdatedNotification";
 
+NSString * const OBAInAppDeepLinkSchemeAddress = @"onebusaway://deep-link";
 NSString * const OBADeepLinkServerAddress = @"http://alerts.onebusaway.org";
 NSString * const OBARegionsServerAddress = @"http://regions.onebusaway.org";
 

--- a/OneBusAway Today/TodayViewController.swift
+++ b/OneBusAway Today/TodayViewController.swift
@@ -15,15 +15,9 @@ import SnapKit
 
 let kMinutes: UInt = 60
 
-/*
- abxoxo - todo:
- 3. Handle states!
- 4. Attributed strings in labels
- */
-
 class TodayViewController: UIViewController {
     let app = OBAApplication.init()
-    let deepLinkRouter = DeepLinkRouter(baseURL: URL(string: OBADeepLinkServerAddress)!)
+    let deepLinkRouter = DeepLinkRouter(baseURL: URL(string: OBAInAppDeepLinkSchemeAddress)!)
     var group: OBABookmarkGroup = OBABookmarkGroup.init(bookmarkGroupType: .todayWidget)
 
     var bookmarkViewsMap: [OBABookmarkV2: TodayRowView] = [:]
@@ -171,7 +165,7 @@ extension TodayViewController {
             return
         }
 
-        let url = deepLinkRouter.deepLinkURL(stopID: bookmark.stopId, regionID: bookmark.regionIdentifier) ?? URL.init(string: OBADeepLinkServerAddress)!
+        let url = deepLinkRouter.deepLinkURL(stopID: bookmark.stopId, regionID: bookmark.regionIdentifier) ?? URL.init(string: OBAInAppDeepLinkSchemeAddress)!
         extensionContext?.open(url, completionHandler: nil)
     }
 

--- a/OneBusAway/OBAApplicationDelegate.m
+++ b/OneBusAway/OBAApplicationDelegate.m
@@ -302,6 +302,7 @@ static NSString * const OBALastRegionRefreshDateUserDefaultsKey = @"OBALastRegio
  Necessary for onebusaway:// URLs to work.
  */
 - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options {
+    [self.deepLinkRouter performActionForURL:url];
     return YES;
 }
 


### PR DESCRIPTION
Fixes a user-reported issue where tapping on the today view widget no longer opens the app, but instead the website.