### PR TITLE
Resolves #1466

### DIFF
--- a/OBAKit/Helpers/OBAEmailHelper.m
+++ b/OBAKit/Helpers/OBAEmailHelper.m
@@ -150,7 +150,8 @@ static NSString * appVersion = nil;
     [debuggingInfo addObject:@[@"iOS Version", [self OSVersion]]];
     [debuggingInfo addObject:@[@"VoiceOver enabled", OBAStringFromBool(UIAccessibilityIsVoiceOverRunning())]];
 
-    [debuggingInfo addObject:@[@"Bookmark Count",@(modelDAO.allBookmarksCount)]];
+    [debuggingInfo addObject:@[@"All Bookmarks Count",@(modelDAO.allBookmarksCount)]];
+    [debuggingInfo addObject:@[@"Today Widget Bookmarks Count",@(modelDAO.todayBookmarkGroupCount)]];
     [debuggingInfo addObject:@[@"Registered for Notifications", OBAStringFromBool(registeredForRemoteNotifications)]];
 
     [debuggingInfo addObject:@[@"Location Auth Status", locationAuthorizationStatusToString(locationAuthorizationStatus)]];

--- a/OBAKit/Models/dao/OBAModelDAO.h
+++ b/OBAKit/Models/dao/OBAModelDAO.h
@@ -55,6 +55,7 @@ extern NSString * const OBARegionDidUpdateNotification;
  The Today View Controller bookmark group.
  */
 @property(nonatomic,strong,readonly) OBABookmarkGroup *todayBookmarkGroup;
+- (NSInteger)todayBookmarkGroupCount;
 
 @property(strong,nonatomic,readonly) NSArray<OBAStopAccessEventV2*> * mostRecentStops;
 @property(nonatomic,copy) CLLocation *mostRecentLocation;

--- a/OBAKit/Models/dao/OBAModelDAO.m
+++ b/OBAKit/Models/dao/OBAModelDAO.m
@@ -376,6 +376,14 @@ const CLLocationDistance kMetersInOneMile = 1609.34;
     }
 }
 
+- (NSInteger)todayBookmarkGroupCount {
+    if (self.todayBookmarkGroup) {
+        return [self.todayBookmarkGroup.bookmarks count];
+    } else {
+        return 0;
+    }
+}
+
 - (void)moveBookmarkGroup:(OBABookmarkGroup*)bookmarkGroup toIndex:(NSUInteger)index {
     OBAGuard(bookmarkGroup) else {
         return;


### PR DESCRIPTION
Adds the number of bookmarks in the today widget to debug info.

I'm guessing that #1466 is user error so if there are any future inquiries regarding the today widget, hopefully this data makes it easier to address.