### PR TITLE
Add link to OTSF in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # OneBusAway for iPhone [![Build Status](https://img.shields.io/travis/OneBusAway/onebusaway-iphone.svg)](https://travis-ci.org/OneBusAway/onebusaway-iphone) [![codebeat badge](https://codebeat.co/badges/080b2d57-c69b-466e-be49-3b5b7e02c8d8)](https://codebeat.co/projects/github-com-onebusaway-onebusaway-iphone) [![Join the OneBusAway chat on Slack](https://onebusaway.herokuapp.com/badge.svg)](https://onebusaway.herokuapp.com/)
 
+A project of the non-profit [Open Transit Software Foundation](https://opentransitsoftwarefoundation.org/)!
+
 ## Start Here
 
 1. [Come join our Slack channel](https://onebusaway.herokuapp.com/) to say hi and let us know what you're interested in working on.


### PR DESCRIPTION
Add a reference and link to the Open Transit Software Foundation.

@aaronbrethorst Feel free to move wherever you feel is most appropriate.