### PR TITLE
Add background to upcoming departure times in Today Extension for visibility

### DIFF
--- a/OBAKit/OBAKit.xcodeproj/project.pbxproj
+++ b/OBAKit/OBAKit.xcodeproj/project.pbxproj
@@ -329,6 +329,7 @@
 		93FF488820EF53C4009CFF13 /* OBAGenericNavigationTarget.m in Sources */ = {isa = PBXBuildFile; fileRef = 93FF488620EF53C4009CFF13 /* OBAGenericNavigationTarget.m */; };
 		93FFA5FA1F88305300EA8008 /* OBAArrivalAndDepartureSectionBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 93FFA5F81F88305300EA8008 /* OBAArrivalAndDepartureSectionBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		93FFA5FB1F88305300EA8008 /* OBAArrivalAndDepartureSectionBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 93FFA5F91F88305300EA8008 /* OBAArrivalAndDepartureSectionBuilder.m */; };
+		CC037D9C23B4287B00C5149C /* OBADepartureTimeBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC037D9A23B4287B00C5149C /* OBADepartureTimeBadge.swift */; };
 		CCD30CFB1E30564600080EFF /* OBAHandoff.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD30CFA1E30564600080EFF /* OBAHandoff.swift */; };
 		CCFFCEC42338588D00DF41D0 /* OBATripScheduleV2+TableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFFCEC32338588D00DF41D0 /* OBATripScheduleV2+TableView.swift */; };
 /* End PBXBuildFile section */
@@ -673,6 +674,7 @@
 		93FF488620EF53C4009CFF13 /* OBAGenericNavigationTarget.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OBAGenericNavigationTarget.m; sourceTree = "<group>"; };
 		93FFA5F81F88305300EA8008 /* OBAArrivalAndDepartureSectionBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OBAArrivalAndDepartureSectionBuilder.h; sourceTree = "<group>"; };
 		93FFA5F91F88305300EA8008 /* OBAArrivalAndDepartureSectionBuilder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OBAArrivalAndDepartureSectionBuilder.m; sourceTree = "<group>"; };
+		CC037D9A23B4287B00C5149C /* OBADepartureTimeBadge.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OBADepartureTimeBadge.swift; sourceTree = "<group>"; };
 		CCD30CFA1E30564600080EFF /* OBAHandoff.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OBAHandoff.swift; sourceTree = "<group>"; };
 		CCFFCEC32338588D00DF41D0 /* OBATripScheduleV2+TableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OBATripScheduleV2+TableView.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -1143,6 +1145,7 @@
 		9358CDAB1DEA1AB000132CDE /* Departures */ = {
 			isa = PBXGroup;
 			children = (
+				CC037D9A23B4287B00C5149C /* OBADepartureTimeBadge.swift */,
 				93FFA5F81F88305300EA8008 /* OBAArrivalAndDepartureSectionBuilder.h */,
 				93FFA5F91F88305300EA8008 /* OBAArrivalAndDepartureSectionBuilder.m */,
 				93089DA71F87E7FC00694A90 /* OBADepartureRow.h */,
@@ -1631,6 +1634,7 @@
 				938956FD215C3F03008AB975 /* RegionsService.swift in Sources */,
 				934196211DB0B099004BBBB7 /* OBARegionChangeRequest.m in Sources */,
 				934C50AA1E2B6D2700DFDCA0 /* OBAAlarm.m in Sources */,
+				CC037D9C23B4287B00C5149C /* OBADepartureTimeBadge.swift in Sources */,
 				934196891DB0B099004BBBB7 /* OBATripInstanceRef.m in Sources */,
 				9341963C1DB0B099004BBBB7 /* OBASetCoordinatePropertyJsonDigesterRule.m in Sources */,
 				934196931DB0B099004BBBB7 /* OBAVehicleStatusV2.m in Sources */,

--- a/OBAKit/UI/Departures/OBADepartureTimeBadge.swift
+++ b/OBAKit/UI/Departures/OBADepartureTimeBadge.swift
@@ -1,0 +1,47 @@
+//
+//  DepartureTimeBadge.swift
+//  OBAKit
+//
+//  Created by Alan Chu on 12/22/19.
+//  Copyright © 2019 OneBusAway. All rights reserved.
+//
+
+import UIKit
+
+/// A rounded time badge representing the provided upcoming departure time and deviation status.
+public class OBADepartureTimeBadge: UILabel {
+    override public init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        if #available(iOS 13.0, *) {
+            self.textColor = .systemGray6
+        } else {
+            self.textColor = .white
+        }
+        
+        self.textAlignment = .center
+        self.font = OBATheme.boldFootnoteFont
+        
+        self.backgroundColor = .clear
+        self.layer.masksToBounds = true
+        self.layer.cornerRadius = 8
+    }
+    
+    required public init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    /// - parameter departure: If `departure` is nil, then this view will be hidden. A non-nil value will unhide this view.
+    public func apply(upcomingDeparture departure: OBAArrivalAndDepartureV2?) {
+        if let departure = departure {
+            self.accessibilityLabel = OBADateHelpers.formatAccessibilityLabelMinutes(until: departure.bestArrivalDepartureDate)
+            self.text = OBADateHelpers.formatMinutes(until: departure.bestArrivalDepartureDate)
+            self.backgroundColor = OBADepartureCellHelpers.color(for: departure.departureStatus)
+
+            self.isHidden = false
+        } else {
+            self.accessibilityLabel = nil
+            self.isHidden = true
+        }
+    }
+}

--- a/OneBusAway Today/TodayRowView.swift
+++ b/OneBusAway Today/TodayRowView.swift
@@ -71,6 +71,7 @@ class TodayRowView: UIView {
 
     private lazy var titleLabel: UILabel = {
         let label = TodayRowView.buildInfoLabel(font: OBATheme.boldFootnoteFont)
+        label.numberOfLines = 0
         return label
     }()
 
@@ -83,13 +84,14 @@ class TodayRowView: UIView {
 
     // MARK: - Departure Labels
 
-    private let leadingDepartureLabel = TodayRowView.buildDepartureLabel()
-    private let middleDepartureLabel = TodayRowView.buildDepartureLabel()
-    private let trailingDepartureLabel = TodayRowView.buildDepartureLabel()
+    private let leadingDepartureLabel = TodayRowView.buildDepartureBadge()
+    private let middleDepartureLabel = TodayRowView.buildDepartureBadge()
+    private let trailingDepartureLabel = TodayRowView.buildDepartureBadge()
 
     private lazy var departuresStack: UIStackView = {
-        let stack = UIStackView.init(arrangedSubviews: [leadingDepartureLabel, middleDepartureLabel, trailingDepartureLabel])
+        let stack = UIStackView(arrangedSubviews: [leadingDepartureLabel, middleDepartureLabel, trailingDepartureLabel])
         stack.axis = .horizontal
+        stack.alignment = .center
         stack.spacing = OBATheme.compactPadding
         stack.isUserInteractionEnabled = false
 
@@ -121,12 +123,15 @@ extension TodayRowView {
         return label
     }
 
-    private static func buildDepartureLabel() -> UILabel {
-        let label = UILabel.oba_autolayoutNew()
-        label.setContentHuggingPriority(.required, for: .horizontal)
-        label.setContentCompressionResistancePriority(.required, for: .vertical)
-        label.font = OBATheme.boldFootnoteFont
-        return label
+    private static func buildDepartureBadge() -> OBADepartureTimeBadge {
+        let badge = OBADepartureTimeBadge()
+        
+        badge.snp_makeConstraints { make in
+            make.height.equalTo(24)
+            make.width.equalTo(42)
+        }
+        
+        return badge
     }
 }
 
@@ -136,9 +141,10 @@ extension TodayRowView {
         let formatString = NSLocalizedString("stops.no_departures_in_next_n_minutes_format", comment: "No departures in the next {MINUTES} minutes")
         let nextDepartureText = String.init(format: formatString, String(kMinutes))
         nextDepartureLabel.text = nextDepartureText
-        leadingDepartureLabel.text = nil
-        middleDepartureLabel.text = nil
-        trailingDepartureLabel.text = nil
+        
+        leadingDepartureLabel.apply(upcomingDeparture: nil)
+        middleDepartureLabel.apply(upcomingDeparture: nil)
+        trailingDepartureLabel.apply(upcomingDeparture: nil)
 
         guard let departures = departures else {
             return
@@ -154,8 +160,8 @@ extension TodayRowView {
         applyUpcomingDeparture(at: 1, to: middleDepartureLabel)
         applyUpcomingDeparture(at: 2, to: trailingDepartureLabel)
     }
-
-    private func applyUpcomingDeparture(at index: Int, to label: UILabel) {
+  
+    private func applyUpcomingDeparture(at index: Int, to badge: OBADepartureTimeBadge) {
         guard let departures = departures else {
             return
         }
@@ -164,9 +170,8 @@ extension TodayRowView {
             return
         }
 
-        let dep = departures[index]
-        label.accessibilityLabel = OBADateHelpers.formatAccessibilityLabelMinutes(until: dep.bestArrivalDepartureDate)
-        label.text = OBADateHelpers.formatMinutes(until: dep.bestArrivalDepartureDate)
-        label.textColor = OBADepartureCellHelpers.color(for: dep.departureStatus)
+        let departure = departures[index]
+      
+        badge.apply(upcomingDeparture: departure)
     }
 }

--- a/OneBusAway/Resources/Images.xcassets/Colors/ScheduledDepartureColor.colorset/Contents.json
+++ b/OneBusAway/Resources/Images.xcassets/Colors/ScheduledDepartureColor.colorset/Contents.json
@@ -23,12 +23,12 @@
         }
       ],
       "color" : {
-        "color-space" : "srgb",
+        "color-space" : "display-p3",
         "components" : {
-          "red" : "1.000",
+          "red" : "0.800",
           "alpha" : "1.000",
-          "blue" : "1.000",
-          "green" : "1.000"
+          "blue" : "0.800",
+          "green" : "0.800"
         }
       }
     }


### PR DESCRIPTION
- Fixes #1453
- Adjusts ScheduledDepartureColor to be gray instead of pure white
- The number of visible rows in compact mode is now calculated instead of a static number of rows

----

This issue only occurs against a super dark/pure black background when in Light appearance. It doesn't seem like adding vibrancy to the text labels makes a big difference.

Adding a background to the departure times emphasizes the time and deviation at the expense of truncating more of the bookmark name. To mitigate this, the bookmark name may overflow to multiple lines if needed.

## Before
<table>
  <tr>
    <th>Light Background</th>
    <th>Dark Appearance</th>
  </tr>
  <tr>
  <td><img src="https://user-images.githubusercontent.com/22162410/71337597-3a357b80-2501-11ea-9dfb-0b497d2e6e96.png" width=256></td>
  <td><img src="https://user-images.githubusercontent.com/22162410/71337715-a617e400-2501-11ea-8060-64a3d13de244.png" width=256></td>
  </tr>
</table>

## After
<table>
  <tr>
    <th>Light Appearance</th>
    <th>Dark Appearance</th>
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/22162410/71451418-5cf6a880-272a-11ea-8ad1-6b17e140c5dc.png" width=256></td>
    <td><img src="https://user-images.githubusercontent.com/22162410/71451410-1e60ee00-272a-11ea-9d21-9f2adc4eb384.png" width=256></td>
  </tr>
</table>

## Side-by-side comparison
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/22162410/71337597-3a357b80-2501-11ea-9dfb-0b497d2e6e96.png" width=256></td>
    <td><img src="https://user-images.githubusercontent.com/22162410/71451417-481a1500-272a-11ea-80e3-582fa71cd5a6.png" width=256></td>
  </tr>
</table>

This is how the change looks on an iPhone 5s (smaller screen)
<table>
  <tr>
    <th>Long & short</th>
    <th>Short & short</th>
    <th>Short & long</th>
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/22162410/71451429-88799300-272a-11ea-8f08-b10d7fa1fab6.png" width=256></td>
    <td><img src="https://user-images.githubusercontent.com/22162410/71451430-88799300-272a-11ea-9c36-18476d3b96fe.png" width=256></td>
    <td><img src="https://user-images.githubusercontent.com/22162410/71451431-88799300-272a-11ea-9603-da9bcac0cfe3.png" width=256></td>
  </tr>
</table>
